### PR TITLE
ci: add umbrella pytest job so branch protection check exists

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,11 @@ permissions:
   contents: read
 
 jobs:
-  pytest:
-    name: pytest
+  # Matrix job — produces check names "pytest (3.10)" etc.  These are NOT
+  # what branch protection requires (it requires a single check named
+  # exactly "pytest"); the umbrella job below provides that.
+  matrix:
+    name: pytest (${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -45,3 +48,22 @@ jobs:
         env:
           KICAD_SYMBOL_DIR: /usr/share/kicad/symbols
         run: python -m pytest tests/ -q
+
+  # Umbrella job — single check named "pytest" that branch protection can
+  # require regardless of how the matrix above changes shape.  Adding or
+  # removing a Python version updates this PR alone; branch protection
+  # never has to be re-edited.
+  pytest:
+    name: pytest
+    needs: matrix
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all matrix jobs passed
+        run: |
+          if [[ "${{ needs.matrix.result }}" == "success" ]]; then
+            echo "All matrix jobs passed."
+            exit 0
+          fi
+          echo "Matrix result: ${{ needs.matrix.result }}"
+          exit 1


### PR DESCRIPTION
## Summary
- Renames the matrix job key from `pytest` to `matrix` (display name unchanged — checks still appear as `pytest (3.10)`, `pytest (3.12)`, `pytest (3.13)`).
- Adds a thin umbrella `pytest` job that `needs: matrix` and exits non-zero unless the matrix succeeded.

## Why
Branch protection requires a check named exactly `pytest`. The matrix workflow only emits `pytest (3.X)` per Python version, never the bare `pytest` name. PR #19 was the first PR to hit this — it was BLOCKED on a `pytest` "Expected — Waiting for status to be reported" check despite the matrix passing, and had to be merged via admin bypass.

This umbrella pattern is matrix-shape-agnostic: adding or removing a Python version no longer requires editing branch protection.

## Test plan
- [ ] Confirm `pytest (3.10)`, `pytest (3.12)`, `pytest (3.13)` checks still appear and pass (unchanged behavior)
- [ ] Confirm new `pytest` umbrella check appears and passes
- [ ] Confirm branch protection's `pytest` requirement is now satisfied without admin bypass
- [ ] (Optional follow-up) consider removing the `Required` flag from individual matrix checks if any are pinned

🤖 Generated with [Claude Code](https://claude.com/claude-code)