### PR TITLE
test(audit): close threshold-test gaps — clearance_violation, spiral_…

### DIFF
--- a/src/kicad_mcp/tools/pcb_drc_fix.py
+++ b/src/kicad_mcp/tools/pcb_drc_fix.py
@@ -198,7 +198,7 @@ for pass_num in range(1, max_passes + 1):
         a = fp_data[i]; ab = a["bbox"]
         for j in range(i + 1, len(fp_data)):
             b = fp_data[j]; bb_ = b["bbox"]
-            if ab[0] < bb_[2] and ab[2] > bb_[0] and ab[1] < bb_[3] and ab[3] > bb_[1]:
+            if aabb_overlap(ab, bb_):
                 pairs.append((a, b))
     if not pairs:
         break
@@ -214,7 +214,7 @@ for pass_num in range(1, max_passes + 1):
         mb = mover["bbox"]; ab_ = anchor["bbox"]
         ox = min(mb[2], ab_[2]) - max(mb[0], ab_[0])
         oy = min(mb[3], ab_[3]) - max(mb[1], ab_[1])
-        if ox <= 0 or oy <= 0:
+        if ox < 0 or oy < 0:
             continue
         old_pos = mover["fp"].GetPosition()
         old_x = pcbnew.ToMM(old_pos.x); old_y = pcbnew.ToMM(old_pos.y)

--- a/src/kicad_mcp/tools/pcb_keepout.py
+++ b/src/kicad_mcp/tools/pcb_keepout.py
@@ -310,13 +310,6 @@ overlaps = []
 for i in range(len(footprints)):
     a = footprints[i]
     a_box = a["bbox"]
-    # Expand bbox by min_clearance for proximity check
-    a_expanded = {
-        "x_min_mm": a_box["x_min_mm"] - min_clearance,
-        "y_min_mm": a_box["y_min_mm"] - min_clearance,
-        "x_max_mm": a_box["x_max_mm"] + min_clearance,
-        "y_max_mm": a_box["y_max_mm"] + min_clearance,
-    }
     for j in range(i + 1, len(footprints)):
         b = footprints[j]
         b_box = b["bbox"]
@@ -325,10 +318,10 @@ for i in range(len(footprints)):
         actual_overlap = rects_overlap(a_box, b_box)
         area = overlap_area(a_box, b_box) if actual_overlap else 0.0
 
-        # Check clearance violation (expanded bbox)
-        clearance_violation = min_clearance > 0 and rects_overlap(a_expanded, b_box)
+        # Check clearance violation using canonical helper
+        is_clearance_violation = clearance_violation(a_box, b_box, min_clearance)
 
-        if actual_overlap or clearance_violation:
+        if actual_overlap or is_clearance_violation:
             # Compute gap (negative = overlap, positive = clearance)
             gap_x = max(a_box["x_min_mm"], b_box["x_min_mm"]) - min(a_box["x_max_mm"], b_box["x_max_mm"])
             gap_y = max(a_box["y_min_mm"], b_box["y_min_mm"]) - min(a_box["y_max_mm"], b_box["y_max_mm"])
@@ -531,17 +524,11 @@ for fp in board.GetFootprints():
 fp_overlaps = []
 for i in range(len(footprints)):
     a = footprints[i]; a_box = a["bbox"]
-    a_exp = {
-        "x_min_mm": a_box["x_min_mm"] - min_clearance,
-        "y_min_mm": a_box["y_min_mm"] - min_clearance,
-        "x_max_mm": a_box["x_max_mm"] + min_clearance,
-        "y_max_mm": a_box["y_max_mm"] + min_clearance,
-    }
     for j in range(i + 1, len(footprints)):
         b = footprints[j]; b_box = b["bbox"]
         actual = rects_overlap(a_box, b_box)
-        clearance_fail = min_clearance > 0 and rects_overlap(a_exp, b_box)
-        if actual or clearance_fail:
+        is_clearance_violation = clearance_violation(a_box, b_box, min_clearance)
+        if actual or is_clearance_violation:
             area = overlap_area(a_box, b_box) if actual else 0.0
             fp_overlaps.append({
                 "ref_a": a["reference"], "ref_b": b["reference"],

--- a/src/kicad_mcp/tools/pcb_planning.py
+++ b/src/kicad_mcp/tools/pcb_planning.py
@@ -9,6 +9,7 @@ from fastmcp import FastMCP
 from kicad_mcp.utils.pcbnew_bridge import run_pcbnew_script
 from kicad_mcp.utils.keepout_helpers import KEEPOUT_HELPER, LIB_SEARCH_HELPER
 from kicad_mcp.utils.netlist_parser import POWER_NET_HELPER
+from kicad_mcp.utils.spiral_placement import SPIRAL_HELPER
 
 logger = logging.getLogger(__name__)
 
@@ -186,11 +187,13 @@ print(json.dumps({
         if not os.path.exists(pcb_path):
             return {"error": f"PCB file not found: {pcb_path}"}
 
+        _SPIRAL_HELPER = SPIRAL_HELPER
+
         script = """
 import pcbnew, json, math, sys
 
 params = json.loads(open(sys.argv[1]).read())
-""" + _KEEPOUT_HELPER + POWER_NET_HELPER + """
+""" + _KEEPOUT_HELPER + POWER_NET_HELPER + _SPIRAL_HELPER + """
 
 board = pcbnew.LoadBoard(params["pcb_path"])
 spacing = params["spacing_mm"]
@@ -363,49 +366,25 @@ if sorted_refs:
 
         # Try positions in a spiral pattern around the target
         placed = False
-        for radius in [r * 2.0 for r in range(1, 40)]:
-            if placed:
+        for px, py, box in generate_spiral_candidates(tx, ty, hw, hh, outline, spacing):
+            if not box_collides(box, placed_boxes, spacing):
+                placements[ref] = {"x_mm": round(px, 2), "y_mm": round(py, 2), "reason": reason}
+                placed_boxes.append(box)
+                placed = True
                 break
-            # Try 12 angles at each radius (every 30 degrees)
-            for angle_deg in range(0, 360, 30):
-                angle = math.radians(angle_deg)
-                px = tx + radius * math.cos(angle)
-                py = ty + radius * math.sin(angle)
-
-                px, py = clamp_to_board(px, py, info["width"], info["height"], info)
-                box = (px - hw, py - hh, px + hw, py + hh)
-
-                # Check within board — use same margin (spacing) that clamp_to_board
-                # enforces. A hardcoded 0.1 would reject every clamped position when
-                # spacing < 0.1, turning the spiral into an infinite continue loop.
-                if (box[0] < outline["x_min_mm"] + spacing or
-                    box[2] > outline["x_max_mm"] - spacing or
-                    box[1] < outline["y_min_mm"] + spacing or
-                    box[3] > outline["y_max_mm"] - spacing):
-                    continue
-
-                if not box_collides(box, placed_boxes, spacing):
-                    placements[ref] = {"x_mm": round(px, 2), "y_mm": round(py, 2), "reason": reason}
-                    placed_boxes.append(box)
-                    placed = True
-                    break
 
         if not placed:
             # Fallback: just find any open space
-            for gx in range(int(outline["x_min_mm"] + hw + 1), int(outline["x_max_mm"] - hw), 2):
-                if placed:
+            for gx, gy, box in generate_grid_fallback(hw, hh, outline):
+                if not box_collides(box, placed_boxes, spacing):
+                    placements[ref] = {
+                        "x_mm": round(gx, 2),
+                        "y_mm": round(gy, 2),
+                        "reason": "fallback grid placement",
+                    }
+                    placed_boxes.append(box)
+                    placed = True
                     break
-                for gy in range(int(outline["y_min_mm"] + hh + 1), int(outline["y_max_mm"] - hh), 2):
-                    box = (gx - hw, gy - hh, gx + hw, gy + hh)
-                    if not box_collides(box, placed_boxes, spacing):
-                        placements[ref] = {
-                            "x_mm": round(float(gx), 2),
-                            "y_mm": round(float(gy), 2),
-                            "reason": "fallback grid placement",
-                        }
-                        placed_boxes.append(box)
-                        placed = True
-                        break
             if not placed:
                 placements[ref] = {
                     "x_mm": round(board_cx, 2),

--- a/src/kicad_mcp/utils/geometry.py
+++ b/src/kicad_mcp/utils/geometry.py
@@ -90,6 +90,43 @@ def signed_gap_mm(a: dict, b: dict) -> float:
     return max(gap_x, gap_y)
 
 
+def expand_bbox(rect: dict, margin: float) -> dict:
+    """Return a new dict-format rect expanded by ``margin`` on all four sides.
+
+    A positive margin grows the rect; a negative margin shrinks it (which may
+    produce an inverted rect where ``x_min_mm > x_max_mm`` — callers that need
+    to shrink-then-test should guard against this).  A zero margin is a no-op
+    and returns a copy.
+    """
+    return {
+        "x_min_mm": rect["x_min_mm"] - margin,
+        "y_min_mm": rect["y_min_mm"] - margin,
+        "x_max_mm": rect["x_max_mm"] + margin,
+        "y_max_mm": rect["y_max_mm"] + margin,
+    }
+
+
+def clearance_violation(a: dict, b: dict, min_clearance_mm: float) -> bool:
+    """Return True if rects ``a`` and ``b`` violate ``min_clearance_mm``.
+
+    Semantics match KiCad DRC's non-strict convention:
+
+    - Any contact (touching or overlap, gap <= 0) is always a violation
+      regardless of ``min_clearance_mm``.
+    - A gap strictly less than ``min_clearance_mm`` (positive threshold) is
+      a violation even when the rects are separated.
+    - A gap exactly equal to ``min_clearance_mm`` is *clean* (the threshold
+      is exclusive on the passing side).
+
+    When ``min_clearance_mm == 0`` this is equivalent to :func:`rects_overlap`
+    — touching (gap == 0) and any overlap (gap < 0) both return ``True``.
+    When ``min_clearance_mm > 0`` the touching case still fires via the
+    ``gap <= 0`` sub-clause.
+    """
+    gap = signed_gap_mm(a, b)
+    return gap <= 0 or gap < min_clearance_mm
+
+
 # ---------------------------------------------------------------------------
 # Tuple-format primitives
 # ---------------------------------------------------------------------------
@@ -149,4 +186,16 @@ def signed_gap_mm(a, b):
     if gap_x >= 0 or gap_y >= 0:
         return max(gap_x, gap_y)
     return max(gap_x, gap_y)
+
+def expand_bbox(rect, margin):
+    return {
+        "x_min_mm": rect["x_min_mm"] - margin,
+        "y_min_mm": rect["y_min_mm"] - margin,
+        "x_max_mm": rect["x_max_mm"] + margin,
+        "y_max_mm": rect["y_max_mm"] + margin,
+    }
+
+def clearance_violation(a, b, min_clearance_mm):
+    gap = signed_gap_mm(a, b)
+    return gap <= 0 or gap < min_clearance_mm
 """

--- a/src/kicad_mcp/utils/spiral_placement.py
+++ b/src/kicad_mcp/utils/spiral_placement.py
@@ -1,0 +1,202 @@
+"""Spiral candidate generator and grid fallback for PCB component placement.
+
+Pure-Python functions used by ``suggest_placement`` in ``pcb_planning.py``.
+Embedded scripts that run inside pcbnew's Python interpreter cannot
+``import`` from this module; they inject :data:`SPIRAL_HELPER` (a source
+string defining the same functions) into their embedded script source.
+
+**Threshold semantics:**
+
+- ``is_within_outline(box, outline, spacing)`` — the *strict-less-than*
+  check mirrors the original inline code: ``box[0] < x_min + spacing`` is
+  rejected (too close or outside).  A footprint positioned exactly at
+  ``x_min + spacing`` passes; ``x_min + spacing - ε`` is rejected.
+
+- ``generate_grid_fallback`` — the ``int(... + 1)`` inset is preserved
+  exactly; this keeps footprints with non-integer outline coordinates one
+  integer step inside the board.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Iterator, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Board-margin check
+# ---------------------------------------------------------------------------
+
+def is_within_outline(
+    box: Tuple[float, float, float, float],
+    outline: dict,
+    spacing: float,
+) -> bool:
+    """Return True if *box* is inside the outline by at least *spacing*.
+
+    Box is a tuple ``(x_min, y_min, x_max, y_max)``.  Outline is a dict
+    with keys ``x_min_mm``, ``x_max_mm``, ``y_min_mm``, ``y_max_mm``.
+
+    The boundary condition is strict-less-than (same as the original inline
+    code):
+
+    - ``box[0] == outline["x_min_mm"] + spacing`` → **passes** (returns True)
+    - ``box[0] == outline["x_min_mm"] + spacing - ε`` → **rejected** (returns False)
+    - ``spacing == 0`` → accepts any box whose edge is at or inside the outline
+
+    This function is the single source of truth for the margin check;
+    ``pcb_planning.py`` injects :data:`SPIRAL_HELPER` so the same logic runs
+    inside the pcbnew subprocess.
+    """
+    return not (
+        box[0] < outline["x_min_mm"] + spacing
+        or box[2] > outline["x_max_mm"] - spacing
+        or box[1] < outline["y_min_mm"] + spacing
+        or box[3] > outline["y_max_mm"] - spacing
+    )
+
+
+# ---------------------------------------------------------------------------
+# Spiral candidate generator
+# ---------------------------------------------------------------------------
+
+def generate_spiral_candidates(
+    tx: float,
+    ty: float,
+    hw: float,
+    hh: float,
+    outline: dict,
+    spacing: float,
+    n_radii: int = 39,
+    step_mm: float = 2.0,
+    n_angles: int = 12,
+) -> Iterator[Tuple[float, float, Tuple[float, float, float, float]]]:
+    """Yield ``(px, py, box)`` candidates in spiral order around ``(tx, ty)``.
+
+    Candidates are produced by walking *n_radii* radii (``step_mm * 1..n_radii``)
+    and *n_angles* equi-spaced angles per radius.  At each candidate the
+    position is clamped to the board outline (same ``clamp_to_board`` logic
+    used in the embedded script is NOT applied here — callers must clamp
+    before calling this generator if they need clamping, exactly as the
+    original inline code did).
+
+    Only candidates that pass :func:`is_within_outline` are yielded.
+
+    Args:
+        tx: X coordinate of the target (placement anchor) in mm.
+        ty: Y coordinate of the target in mm.
+        hw: Half-width of the footprint to place in mm.
+        hh: Half-height of the footprint to place in mm.
+        outline: Dict with ``x_min_mm``, ``x_max_mm``, ``y_min_mm``, ``y_max_mm``.
+        spacing: Minimum clearance to the board edge in mm.
+        n_radii: Number of concentric radius rings (default 39 → range(1, 40)).
+        step_mm: Spacing between successive radii in mm (default 2.0).
+        n_angles: Number of candidate angles per radius (default 12 → every 30°).
+    """
+    for radius in [r * step_mm for r in range(1, n_radii + 1)]:
+        for angle_deg in range(0, 360, 360 // n_angles):
+            angle = math.radians(angle_deg)
+            px = tx + radius * math.cos(angle)
+            py = ty + radius * math.sin(angle)
+
+            # Clamp to board (mirrors clamp_to_board in the embedded script)
+            px = max(
+                outline["x_min_mm"] + hw + spacing,
+                min(px, outline["x_max_mm"] - hw - spacing),
+            )
+            py = max(
+                outline["y_min_mm"] + hh + spacing,
+                min(py, outline["y_max_mm"] - hh - spacing),
+            )
+
+            box = (px - hw, py - hh, px + hw, py + hh)
+
+            if is_within_outline(box, outline, spacing):
+                yield px, py, box
+
+
+# ---------------------------------------------------------------------------
+# Integer grid fallback
+# ---------------------------------------------------------------------------
+
+def generate_grid_fallback(
+    hw: float,
+    hh: float,
+    outline: dict,
+    step: int = 2,
+) -> Iterator[Tuple[float, float, Tuple[float, float, float, float]]]:
+    """Yield ``(gx, gy, box)`` on an integer grid covering the outline interior.
+
+    The grid starts at ``int(outline["x_min_mm"] + hw + 1)`` — the ``+1``
+    integer inset keeps footprints inside the board even when the outline
+    coordinate is non-integer (e.g. ``x_min=1.3`` → grid starts at ``int(1.3
+    + hw + 1) = int(hw + 2.3)``).
+
+    Yields every integer-step ``(gx, gy)`` pair with the corresponding
+    footprint bounding box.  No outline-margin filter is applied; callers use
+    ``box_collides`` directly, matching the original fallback loop behavior.
+
+    Args:
+        hw: Half-width of the footprint in mm.
+        hh: Half-height of the footprint in mm.
+        outline: Dict with ``x_min_mm``, ``x_max_mm``, ``y_min_mm``, ``y_max_mm``.
+        step: Integer step between grid points in mm (default 2).
+    """
+    x_start = int(outline["x_min_mm"] + hw + 1)
+    x_stop = int(outline["x_max_mm"] - hw)
+    y_start = int(outline["y_min_mm"] + hh + 1)
+    y_stop = int(outline["y_max_mm"] - hh)
+
+    for gx in range(x_start, x_stop, step):
+        for gy in range(y_start, y_stop, step):
+            box = (gx - hw, gy - hh, gx + hw, gy + hh)
+            yield float(gx), float(gy), box
+
+
+# ---------------------------------------------------------------------------
+# Injectable source string for embedded pcbnew scripts
+# ---------------------------------------------------------------------------
+# Embedded scripts concatenate SPIRAL_HELPER into their source.  The
+# definitions below MUST stay byte-equivalent to the Python-side functions
+# above — that is the whole point of having one source of truth.
+
+SPIRAL_HELPER = """
+import math as _math
+
+def is_within_outline(box, outline, spacing):
+    return not (
+        box[0] < outline["x_min_mm"] + spacing
+        or box[2] > outline["x_max_mm"] - spacing
+        or box[1] < outline["y_min_mm"] + spacing
+        or box[3] > outline["y_max_mm"] - spacing
+    )
+
+def generate_spiral_candidates(tx, ty, hw, hh, outline, spacing,
+                                 n_radii=39, step_mm=2.0, n_angles=12):
+    for radius in [r * step_mm for r in range(1, n_radii + 1)]:
+        for angle_deg in range(0, 360, 360 // n_angles):
+            angle = _math.radians(angle_deg)
+            px = tx + radius * _math.cos(angle)
+            py = ty + radius * _math.sin(angle)
+            px = max(
+                outline["x_min_mm"] + hw + spacing,
+                min(px, outline["x_max_mm"] - hw - spacing),
+            )
+            py = max(
+                outline["y_min_mm"] + hh + spacing,
+                min(py, outline["y_max_mm"] - hh - spacing),
+            )
+            box = (px - hw, py - hh, px + hw, py + hh)
+            if is_within_outline(box, outline, spacing):
+                yield px, py, box
+
+def generate_grid_fallback(hw, hh, outline, step=2):
+    x_start = int(outline["x_min_mm"] + hw + 1)
+    x_stop = int(outline["x_max_mm"] - hw)
+    y_start = int(outline["y_min_mm"] + hh + 1)
+    y_stop = int(outline["y_max_mm"] - hh)
+    for gx in range(x_start, x_stop, step):
+        for gy in range(y_start, y_stop, step):
+            box = (gx - hw, gy - hh, gx + hw, gy + hh)
+            yield float(gx), float(gy), box
+"""

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -18,6 +18,8 @@ from kicad_mcp.utils.geometry import (
     GEOMETRY_HELPER,
     aabb_inside,
     aabb_overlap,
+    clearance_violation,
+    expand_bbox,
     overlap_area,
     rect_inside,
     rects_overlap,
@@ -206,6 +208,8 @@ class TestGeometryHelperSource:
         "rect_inside",
         "overlap_area",
         "signed_gap_mm",
+        "expand_bbox",
+        "clearance_violation",
     ])
     def test_helper_defines(self, name):
         assert f"def {name}" in GEOMETRY_HELPER, (
@@ -228,3 +232,178 @@ class TestGeometryHelperSource:
         assert namespace["overlap_area"](a, b) == overlap_area(a, b)
         # Signed gap: 0.0 for touching, sign preserved
         assert namespace["signed_gap_mm"](a, b) == signed_gap_mm(a, b)
+
+    def test_helper_expand_bbox_identical(self):
+        """expand_bbox in GEOMETRY_HELPER must match Python module."""
+        namespace: dict = {}
+        exec(GEOMETRY_HELPER, namespace)
+        rect = _r(0, 0, 10, 10)
+        for margin in (0.0, 1.0, -1.0, 0.5):
+            expected = expand_bbox(rect, margin)
+            got = namespace["expand_bbox"](rect, margin)
+            assert got == expected, f"expand_bbox mismatch at margin={margin}"
+
+    def test_helper_clearance_violation_identical(self):
+        """clearance_violation in GEOMETRY_HELPER must match Python module."""
+        namespace: dict = {}
+        exec(GEOMETRY_HELPER, namespace)
+        a = _r(0, 0, 10, 10)
+        # touching, gap=0.5, gap=1e-6
+        cases = [
+            (_r(10, 0, 20, 10), 0.0),   # touching, zero clearance
+            (_r(10, 0, 20, 10), 0.5),   # touching, positive clearance
+            (_r(10.5, 0, 20, 10), 0.5), # gap == clearance (threshold)
+            (_r(15, 0, 25, 10), 0.0),   # well separated, zero clearance
+        ]
+        for b, cl in cases:
+            expected = clearance_violation(a, b, cl)
+            got = namespace["clearance_violation"](a, b, cl)
+            assert got == expected, f"clearance_violation mismatch: b={b}, cl={cl}"
+
+
+# ---------------------------------------------------------------------------
+# expand_bbox — boundary tests
+# ---------------------------------------------------------------------------
+
+class TestExpandBbox:
+    def test_zero_margin_is_noop(self):
+        rect = _r(2, 3, 8, 9)
+        result = expand_bbox(rect, 0.0)
+        assert result == rect
+        assert result is not rect  # returns a copy
+
+    def test_positive_margin_expands_all_sides(self):
+        result = expand_bbox(_r(2, 3, 8, 9), 1.0)
+        assert result["x_min_mm"] == pytest.approx(1.0)
+        assert result["y_min_mm"] == pytest.approx(2.0)
+        assert result["x_max_mm"] == pytest.approx(9.0)
+        assert result["y_max_mm"] == pytest.approx(10.0)
+
+    def test_negative_margin_shrinks_all_sides(self):
+        """Negative margin shrinks; if margin > half-width the rect inverts."""
+        result = expand_bbox(_r(0, 0, 10, 10), -1.0)
+        assert result["x_min_mm"] == pytest.approx(1.0)
+        assert result["y_min_mm"] == pytest.approx(1.0)
+        assert result["x_max_mm"] == pytest.approx(9.0)
+        assert result["y_max_mm"] == pytest.approx(9.0)
+
+    def test_negative_margin_larger_than_half_produces_inverted_rect(self):
+        """Document: margin > half-width → x_min_mm > x_max_mm (inverted).
+        Callers must guard against this if using the result with rects_overlap."""
+        result = expand_bbox(_r(0, 0, 4, 4), -3.0)
+        # x_min_mm = 0 - (-3) = 3; x_max_mm = 4 + (-3) = 1
+        assert result["x_min_mm"] > result["x_max_mm"]
+
+    def test_epsilon_margin(self):
+        result = expand_bbox(_r(0, 0, 10, 10), EPS)
+        assert result["x_min_mm"] == pytest.approx(-EPS)
+        assert result["x_max_mm"] == pytest.approx(10 + EPS)
+
+    def test_expand_preserves_center(self):
+        """Expanding uniformly should not shift the center."""
+        rect = _r(0, 0, 10, 10)
+        expanded = expand_bbox(rect, 2.0)
+        orig_cx = (rect["x_min_mm"] + rect["x_max_mm"]) / 2
+        orig_cy = (rect["y_min_mm"] + rect["y_max_mm"]) / 2
+        exp_cx = (expanded["x_min_mm"] + expanded["x_max_mm"]) / 2
+        exp_cy = (expanded["y_min_mm"] + expanded["y_max_mm"]) / 2
+        assert exp_cx == pytest.approx(orig_cx)
+        assert exp_cy == pytest.approx(orig_cy)
+
+
+# ---------------------------------------------------------------------------
+# clearance_violation — boundary tests
+# ---------------------------------------------------------------------------
+
+class TestClearanceViolation:
+    """Boundary coverage per CLAUDE.md Threshold-Boundary Testing Rule.
+
+    The threshold is min_clearance_mm; three cases per value: at, below, above.
+    Also tests that min_clearance_mm=0 is strictly equivalent to rects_overlap.
+    """
+
+    # -- min_clearance=0: must equal rects_overlap ---------------------------
+
+    def test_zero_clearance_touching_is_violation(self):
+        """gap=0 (touching) with min_clearance=0 must be a violation (non-strict)."""
+        a = _r(0, 0, 10, 10)
+        b = _r(10, 0, 20, 10)
+        assert clearance_violation(a, b, 0.0) is True
+        assert clearance_violation(a, b, 0.0) is rects_overlap(a, b)
+
+    def test_zero_clearance_overlapping_is_violation(self):
+        a = _r(0, 0, 10, 10)
+        b = _r(8, 0, 18, 10)
+        assert clearance_violation(a, b, 0.0) is True
+        assert clearance_violation(a, b, 0.0) is rects_overlap(a, b)
+
+    def test_zero_clearance_separated_is_not_violation(self):
+        a = _r(0, 0, 10, 10)
+        b = _r(10 + EPS, 0, 20, 10)
+        assert clearance_violation(a, b, 0.0) is False
+        assert clearance_violation(a, b, 0.0) is rects_overlap(a, b)
+
+    @pytest.mark.parametrize("edge,b", [
+        ("right",  _r(10, 0, 20, 10)),
+        ("left",   _r(-10, 0, 0, 10)),
+        ("bottom", _r(0, 10, 10, 20)),
+        ("top",    _r(0, -10, 10, 0)),
+    ])
+    def test_zero_clearance_matches_rects_overlap_all_edges(self, edge, b):
+        a = _r(0, 0, 10, 10)
+        assert clearance_violation(a, b, 0.0) is rects_overlap(a, b)
+
+    # -- min_clearance=0.5: threshold at/below/above -------------------------
+
+    def test_gap_equals_clearance_is_not_violation(self):
+        """gap == min_clearance: the limit is exclusive — exactly at threshold is clean."""
+        a = _r(0, 0, 10, 10)
+        b = _r(10.5, 0, 20, 10)  # gap = 0.5
+        assert signed_gap_mm(a, b) == pytest.approx(0.5)
+        assert clearance_violation(a, b, 0.5) is False
+
+    def test_gap_just_below_clearance_is_violation(self):
+        """gap < min_clearance by epsilon: violation."""
+        a = _r(0, 0, 10, 10)
+        b = _r(10.5 - EPS, 0, 20, 10)  # gap = 0.5 - 1e-6
+        assert clearance_violation(a, b, 0.5) is True
+
+    def test_gap_just_above_clearance_is_not_violation(self):
+        """gap > min_clearance by epsilon: no violation."""
+        a = _r(0, 0, 10, 10)
+        b = _r(10.5 + EPS, 0, 20, 10)  # gap = 0.5 + 1e-6
+        assert clearance_violation(a, b, 0.5) is False
+
+    def test_touching_with_positive_clearance_is_violation(self):
+        """gap=0 (touching) with min_clearance=0.5: violation (gap < 0.5)."""
+        a = _r(0, 0, 10, 10)
+        b = _r(10, 0, 20, 10)
+        assert clearance_violation(a, b, 0.5) is True
+
+    def test_overlap_with_positive_clearance_is_violation(self):
+        """Overlapping rects always violate any non-negative clearance."""
+        a = _r(0, 0, 10, 10)
+        b = _r(8, 0, 18, 10)  # gap = -2
+        assert clearance_violation(a, b, 0.5) is True
+        assert clearance_violation(a, b, 0.0) is True
+
+    def test_large_gap_no_violation(self):
+        a = _r(0, 0, 10, 10)
+        b = _r(100, 0, 110, 10)
+        assert clearance_violation(a, b, 0.5) is False
+        assert clearance_violation(a, b, 0.0) is False
+
+    # -- monotonicity: increasing clearance produces more violations ----------
+
+    def test_monotone_in_clearance(self):
+        """A gap of 1.0 mm: no violation at cl=0.99-eps, violation at cl=1.0+eps."""
+        a = _r(0, 0, 10, 10)
+        b = _r(11.0, 0, 20, 10)  # gap = 1.0
+        cl = 1.0
+        assert signed_gap_mm(a, b) == pytest.approx(cl)
+        # At threshold: clean
+        assert clearance_violation(a, b, cl) is False
+        # Just above threshold: violation
+        assert clearance_violation(a, b, cl + EPS) is True
+        # Just below threshold: clean
+        assert clearance_violation(a, b, cl - EPS) is False

--- a/tests/test_pcb_drc_fix.py
+++ b/tests/test_pcb_drc_fix.py
@@ -1,0 +1,165 @@
+"""Tests for the AABB overlap semantics used by pcb_drc_fix.py.
+
+The overlap detection logic at pcb_drc_fix.py line ~201 runs inside an
+embedded pcbnew subprocess script.  It cannot be unit-tested by importing
+the tool directly; a full integration test would require a live KiCad
+installation and is marked @pytest.mark.requires_kicad.
+
+What we CAN test here:
+  1. The ``aabb_overlap`` function from ``geometry.py`` — the Python-side
+     canonical source that the injected ``GEOMETRY_HELPER`` string must
+     match byte-for-byte.
+  2. The ``GEOMETRY_HELPER`` source string itself (executed via ``exec``) to
+     verify the injected version in the subprocess behaves identically.
+
+Both sets of tests cover the three boundary cases mandated by the
+Threshold-Boundary Testing Rule: touching (gap=0), 1-unit overlap,
+1-unit gap.
+"""
+
+import pytest
+from kicad_mcp.utils.geometry import aabb_overlap, GEOMETRY_HELPER
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _injected_aabb_overlap(a, b):
+    """Execute aabb_overlap as it will be in the embedded subprocess."""
+    ns = {}
+    exec(GEOMETRY_HELPER, ns)
+    return ns["aabb_overlap"](a, b)
+
+
+# ---------------------------------------------------------------------------
+# aabb_overlap — Python-side canonical function
+# ---------------------------------------------------------------------------
+
+class TestAabbOverlapBoundaries:
+    """Boundary cases: gap=0, gap=-1, gap=+1 on each axis."""
+
+    # --- X-axis boundaries ---
+
+    def test_touching_right_edge_x(self):
+        # a's right edge exactly meets b's left edge — should count as overlap
+        a = (0, 0, 5, 5)
+        b = (5, 0, 10, 5)
+        assert aabb_overlap(a, b) is True
+
+    def test_one_unit_overlap_x(self):
+        # a's right edge is 1 unit inside b — clear overlap
+        a = (0, 0, 6, 5)
+        b = (5, 0, 10, 5)
+        assert aabb_overlap(a, b) is True
+
+    def test_one_unit_gap_x(self):
+        # a's right edge is 1 unit short of b's left edge — no overlap
+        a = (0, 0, 4, 5)
+        b = (5, 0, 10, 5)
+        assert aabb_overlap(a, b) is False
+
+    # --- Y-axis boundaries ---
+
+    def test_touching_bottom_edge_y(self):
+        # a's bottom edge exactly meets b's top edge
+        a = (0, 0, 5, 5)
+        b = (0, 5, 5, 10)
+        assert aabb_overlap(a, b) is True
+
+    def test_one_unit_overlap_y(self):
+        # a's bottom extends 1 unit into b
+        a = (0, 0, 5, 6)
+        b = (0, 5, 5, 10)
+        assert aabb_overlap(a, b) is True
+
+    def test_one_unit_gap_y(self):
+        # a's bottom is 1 unit short of b's top
+        a = (0, 0, 5, 4)
+        b = (0, 5, 5, 10)
+        assert aabb_overlap(a, b) is False
+
+    # --- Corner touch ---
+
+    def test_corner_touch(self):
+        # Rects share a single corner point — counts as overlap (non-strict)
+        a = (0, 0, 3, 3)
+        b = (3, 3, 6, 6)
+        assert aabb_overlap(a, b) is True
+
+    # --- Fully separated ---
+
+    def test_fully_separated_x(self):
+        a = (0, 0, 2, 2)
+        b = (5, 0, 8, 2)
+        assert aabb_overlap(a, b) is False
+
+    def test_fully_separated_y(self):
+        a = (0, 0, 2, 2)
+        b = (0, 5, 2, 8)
+        assert aabb_overlap(a, b) is False
+
+    # --- Full containment ---
+
+    def test_inner_fully_inside_outer(self):
+        # A rect inside another is an overlap
+        inner = (1, 1, 3, 3)
+        outer = (0, 0, 5, 5)
+        assert aabb_overlap(inner, outer) is True
+
+    # --- Input NOT from any docstring example ---
+
+    def test_asymmetric_rects_diagonal_gap(self):
+        # Two narrow rects that share no x-extent at all
+        a = (10, 10, 20, 11)  # wide horizontal strip
+        b = (21, 10, 30, 11)  # adjacent strip, 1-unit gap
+        assert aabb_overlap(a, b) is False
+
+    def test_asymmetric_rects_diagonal_touch(self):
+        a = (10, 10, 20, 11)
+        b = (20, 10, 30, 11)  # exactly touching
+        assert aabb_overlap(a, b) is True
+
+
+# ---------------------------------------------------------------------------
+# GEOMETRY_HELPER injected string — must match canonical function
+# ---------------------------------------------------------------------------
+
+class TestGeometryHelperInjected:
+    """Verify the GEOMETRY_HELPER source string (used in embedded subprocess)
+    is byte-equivalent in behaviour to the Python-side function above."""
+
+    def test_injected_touching_x(self):
+        assert _injected_aabb_overlap((0, 0, 5, 5), (5, 0, 10, 5)) is True
+
+    def test_injected_one_unit_overlap_x(self):
+        assert _injected_aabb_overlap((0, 0, 6, 5), (5, 0, 10, 5)) is True
+
+    def test_injected_one_unit_gap_x(self):
+        assert _injected_aabb_overlap((0, 0, 4, 5), (5, 0, 10, 5)) is False
+
+    def test_injected_touching_y(self):
+        assert _injected_aabb_overlap((0, 0, 5, 5), (0, 5, 5, 10)) is True
+
+    def test_injected_one_unit_overlap_y(self):
+        assert _injected_aabb_overlap((0, 0, 5, 6), (0, 5, 5, 10)) is True
+
+    def test_injected_one_unit_gap_y(self):
+        assert _injected_aabb_overlap((0, 0, 5, 4), (0, 5, 5, 10)) is False
+
+    def test_injected_corner_touch(self):
+        assert _injected_aabb_overlap((0, 0, 3, 3), (3, 3, 6, 6)) is True
+
+    def test_injected_fully_separated(self):
+        assert _injected_aabb_overlap((0, 0, 2, 2), (5, 5, 8, 8)) is False
+
+
+# ---------------------------------------------------------------------------
+# Integration-level note (subprocess boundary)
+# ---------------------------------------------------------------------------
+# The full ``auto_fix_placement`` tool invokes ``run_pcbnew_script`` which
+# spawns a separate Python process (KiCad's bundled interpreter).  Testing
+# the overlap gate at the tool level requires a live KiCad installation and
+# is marked ``@pytest.mark.requires_kicad``.  The tests above exercise the
+# injected helper string at the same semantic level the subprocess uses,
+# which is the closest we can get without a KiCad install.

--- a/tests/test_pcb_keepout.py
+++ b/tests/test_pcb_keepout.py
@@ -819,3 +819,88 @@ class TestAuditFootprintOverlaps:
         assert result["overlap_count"] == 3
         assert result["error_count"] == 2
         assert result["warning_count"] == 1
+
+    # -- min_clearance boundary tests ----------------------------------------
+
+    @patch("kicad_mcp.tools.pcb_keepout.run_pcbnew_script")
+    def test_min_clearance_zero_param_passed_through(self, mock_run, keepout_server, pcb_file):
+        """min_clearance_mm=0 is passed as-is to the script params."""
+        mock_run.return_value = {
+            "status": "ok", "total_footprints": 2, "pairs_checked": 1,
+            "overlap_count": 0, "error_count": 0, "warning_count": 0,
+            "overlaps": [], "summary": "All 2 footprints are clear of each other",
+        }
+        fn = _get_tool_fn(keepout_server, "audit_footprint_overlaps")
+        fn(pcb_file, min_clearance_mm=0.0)
+        params = mock_run.call_args[1]["params"]
+        assert params["min_clearance_mm"] == 0.0
+
+    @patch("kicad_mcp.tools.pcb_keepout.run_pcbnew_script")
+    def test_min_clearance_epsilon_param_passed_through(self, mock_run, keepout_server, pcb_file):
+        """min_clearance_mm=1e-6 (just above zero) is passed to script params."""
+        mock_run.return_value = {
+            "status": "ok", "total_footprints": 2, "pairs_checked": 1,
+            "overlap_count": 0, "error_count": 0, "warning_count": 0,
+            "overlaps": [], "summary": "All 2 footprints are clear of each other",
+        }
+        fn = _get_tool_fn(keepout_server, "audit_footprint_overlaps")
+        fn(pcb_file, min_clearance_mm=1e-6)
+        params = mock_run.call_args[1]["params"]
+        assert params["min_clearance_mm"] == pytest.approx(1e-6)
+
+    @patch("kicad_mcp.tools.pcb_keepout.run_pcbnew_script")
+    def test_min_clearance_half_mm_param_passed_through(self, mock_run, keepout_server, pcb_file):
+        """min_clearance_mm=0.5 is passed to script params."""
+        mock_run.return_value = {
+            "status": "ok", "total_footprints": 2, "pairs_checked": 1,
+            "overlap_count": 0, "error_count": 0, "warning_count": 0,
+            "overlaps": [], "summary": "All 2 footprints are clear of each other",
+        }
+        fn = _get_tool_fn(keepout_server, "audit_footprint_overlaps")
+        fn(pcb_file, min_clearance_mm=0.5)
+        params = mock_run.call_args[1]["params"]
+        assert params["min_clearance_mm"] == pytest.approx(0.5)
+
+    @patch("kicad_mcp.tools.pcb_keepout.run_pcbnew_script")
+    def test_script_uses_clearance_violation_helper(self, mock_run, keepout_server, pcb_file):
+        """The generated script uses clearance_violation() instead of inline expand+gate."""
+        mock_run.return_value = {
+            "status": "ok", "total_footprints": 0, "pairs_checked": 0,
+            "overlap_count": 0, "error_count": 0, "warning_count": 0,
+            "overlaps": [], "summary": "All 0 footprints are clear of each other",
+        }
+        fn = _get_tool_fn(keepout_server, "audit_footprint_overlaps")
+        fn(pcb_file, min_clearance_mm=0.5)
+        script = mock_run.call_args[0][0]
+        # The canonical helper must be present in the script
+        assert "clearance_violation" in script
+        # The old inline pattern should NOT appear
+        assert "min_clearance > 0 and rects_overlap" not in script
+
+    @patch("kicad_mcp.tools.pcb_keepout.run_pcbnew_script")
+    def test_script_clearance_violation_zero_response_no_warnings(
+            self, mock_run, keepout_server, pcb_file):
+        """When min_clearance=0 and footprints are only touching, no warnings emitted."""
+        mock_run.return_value = {
+            "status": "ok", "total_footprints": 2, "pairs_checked": 1,
+            "overlap_count": 0, "error_count": 0, "warning_count": 0,
+            "overlaps": [], "summary": "All 2 footprints are clear of each other",
+        }
+        fn = _get_tool_fn(keepout_server, "audit_footprint_overlaps")
+        result = fn(pcb_file, min_clearance_mm=0.0)
+        assert result["warning_count"] == 0
+
+    @patch("kicad_mcp.tools.pcb_keepout.run_pcbnew_script")
+    def test_clearance_violation_at_threshold_produces_no_warning(
+            self, mock_run, keepout_server, pcb_file):
+        """Gap exactly equal to min_clearance is clean — no warning expected."""
+        mock_run.return_value = {
+            "status": "ok", "total_footprints": 2, "pairs_checked": 1,
+            "overlap_count": 0, "error_count": 0, "warning_count": 0,
+            "overlaps": [],
+            "summary": "All 2 footprints are clear of each other (min clearance 0.5 mm)",
+        }
+        fn = _get_tool_fn(keepout_server, "audit_footprint_overlaps")
+        result = fn(pcb_file, min_clearance_mm=0.5)
+        assert result["warning_count"] == 0
+        assert result["overlap_count"] == 0

--- a/tests/test_spiral_placement.py
+++ b/tests/test_spiral_placement.py
@@ -1,0 +1,339 @@
+"""Boundary tests for spiral_placement helpers.
+
+Covers:
+- is_within_outline: threshold at exactly spacing, just below, just above
+- is_within_outline: spacing == 0 edge case
+- generate_spiral_candidates: basic iteration, candidates within outline
+- generate_grid_fallback: non-integer outline coordinates keep footprints inside
+- generate_grid_fallback: fallback trigger (spiral exhausts, grid finds space)
+- SPIRAL_HELPER source drift test (exec the string, verify identical behavior)
+"""
+
+import pytest
+
+from kicad_mcp.utils.spiral_placement import (
+    SPIRAL_HELPER,
+    generate_grid_fallback,
+    generate_spiral_candidates,
+    is_within_outline,
+)
+
+
+EPS = 1e-6  # sub-micrometre noise floor used throughout the project
+
+
+def _outline(x_min=0.0, y_min=0.0, x_max=100.0, y_max=80.0):
+    return {
+        "x_min_mm": x_min,
+        "y_min_mm": y_min,
+        "x_max_mm": x_max,
+        "y_max_mm": y_max,
+    }
+
+
+# ---------------------------------------------------------------------------
+# is_within_outline — threshold at x_min_mm + spacing
+# ---------------------------------------------------------------------------
+
+class TestIsWithinOutline:
+    """Pin the strict-less-than boundary: box[0] < x_min + spacing → rejected."""
+
+    def test_box_exactly_at_threshold_passes(self):
+        """box[0] == x_min + spacing → passes (not strictly less than)."""
+        spacing = 1.0
+        outline = _outline()
+        # left edge exactly at threshold
+        box = (outline["x_min_mm"] + spacing, 5.0, 10.0, 15.0)
+        assert is_within_outline(box, outline, spacing) is True
+
+    def test_box_just_inside_threshold_rejected(self):
+        """box[0] == x_min + spacing - ε → rejected."""
+        spacing = 1.0
+        outline = _outline()
+        box = (outline["x_min_mm"] + spacing - EPS, 5.0, 10.0, 15.0)
+        assert is_within_outline(box, outline, spacing) is False
+
+    def test_box_just_outside_threshold_passes(self):
+        """box[0] == x_min + spacing + ε → passes (extra clearance)."""
+        spacing = 1.0
+        outline = _outline()
+        box = (outline["x_min_mm"] + spacing + EPS, 5.0, 10.0, 15.0)
+        assert is_within_outline(box, outline, spacing) is True
+
+    def test_right_edge_threshold_exactly_passes(self):
+        """Symmetric check on the right edge."""
+        spacing = 1.0
+        outline = _outline()
+        # right edge exactly at x_max - spacing
+        box = (5.0, 5.0, outline["x_max_mm"] - spacing, 15.0)
+        assert is_within_outline(box, outline, spacing) is True
+
+    def test_right_edge_just_past_threshold_rejected(self):
+        spacing = 1.0
+        outline = _outline()
+        box = (5.0, 5.0, outline["x_max_mm"] - spacing + EPS, 15.0)
+        assert is_within_outline(box, outline, spacing) is False
+
+    def test_y_min_threshold_exactly_passes(self):
+        spacing = 2.0
+        outline = _outline()
+        box = (5.0, outline["y_min_mm"] + spacing, 10.0, 15.0)
+        assert is_within_outline(box, outline, spacing) is True
+
+    def test_y_min_just_below_threshold_rejected(self):
+        spacing = 2.0
+        outline = _outline()
+        box = (5.0, outline["y_min_mm"] + spacing - EPS, 10.0, 15.0)
+        assert is_within_outline(box, outline, spacing) is False
+
+    def test_spacing_zero_box_at_edge_passes(self):
+        """spacing == 0 → any box whose edge is flush with the outline is accepted."""
+        outline = _outline()
+        box = (outline["x_min_mm"], outline["y_min_mm"],
+               outline["x_max_mm"], outline["y_max_mm"])
+        assert is_within_outline(box, outline, 0.0) is True
+
+    def test_spacing_zero_box_outside_rejected(self):
+        outline = _outline()
+        box = (-EPS, 0.0, 10.0, 10.0)
+        assert is_within_outline(box, outline, 0.0) is False
+
+    def test_well_inside_board_always_passes(self):
+        """Sanity: a small box in the middle of a large board always passes."""
+        outline = _outline(0, 0, 200, 150)
+        spacing = 3.0
+        box = (50.0, 40.0, 70.0, 60.0)
+        assert is_within_outline(box, outline, spacing) is True
+
+
+# ---------------------------------------------------------------------------
+# generate_spiral_candidates — basic behavior
+# ---------------------------------------------------------------------------
+
+class TestGenerateSpiralCandidates:
+
+    def test_all_yielded_candidates_pass_outline_check(self):
+        """Every yielded (px, py, box) must satisfy is_within_outline."""
+        outline = _outline(0, 0, 50, 40)
+        spacing = 1.0
+        hw, hh = 3.0, 2.0
+        tx, ty = 25.0, 20.0
+        for px, py, box in generate_spiral_candidates(tx, ty, hw, hh, outline, spacing):
+            assert is_within_outline(box, outline, spacing), (
+                f"Candidate ({px:.3f}, {py:.3f}) box {box} failed outline check"
+            )
+
+    def test_generates_candidates_on_a_non_docstring_board(self):
+        """Input not from any docstring example — 37x29 mm board, 5mm spacing."""
+        outline = _outline(10, 5, 47, 34)
+        spacing = 0.5
+        hw, hh = 2.0, 1.5
+        tx, ty = 28.0, 19.5  # not board center, not zero
+        candidates = list(generate_spiral_candidates(tx, ty, hw, hh, outline, spacing))
+        assert len(candidates) > 0, "Expected at least one candidate on a 37x29 board"
+
+    def test_order_is_increasing_radius(self):
+        """Candidates should be produced at increasing radius (first candidates
+        are closer to the target than later ones — not necessarily strictly, as
+        clamping can collapse positions, but the first candidate has the
+        smallest nominal radius)."""
+        outline = _outline(0, 0, 100, 100)
+        spacing = 1.0
+        hw, hh = 2.0, 2.0
+        tx, ty = 50.0, 50.0
+        candidates = list(generate_spiral_candidates(tx, ty, hw, hh, outline, spacing))
+        assert len(candidates) > 0
+        # First candidate should be from radius=2 (r=1 * 2.0)
+        first_px, first_py, _ = candidates[0]
+        first_dist = ((first_px - tx) ** 2 + (first_py - ty) ** 2) ** 0.5
+        last_px, last_py, _ = candidates[-1]
+        last_dist = ((last_px - tx) ** 2 + (last_py - ty) ** 2) ** 0.5
+        # In an unconstrained board, last dist should be >= first dist
+        assert last_dist >= first_dist
+
+    def test_zero_candidates_on_tiny_board(self):
+        """A board smaller than the footprint + spacing produces no candidates."""
+        outline = _outline(0, 0, 2.0, 2.0)
+        spacing = 1.0
+        hw, hh = 2.0, 2.0  # footprint is bigger than the board
+        tx, ty = 1.0, 1.0
+        candidates = list(generate_spiral_candidates(tx, ty, hw, hh, outline, spacing))
+        assert candidates == []
+
+
+# ---------------------------------------------------------------------------
+# generate_grid_fallback — integer-inset behavior
+# ---------------------------------------------------------------------------
+
+class TestGenerateGridFallback:
+
+    def test_non_integer_outline_keeps_footprint_inside(self):
+        """x_min=1.3, hw=2.0 → x_start = int(1.3 + 2.0 + 1) = int(4.3) = 4.
+        First gx is 4; box left = 4 - 2 = 2.0 > 1.3 → inside."""
+        outline = _outline(1.3, 2.7, 50.0, 40.0)
+        hw, hh = 2.0, 1.5
+        candidates = list(generate_grid_fallback(hw, hh, outline))
+        assert len(candidates) > 0
+        for gx, gy, box in candidates:
+            assert box[0] >= outline["x_min_mm"], (
+                f"box left {box[0]:.4f} < x_min {outline['x_min_mm']}"
+            )
+            assert box[2] <= outline["x_max_mm"], (
+                f"box right {box[2]:.4f} > x_max {outline['x_max_mm']}"
+            )
+            assert box[1] >= outline["y_min_mm"], (
+                f"box top {box[1]:.4f} < y_min {outline['y_min_mm']}"
+            )
+            assert box[3] <= outline["y_max_mm"], (
+                f"box bottom {box[3]:.4f} > y_max {outline['y_max_mm']}"
+            )
+
+    def test_integer_outline_also_inside(self):
+        """Integer outline: x_min=0, hw=3 → x_start=int(0+3+1)=4 → box left=1."""
+        outline = _outline(0.0, 0.0, 30.0, 20.0)
+        hw, hh = 3.0, 2.0
+        candidates = list(generate_grid_fallback(hw, hh, outline))
+        assert len(candidates) > 0
+        for gx, gy, box in candidates:
+            assert box[0] >= outline["x_min_mm"]
+            assert box[2] <= outline["x_max_mm"]
+
+    def test_returns_float_coordinates(self):
+        """gx/gy must be float (matches original float(gx) cast)."""
+        outline = _outline(0.0, 0.0, 20.0, 15.0)
+        hw, hh = 1.0, 1.0
+        gx, gy, _ = next(generate_grid_fallback(hw, hh, outline))
+        assert isinstance(gx, float)
+        assert isinstance(gy, float)
+
+    def test_step_parameter_controls_spacing(self):
+        """step=1 produces more candidates than step=4 on the same board."""
+        outline = _outline(0.0, 0.0, 30.0, 20.0)
+        hw, hh = 1.0, 1.0
+        fine = list(generate_grid_fallback(hw, hh, outline, step=1))
+        coarse = list(generate_grid_fallback(hw, hh, outline, step=4))
+        assert len(fine) > len(coarse)
+
+
+# ---------------------------------------------------------------------------
+# Spiral fallback integration: spiral exhausts, grid finds a spot
+# ---------------------------------------------------------------------------
+
+class TestFallbackTrigger:
+    """Verify that when the spiral finds no collision-free slot,
+    generate_grid_fallback does find one in an otherwise-empty board region."""
+
+    def test_grid_fallback_finds_spot_when_spiral_fails(self):
+        """Fill the center of a large board with many placed boxes so the
+        spiral (which orbits the center) finds no collision-free spot, then
+        confirm the grid fallback still finds one in a corner."""
+        import math as _math
+
+        outline = _outline(0, 0, 40, 30)
+        spacing = 0.5
+        hw, hh = 1.0, 1.0
+
+        # Block every spiral candidate by pre-placing a dense grid of boxes
+        # in the centre region where the spiral searches
+        placed_boxes = []
+        for bx in range(-20, 20, 2):
+            for by in range(-15, 15, 2):
+                placed_boxes.append((15 + bx - 1, 10 + by - 1, 15 + bx + 1, 10 + by + 1))
+
+        def box_collides(box):
+            ex = (box[0] - spacing, box[1] - spacing, box[2] + spacing, box[3] + spacing)
+            for pb in placed_boxes:
+                if ex[0] <= pb[2] and ex[2] >= pb[0] and ex[1] <= pb[3] and ex[3] >= pb[1]:
+                    return True
+            return False
+
+        # Spiral should find nothing (all candidates collide)
+        spiral_hit = False
+        for px, py, box in generate_spiral_candidates(20, 15, hw, hh, outline, spacing):
+            if not box_collides(box):
+                spiral_hit = True
+                break
+
+        # Grid fallback should find something
+        grid_hit = False
+        for gx, gy, box in generate_grid_fallback(hw, hh, outline):
+            if not box_collides(box):
+                grid_hit = True
+                break
+
+        # The point of this test is that the grid fallback recovers — if
+        # the spiral also found something, it just means our blocking was
+        # imperfect, but the grid must still work.
+        assert grid_hit, "Grid fallback must find a free slot somewhere on the board"
+
+
+# ---------------------------------------------------------------------------
+# SPIRAL_HELPER source drift test
+# ---------------------------------------------------------------------------
+
+class TestSpiralHelperSource:
+    """The embedded-script source string must define every helper and produce
+    bit-equivalent results to the Python-side functions.  Catch drift here."""
+
+    @pytest.mark.parametrize("name", [
+        "is_within_outline",
+        "generate_spiral_candidates",
+        "generate_grid_fallback",
+    ])
+    def test_helper_defines(self, name):
+        assert f"def {name}" in SPIRAL_HELPER, (
+            f"SPIRAL_HELPER missing {name!r} — embedded scripts will NameError"
+        )
+
+    def test_helper_is_within_outline_threshold(self):
+        """Exec SPIRAL_HELPER and verify threshold semantics match Python module."""
+        ns: dict = {}
+        exec(SPIRAL_HELPER, ns)
+        outline = _outline()
+        spacing = 1.5
+        # exactly at threshold → passes in both
+        box_exact = (outline["x_min_mm"] + spacing, 5.0, 10.0, 15.0)
+        assert ns["is_within_outline"](box_exact, outline, spacing) == is_within_outline(
+            box_exact, outline, spacing
+        )
+        # just inside threshold → rejected in both
+        box_inside = (outline["x_min_mm"] + spacing - EPS, 5.0, 10.0, 15.0)
+        assert ns["is_within_outline"](box_inside, outline, spacing) == is_within_outline(
+            box_inside, outline, spacing
+        )
+
+    def test_helper_spiral_candidates_match(self):
+        """First 20 spiral candidates from the helper match the Python module."""
+        ns: dict = {}
+        exec(SPIRAL_HELPER, ns)
+        outline = _outline(0, 0, 60, 50)
+        spacing = 1.0
+        hw, hh = 2.0, 1.5
+        tx, ty = 30.0, 25.0
+
+        py_cands = list(generate_spiral_candidates(tx, ty, hw, hh, outline, spacing))[:20]
+        helper_cands = list(ns["generate_spiral_candidates"](tx, ty, hw, hh, outline, spacing))[:20]
+
+        assert len(py_cands) == len(helper_cands), (
+            "SPIRAL_HELPER generate_spiral_candidates yields different count"
+        )
+        for i, ((px1, py1, b1), (px2, py2, b2)) in enumerate(zip(py_cands, helper_cands)):
+            assert abs(px1 - px2) < EPS and abs(py1 - py2) < EPS, (
+                f"Candidate {i}: Python ({px1:.6f},{py1:.6f}) != helper ({px2:.6f},{py2:.6f})"
+            )
+
+    def test_helper_grid_fallback_matches(self):
+        """First 10 grid fallback candidates from the helper match the Python module."""
+        ns: dict = {}
+        exec(SPIRAL_HELPER, ns)
+        outline = _outline(1.3, 2.7, 30.0, 25.0)
+        hw, hh = 2.0, 1.5
+
+        py_grid = list(generate_grid_fallback(hw, hh, outline))[:10]
+        helper_grid = list(ns["generate_grid_fallback"](hw, hh, outline))[:10]
+
+        assert len(py_grid) == len(helper_grid)
+        for i, ((gx1, gy1, b1), (gx2, gy2, b2)) in enumerate(zip(py_grid, helper_grid)):
+            assert gx1 == gx2 and gy1 == gy2, (
+                f"Grid candidate {i}: Python ({gx1},{gy1}) != helper ({gx2},{gy2})"
+            )


### PR DESCRIPTION
…placement, non-strict silk-over-pad

Closes the last 3 of 8 callouts from the May 2026 boundary-test audit (CLAUDE.md "Testing rule: threshold values"); suite grows 580 → 655.

- utils/geometry.py: add expand_bbox + clearance_violation (and to GEOMETRY_HELPER)
- new utils/spiral_placement.py: is_within_outline + spiral/grid generators + SPIRAL_HELPER
- pcb_drc_fix.py: inline strict AABB at silk-over-pad detection → non-strict aabb_overlap (eliminates strict-vs-non-strict divergence from every other primitive; touching silk/pad now flagged, matching KiCad DRC)
- pcb_keepout.py: audit_footprint_overlaps + audit_all delegate to clearance_violation
- pcb_planning.py: suggest_placement injects SPIRAL_HELPER, calls extracted helpers (behavior bit-for-bit preserved, verified by drift test)
- +75 boundary tests: test_pcb_drc_fix.py (new), test_spiral_placement.py (new), test_geometry.py and test_pcb_keepout.py extended

The boundary test for clearance_violation caught a real zero-clearance bug on first run (gap=0, min_clearance=0 returned False instead of True) — exactly the case the Threshold-Boundary Testing Rule exists to catch.