### PR TITLE
Phase 1: library + analyze + export routers (97 → 90)

### DIFF
--- a/AGENT-INSTALL.md
+++ b/AGENT-INSTALL.md
@@ -4,7 +4,7 @@ This file is for you, the AI agent. It tells you what needs to be true on this s
 
 ## What This Is
 
-kicad-mcp is a Model Context Protocol (MCP) server providing 97 tools for KiCad electronic design automation — schematic capture, PCB layout, autorouting, DRC, and more. Once installed and registered, these tools appear in your tool list and you can design circuit boards conversationally.
+kicad-mcp is a Model Context Protocol (MCP) server providing 90 tools for KiCad electronic design automation — schematic capture, PCB layout, autorouting, DRC, and more. Once installed and registered, these tools appear in your tool list and you can design circuit boards conversationally.
 
 **Origin:** Built by one person for personal use, on a Mac, with Claude Code. Other platforms *should* work (the code handles macOS, Windows, and Linux) but are untested. PRs for other agents and platforms will be considered.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This tool enables your AI agent to use [KiCad](https://www.kicad.org/) — the i
 
 ## What This Does
 
-You describe what you need — "design a board for this ESP32 circuit" or "here's the schematic, lay out the PCB" — and your AI agent does the rest: drawing the schematic, choosing components, placing them on the board, routing traces, checking for errors, and producing manufacturing-ready files. All using the same KiCad that professional engineers use, with 97 tools covering the full design workflow.
+You describe what you need — "design a board for this ESP32 circuit" or "here's the schematic, lay out the PCB" — and your AI agent does the rest: drawing the schematic, choosing components, placing them on the board, routing traces, checking for errors, and producing manufacturing-ready files. All using the same KiCad that professional engineers use, with 90 tools covering the full design workflow.
 
 You don't need to know KiCad. You don't need to know what a PCB layout tool does. You just need an AI agent (like [Claude](https://claude.ai/)).
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1,5 +1,5 @@
 # Tool Summary
 
-This MCP server exposes 97 MCP tools for KiCad EDA.
+This MCP server exposes 90 MCP tools for KiCad EDA.
 
 See [README.md](README.md) for the full tool list and usage guide.

--- a/docs/SPEC_Tool_Consolidation.md
+++ b/docs/SPEC_Tool_Consolidation.md
@@ -1,0 +1,311 @@
+# SPEC — Tool Consolidation (Domain-Router Pattern)
+
+**Status:** Approved for phased implementation
+**Author:** Brian + Claude
+**Date:** 2026-05-27
+**Target:** kicad-mcp at 97 tools → 14 tools
+
+## Motivation
+
+Tool count matters for two independent reasons:
+
+1. **Hard caps in MCP clients.** Cursor caps at 40, Gemini at ~100. Anything above
+   Cursor's cap is silently truncated and the agent fails confusingly. Gemini we
+   already brush against.
+2. **System-prompt overhead, every client.** Each tool's name + description +
+   schema costs ~200–500 tokens of system prompt on every turn. At 97 tools that
+   is a meaningful slice of the model's per-turn context — including on Claude
+   Code, which has no hard cap.
+
+The companion project freecad-mcp uses a domain-router pattern (one tool per
+FreeCAD domain, each carrying an `operation=` discriminator) and has held up
+well in practice. This spec proposes the same shape for kicad-mcp.
+
+## Non-goals
+
+- **Not** fitting under Cursor's 40-tool cap. That would force aggressive
+  per-tool conditional schemas with little headroom. Comfortably under 100 with
+  margin is the goal; Cursor users can run the unconsolidated branch or split
+  into multiple MCP server registrations.
+- **Not** changing the underlying KiCad operations. This is a tool-surface
+  refactor. Behavior, params, and return shapes of each operation stay
+  equivalent.
+- **Not** maintaining backwards-compatible aliases for old tool names. The
+  project is on `0.10.0.dev0`; v0.9.0 was the first release. Hard break, one
+  migration note in CHANGELOG.
+
+## Pattern
+
+### Domain routers
+
+A domain router is one MCP tool that takes:
+
+- `operation`: string — names a sub-operation within the domain
+- additional named params — used by one or more operations; per-operation arg
+  validation happens inside the router
+
+Example shape (Python, FastMCP-style):
+
+```python
+@mcp.tool()
+def schematic(
+    operation: str,
+    *,
+    # Args used by multiple ops (union of needs)
+    schematic_path: str | None = None,
+    name: str | None = None,
+    project_path: str | None = None,
+    # ... etc
+) -> dict:
+    """Schematic-domain operations.
+
+    Operations:
+      create(name, project_path?) -> {schematic_path}
+      load(schematic_path) -> {component_count, net_count, ...}
+      save(schematic_path?) -> {status}
+      validate(schematic_path?) -> {issues, summary}
+      info(schematic_path?) -> {...}
+      clone(schematic_path, new_path) -> {status}
+      backup(schematic_path) -> {backup_path}
+    """
+    if operation == "create":
+        return _create(name, project_path)
+    elif operation == "load":
+        return _load(schematic_path)
+    # ...
+    else:
+        return {"error": f"unknown operation {operation!r}; "
+                f"valid: create|load|save|validate|info|clone|backup"}
+```
+
+### Schema decisions
+
+Two ways to encode operation-specific args:
+
+| Approach | Pros | Cons |
+|---|---|---|
+| **A. Flat union of params** (proposed) | Matches freecad-mcp; simple schema; model sees one tool description; easy to add ops | Caller can pass wrong combinations; per-op validation lives in Python |
+| **B. `oneOf` discriminated schema** | Strict typing per operation; auto-rejects bad combos at JSON Schema level | Heavier schema; some clients have spotty `oneOf` support |
+
+**Proposal: A.** Match the freecad-mcp shape that's already proven in practice.
+Per-operation arg validation in Python with clear error messages on missing
+required args. The cost (loose schema) is paid in better operation
+discoverability via the docstring.
+
+### Error contract
+
+Every router returns either `{"status": "ok", ...}` or `{"error": "..."}`.
+Unknown `operation` returns an error that enumerates valid ops verbatim. Missing
+required arg for a given op returns an error naming the op and the missing arg.
+Same shape as today's individual tools.
+
+## Domain breakdown
+
+9 routers + 5 standalone = **14 tools** total. Folds aggressively along
+freecad-mcp's domain-router shape: one router per coherent KiCad domain.
+
+### 1. `schematic` — all schematic editing
+
+Currently: 37 tools.
+
+Folds: schematic file lifecycle + components + wires + labels + text + sheets
++ junctions + pin-collision check.
+
+Ops: `create`, `load`, `save`, `validate`, `info`, `clone`, `backup`,
+`check_pin_collisions`,
+`add_component`, `remove_component`, `move_component`, `list_components`,
+`filter_components`, `components_in_area`, `bulk_update_components`,
+`add_multi_unit_component`, `get_component_pin_position`, `list_component_pins`,
+`find_component_connections`,
+`add_wire`, `remove_wire`, `add_wire_between_pins`, `add_junction`,
+`add_label`, `remove_label`, `edit_label`, `add_label_to_pin`,
+`add_hierarchical_label`, `connect_pins_with_labels`,
+`add_text`, `add_text_box`, `edit_text`,
+`add_sheet`, `add_sheet_pin`
+
+Highest op count by far. Spot-check the docstring size when implementing — if
+it exceeds FastMCP's tool-description limit, split into `schematic` and
+`schematic_edit` (or similar) along the file-lifecycle / item-CRUD seam.
+
+### 2. `pcb` — all PCB editing
+
+Currently: 27 tools.
+
+Folds: PCB file lifecycle + board outline/rules + footprints + nets + manual
+routing + zones + silkscreen + pcb-text.
+
+Ops: `create`, `load`, `finalize`,
+`set_outline`, `set_design_rules`, `get_constraints`,
+`place_footprint`, `move_footprint`, `list_footprints`, `get_pad_positions`,
+`get_footprint_dimensions`,
+`add_net`, `rename_net`, `list_nets`, `set_net_class`, `assign_pad_net`,
+`bulk_assign_pad_nets`,
+`add_trace`, `add_via`, `clear_routing`, `edit_trace_width`,
+`add_zone`, `fill_zones`,
+`add_text`,
+`list_silkscreen`, `update_silkscreen`, `auto_fix_silkscreen`,
+`check_silkscreen_overlaps`
+
+Second-highest op count. Same spot-check applies. If split is needed, natural
+seam is `pcb_edit` (footprints/nets/routing/zones) vs `pcb_text` (silkscreen +
+text + drawings).
+
+### 3. `audit` — placement + clearance verification + fixes
+
+Currently: 9 tools (audit_all, audit_pcb_placement, audit_footprint_overlaps,
+check_pad_clearances, validate_placement, auto_fix_placement, get_keepout_zones,
+pre_route_check, plus overlap with silkscreen).
+
+Ops: `all`, `placement`, `footprint_overlaps`, `pad_clearances`, `validate_one`,
+`auto_fix_placement`, `keepouts`, `pre_route_check`
+
+**Detail flag:** the earlier finding that `audit_all` returns less detail than
+the standalone variants is resolved by a `detail="summary"|"full"` flag.
+Default `summary` matches current `audit_all` output; `full` matches the
+standalone tools (bboxes, gap_mm, severity messages, silk_text, pad_number).
+
+### 4. `drc` — KiCad DRC engine
+
+Currently: 3 tools.
+
+Ops: `run`, `autofix`, `history`
+
+### 5. `autoroute` — FreeRouter integration
+
+Currently: 5 tools.
+
+Ops: `run` (sync), `start` (async), `poll`, `cancel`, `list_jobs`
+
+Both sync and async live here. Different return shapes per op — sync `run`
+returns the result; `start` returns a `job_id`; `poll` returns status or
+result-when-done. Distinct from the freecad async issue (UI-thread blocking
+forced all-async there); here sync is fine for short routes and async is
+useful for routes that exceed model-turn time budgets.
+
+### 6. `library` — symbol/footprint library search
+
+Currently: 2 tools (search, rebuild_library_index).
+
+Ops: `search` (with `type="symbol"|"footprint"`), `rebuild_index`
+
+### 7. `project` — KiCad project files
+
+Currently: 4 tools.
+
+Ops: `list`, `open`, `get_structure`, `validate`
+
+### 8. `analyze` — read-only analysis
+
+Currently: 5 tools (analyze_schematic_connections, identify_circuit_patterns,
+analyze_project_circuit_patterns, analyze_bom, extract_netlist).
+
+Ops: `connections`, `circuit_patterns`, `project_patterns`, `bom`, `netlist`
+
+### 9. `export` — manufacturing/output files
+
+Currently: 3 tools (export_gerbers, export_bom_csv, generate_pcb_thumbnail).
+
+Ops: `gerbers`, `bom_csv`, `thumbnail`
+
+### Standalone (no router) — heavy hitters with distinctive semantics
+
+| Tool | Why standalone |
+|---|---|
+| `build_pcb_from_schematic` | Top-level orchestration; not a verb within a domain |
+| `update_pcb_from_schematic` | Cross-domain sync; semantically loud enough to deserve its own name |
+| `panelize_pcb` | One-shot manufacturing op; no related siblings |
+| `estimate_board_size` | Planning aid called before any pcb router op |
+| `suggest_placement` | Planning aid; not a CRUD op on footprints |
+
+**Standalone count: 5.**
+
+**Total: 9 routers + 5 standalone = 14 tools.** Net reduction: 97 → 14, an 85% cut.
+
+## Migration strategy
+
+This is a hard break. v0.10.0.dev0 → v0.11.0 (or 1.0). Steps:
+
+1. Add new routers alongside old tools in one branch (both registered).
+2. Update workflow docs (CLAUDE.md, AGENT-INSTALL.md, README.md) to use
+   router-style calls everywhere.
+3. Bump to a single PR that deletes the old tool wrappers and ships the
+   router-only surface.
+4. CHANGELOG entry calls out the rename mapping table verbatim.
+
+Do **not** ship deprecation aliases. They double the tool count temporarily
+which defeats the purpose, and external users on v0.9.0 will read the
+CHANGELOG when they update.
+
+## Test impact
+
+The existing 577 tests are organized by current module. After consolidation:
+
+- Each router gets a new test file: `tests/test_router_schematic.py`,
+  `tests/test_router_pcb.py`, etc.
+- Per-operation tests inside each router test file (one test class per op).
+- `tests/test_server.py` tool-count snapshot bumps from 97 to 18.
+- Existing tests are rewritten to call routers (mechanical update of
+  `tool_name` lookups + adding `operation=...` arg).
+
+Estimated rewrite: ~1 day, mostly mechanical.
+
+## Implementation phasing
+
+Each phase is an independently reviewable PR. Read-only and self-contained
+domains land first to validate the router shape before the larger editing
+routers go in.
+
+| Phase | Routers | Tools before → after | Risk |
+|---|---|---|---|
+| 1 | `library`, `analyze`, `export` | 10 → 3 | Low — read-only |
+| 2 | `project`, `drc`, `autoroute` | 12 → 3 | Low — self-contained |
+| 3 | `audit` (with `detail` flag) | 9 → 1 | Med — preserves both detail levels |
+| 4 | `pcb` | 27 → 1 | High — large op count; spot-check description size |
+| 5 | `schematic` | 37 → 1 | High — largest op count |
+| 6 | Delete standalones that didn't make it; final cleanup | — | Trivial |
+
+After all phases: 97 → 14 tools (9 routers + 5 standalone).
+
+If phase 4 or 5 hits the FastMCP tool-description-size limit, split that
+router along the seam noted in its section above. Worst case: 14 → 16 tools.
+
+## Resolved questions
+
+All six original open questions are now decided:
+
+1. **Naming convention** → snake_case ops (matches freecad-mcp).
+2. **Audit/silkscreen merge** → not merged. Silkscreen ops fold into the `pcb`
+   router because they're PCB-editing operations, not verification. Only the
+   verification op (`check_silkscreen_overlaps`) stays available there too —
+   `audit.silkscreen` and `pcb.check_silkscreen_overlaps` both work, sharing
+   one impl.
+3. **`extract_netlist` standalone vs in `analyze`** → in `analyze`. Adding
+   exceptions undermines the pattern.
+4. **Sync + async autoroute in one router** → yes. The freecad UI-thread
+   reason for going async-only doesn't apply (no UI to block); both have value
+   here for different route lengths.
+5. **`build_pcb_from_schematic` / `update_pcb_from_schematic`** → standalone.
+   Only two pipeline ops, not worth a router; they're semantically distinct
+   enough that a router would obscure rather than organize.
+6. **MCP `tools/list_changed` for further reduction** → skip. At 14 tools
+   we're well below any client cap. Dynamic loading adds client-compat risk
+   for marginal further reduction.
+
+## Acceptance criteria
+
+- Tool count: ≤ 16 registered on the FastMCP instance (14 target, 16 ceiling
+  if `pcb` or `schematic` has to split).
+- All 577 existing tests pass under the new surface (rewritten as needed).
+- CLAUDE.md workflow examples use router-style calls.
+- CHANGELOG documents every renamed/removed tool with the new operation name.
+- No backwards-compat aliases registered.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Models forget operation names because they live in prose | Mirror freecad-mcp's docstring conventions; verify with eval prompts before merging each phase |
+| Per-operation arg validation diverges across routers | Shared helper `_require_args(op_name, args_dict)` used by every router |
+| External users break | Hard break, clearly documented; v0.9.0 is one minor version old |
+| Audit-detail regression (already identified) | `detail=full|summary` flag in `audit` router |
+| FastMCP client tool description size limit | Each router's docstring is ~30–60 lines; well within limits. Spot-check with longest (`schematic` or `component`) before merging |

--- a/src/kicad_mcp/server.py
+++ b/src/kicad_mcp/server.py
@@ -37,20 +37,23 @@ def create_server() -> FastMCP:
     register_pcb_drc_fix_tools(mcp)
     register_pipeline_tools(mcp)
 
-    # Upstream tools (project, export, DRC, BOM, netlist, patterns)
-    from kicad_mcp.tools.project import register_project_tools
+    # Domain routers (phase 1: library + analyze + export)
+    from kicad_mcp.tools.library import register_library_tools
+    from kicad_mcp.tools.analyze import register_analyze_tools
     from kicad_mcp.tools.export import register_export_tools
+
+    register_library_tools(mcp)
+    register_analyze_tools(mcp)
+    register_export_tools(mcp)
+
+    # Tools not yet consolidated into routers
+    from kicad_mcp.tools.project import register_project_tools
     from kicad_mcp.tools.drc import register_drc_tools
-    from kicad_mcp.tools.bom import register_bom_tools
     from kicad_mcp.tools.netlist import register_netlist_tools
-    from kicad_mcp.tools.patterns import register_pattern_tools
 
     register_project_tools(mcp)
-    register_export_tools(mcp)
     register_drc_tools(mcp)
-    register_bom_tools(mcp)
     register_netlist_tools(mcp)
-    register_pattern_tools(mcp)
 
     # Schematic tools (wrapping kicad-sch-api)
     from kicad_mcp.tools.schematic import register_schematic_tools

--- a/src/kicad_mcp/tools/analyze.py
+++ b/src/kicad_mcp/tools/analyze.py
@@ -1,0 +1,89 @@
+"""Analyze router — read-only schematic/project analysis.
+
+See docs/SPEC_Tool_Consolidation.md.
+"""
+import logging
+from typing import Any, Dict, Optional
+
+from fastmcp import FastMCP, Context
+
+from kicad_mcp.tools.bom import _op_analyze_bom
+from kicad_mcp.tools.netlist import (
+    _op_extract_netlist,
+    _op_analyze_schematic_connections,
+)
+from kicad_mcp.tools.patterns import (
+    _op_identify_circuit_patterns,
+    _op_analyze_project_circuit_patterns,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def register_analyze_tools(mcp: FastMCP) -> None:
+    """Register the analyze domain router."""
+
+    @mcp.tool()
+    async def analyze(
+        operation: str,
+        ctx: Context | None,
+        *,
+        path: Optional[str] = None,
+        schematic_path: Optional[str] = None,
+        project_path: Optional[str] = None,
+        column_map: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        """Read-only analysis of schematics and projects.
+
+        Operations:
+          netlist(path)
+              -> {success, components, nets, analysis, ...}
+              Extract netlist from a .kicad_sch or .kicad_pro file.
+
+          connections(schematic_path)
+              -> {success, analysis: {power_nets, signal_nets, potential_issues, ...}}
+              Analyze schematic connections, including floating-net detection
+              and power/signal net classification.
+
+          circuit_patterns(schematic_path)
+              -> {success, identified_patterns: {power_supply_circuits, ...}}
+              Identify common circuit blocks (regulators, amplifiers, filters,
+              digital interfaces, microcontrollers, etc.) in a schematic.
+
+          project_patterns(project_path)
+              -> {success, identified_patterns: {...}}
+              Same as circuit_patterns, but resolves the schematic from a
+              project file first.
+
+          bom(project_path, column_map=None)
+              -> {success, bom_files, component_summary, ...}
+              Analyze the project's BOM file(s) — counts, categories, cost,
+              supplier metadata. column_map overrides heuristic column-name
+              detection per canonical field.
+        """
+        if operation == "netlist":
+            if path is None:
+                return {"error": "operation='netlist' requires 'path'"}
+            return await _op_extract_netlist(path, ctx)
+        if operation == "connections":
+            if schematic_path is None:
+                return {"error": "operation='connections' requires 'schematic_path'"}
+            return await _op_analyze_schematic_connections(schematic_path, ctx)
+        if operation == "circuit_patterns":
+            if schematic_path is None:
+                return {"error": "operation='circuit_patterns' requires 'schematic_path'"}
+            return await _op_identify_circuit_patterns(schematic_path, ctx)
+        if operation == "project_patterns":
+            if project_path is None:
+                return {"error": "operation='project_patterns' requires 'project_path'"}
+            return await _op_analyze_project_circuit_patterns(project_path, ctx)
+        if operation == "bom":
+            if project_path is None:
+                return {"error": "operation='bom' requires 'project_path'"}
+            return await _op_analyze_bom(project_path, ctx, column_map=column_map)
+        return {
+            "error": (
+                f"unknown operation {operation!r}; "
+                f"valid: netlist|connections|circuit_patterns|project_patterns|bom"
+            )
+        }

--- a/src/kicad_mcp/tools/bom.py
+++ b/src/kicad_mcp/tools/bom.py
@@ -1,5 +1,8 @@
-"""
-Bill of Materials (BOM) processing tools for KiCad projects.
+"""BOM operation implementations.
+
+Tool surface lives on the `analyze` router (operation="bom") and the
+`export` router (operation="bom_csv"). This module contains the impls
+and the parser/analyzer helpers they share.
 """
 import csv
 import json
@@ -15,278 +18,225 @@ try:
 except ImportError:
     pd = None
 
-from fastmcp import FastMCP, Context
+from fastmcp import Context
 
 from kicad_mcp.utils.file_utils import get_project_files
 
 
-def register_bom_tools(mcp: FastMCP) -> None:
-    """Register BOM-related tools with the MCP server.
+async def _op_analyze_bom(
+    project_path: str,
+    ctx: Context | None,
+    column_map: Optional[Dict[str, str]] = None,
+) -> Dict[str, Any]:
+    """Analyze a KiCad project's Bill of Materials."""
+    print(f"Analyzing BOM for project: {project_path}")
 
-    Args:
-        mcp: The FastMCP server instance
-    """
-
-    @mcp.tool()
-    async def analyze_bom(
-        project_path: str,
-        ctx: Context | None,
-        column_map: Optional[Dict[str, str]] = None,
-    ) -> Dict[str, Any]:
-        """Analyze a KiCad project's Bill of Materials.
-
-        Looks for BOM files related to a KiCad project and provides analysis
-        including component counts, categories, cost estimates, and any
-        supplier metadata (MPN, manufacturer, LCSC, etc.) present in the BOM.
-
-        Args:
-            project_path: Path to the KiCad project file (.kicad_pro)
-            ctx: MCP context for progress reporting
-            column_map: Optional override of column-name detection. Keys are
-                canonical field names ("reference", "value", "quantity",
-                "footprint", "cost", "category", "mpn", "manufacturer",
-                "lcsc", "datasheet", "description"); values are the actual
-                column names in the BOM. Fields not in column_map fall
-                back to heuristic detection.
-
-        Returns:
-            Dictionary with BOM analysis results. Per-file analysis includes:
-            - counts, categories, cost data
-            - detected_fields: which BOM columns were classified as which field
-            - all_columns: full list of column names in the BOM (so nothing
-              is silently invisible to the caller)
-            - analysis_error or stage_errors: present if any analysis stage
-              failed (counts may still be partial)
-        """
-        print(f"Analyzing BOM for project: {project_path}")
-
-        if not os.path.exists(project_path):
-            print(f"Project not found: {project_path}")
-            if ctx:
-                ctx.info(f"Project not found: {project_path}")
-            return {"success": False, "error": f"Project not found: {project_path}"}
-
+    if not os.path.exists(project_path):
+        print(f"Project not found: {project_path}")
         if ctx:
-            await ctx.report_progress(10, 100)
-            ctx.info(
-                f"Looking for BOM files related to {os.path.basename(project_path)}"
-            )
+            ctx.info(f"Project not found: {project_path}")
+        return {"success": False, "error": f"Project not found: {project_path}"}
 
-        files = get_project_files(project_path)
+    if ctx:
+        await ctx.report_progress(10, 100)
+        ctx.info(
+            f"Looking for BOM files related to {os.path.basename(project_path)}"
+        )
 
-        # Look for BOM files
-        bom_files = {}
-        for file_type, file_path in files.items():
-            if "bom" in file_type.lower() or file_path.lower().endswith(".csv"):
-                bom_files[file_type] = file_path
-                print(f"Found potential BOM file: {file_path}")
+    files = get_project_files(project_path)
 
-        if not bom_files:
-            print("No BOM files found for project")
-            if ctx:
-                ctx.info("No BOM files found for project")
-            return {
-                "success": False,
-                "error": "No BOM files found. Export a BOM from KiCad first.",
-                "project_path": project_path,
-            }
+    bom_files = {}
+    for file_type, file_path in files.items():
+        if "bom" in file_type.lower() or file_path.lower().endswith(".csv"):
+            bom_files[file_type] = file_path
+            print(f"Found potential BOM file: {file_path}")
 
+    if not bom_files:
+        print("No BOM files found for project")
         if ctx:
-            await ctx.report_progress(30, 100)
-
-        results: Dict[str, Any] = {
-            "success": True,
+            ctx.info("No BOM files found for project")
+        return {
+            "success": False,
+            "error": "No BOM files found. Export a BOM from KiCad first.",
             "project_path": project_path,
-            "bom_files": {},
-            "component_summary": {},
         }
 
-        total_unique_components = 0
-        total_components = 0
-        file_error_count = 0
-        file_parse_skipped = 0
+    if ctx:
+        await ctx.report_progress(30, 100)
 
-        for file_type, file_path in bom_files.items():
-            try:
-                if ctx:
-                    ctx.info(f"Analyzing {os.path.basename(file_path)}")
+    results: Dict[str, Any] = {
+        "success": True,
+        "project_path": project_path,
+        "bom_files": {},
+        "component_summary": {},
+    }
 
-                bom_data, format_info = _parse_bom_file(file_path)
+    total_unique_components = 0
+    total_components = 0
+    file_error_count = 0
+    file_parse_skipped = 0
 
-                if not bom_data:
-                    print(f"Failed to parse BOM file: {file_path}")
-                    file_parse_skipped += 1
-                    continue
-
-                analysis = _analyze_bom_data(bom_data, format_info, column_map=column_map)
-
-                results["bom_files"][file_type] = {
-                    "path": file_path,
-                    "format": format_info,
-                    "analysis": analysis,
-                }
-
-                total_unique_components += analysis["unique_component_count"]
-                total_components += analysis["total_component_count"]
-
-                print(f"Successfully analyzed BOM file: {file_path}")
-
-            except (OSError, ValueError, KeyError) as e:
-                # OSError = file/IO; ValueError = parse/CSV; KeyError = schema.
-                # Anything else (AttributeError, ImportError) propagates as a
-                # programming bug. file_error_count is surfaced below so a
-                # caller scanning only "results" doesn't miss partial failure.
-                print(f"Error analyzing BOM file {file_path}: {e}")
-                file_error_count += 1
-                results["bom_files"][file_type] = {
-                    "path": file_path,
-                    "error": f"{type(e).__name__}: {e}",
-                }
-
-        # Surface partial-failure counts so callers don't have to scan the
-        # bom_files dict for "error" keys.
-        if file_error_count or file_parse_skipped:
-            results["file_error_count"] = file_error_count
-            results["file_parse_skipped"] = file_parse_skipped
-
-        if ctx:
-            await ctx.report_progress(70, 100)
-
-        # Generate overall component summary
-        if total_components > 0:
-            results["component_summary"] = {
-                "total_unique_components": total_unique_components,
-                "total_components": total_components,
-            }
-
-            all_categories: dict[str, int] = {}
-            for file_type, file_info in results["bom_files"].items():
-                if "analysis" in file_info and "categories" in file_info["analysis"]:
-                    for category, count in file_info["analysis"]["categories"].items():
-                        if category not in all_categories:
-                            all_categories[category] = 0
-                        all_categories[category] += count
-
-            results["component_summary"]["categories"] = all_categories
-
-            total_cost = 0.0
-            cost_available = False
-            for file_type, file_info in results["bom_files"].items():
-                if "analysis" in file_info and "total_cost" in file_info["analysis"]:
-                    if file_info["analysis"]["total_cost"] > 0:
-                        total_cost += file_info["analysis"]["total_cost"]
-                        cost_available = True
-
-            if cost_available:
-                results["component_summary"]["total_cost"] = round(total_cost, 2)
-                currency = next(
-                    (
-                        file_info["analysis"].get("currency", "USD")
-                        for file_type, file_info in results["bom_files"].items()
-                        if "analysis" in file_info
-                        and "currency" in file_info["analysis"]
-                    ),
-                    "USD",
-                )
-                results["component_summary"]["currency"] = currency
-
-        if ctx:
-            await ctx.report_progress(100, 100)
-            ctx.info(f"BOM analysis complete: found {total_components} components")
-
-        return results
-
-    @mcp.tool()
-    async def export_bom_csv(
-        project_path: str, ctx: Context | None
-    ) -> Dict[str, Any]:
-        """Export a Bill of Materials for a KiCad project.
-
-        This tool attempts to generate a CSV BOM file for a KiCad project.
-        It requires KiCad to be installed with the appropriate command-line tools.
-
-        Args:
-            project_path: Path to the KiCad project file (.kicad_pro)
-            ctx: MCP context for progress reporting
-
-        Returns:
-            Dictionary with export results
-        """
-        print(f"Exporting BOM for project: {project_path}")
-
-        if not os.path.exists(project_path):
-            print(f"Project not found: {project_path}")
-            if ctx:
-                ctx.info(f"Project not found: {project_path}")
-            return {"success": False, "error": f"Project not found: {project_path}"}
-
-        if ctx:
-            await ctx.report_progress(10, 100)
-
-        files = get_project_files(project_path)
-
-        if "schematic" not in files:
-            print("Schematic file not found in project")
-            if ctx:
-                ctx.info("Schematic file not found in project")
-            return {"success": False, "error": "Schematic file not found"}
-
-        schematic_file = files["schematic"]
-        project_dir = os.path.dirname(project_path)
-        project_name = os.path.basename(project_path)[:-10]
-
-        if ctx:
-            await ctx.report_progress(20, 100)
-            ctx.info(f"Found schematic file: {os.path.basename(schematic_file)}")
-
-        # Try CLI export
+    for file_type, file_path in bom_files.items():
         try:
             if ctx:
-                ctx.info("Attempting to export BOM using command-line tools...")
-            export_result = await _export_bom_with_cli(
-                schematic_file, project_dir, project_name, ctx
+                ctx.info(f"Analyzing {os.path.basename(file_path)}")
+
+            bom_data, format_info = _parse_bom_file(file_path)
+
+            if not bom_data:
+                print(f"Failed to parse BOM file: {file_path}")
+                file_parse_skipped += 1
+                continue
+
+            analysis = _analyze_bom_data(bom_data, format_info, column_map=column_map)
+
+            results["bom_files"][file_type] = {
+                "path": file_path,
+                "format": format_info,
+                "analysis": analysis,
+            }
+
+            total_unique_components += analysis["unique_component_count"]
+            total_components += analysis["total_component_count"]
+
+            print(f"Successfully analyzed BOM file: {file_path}")
+
+        except (OSError, ValueError, KeyError) as e:
+            # OSError = file/IO; ValueError = parse/CSV; KeyError = schema.
+            # Anything else (AttributeError, ImportError) propagates as a
+            # programming bug. file_error_count is surfaced below so a
+            # caller scanning only "results" doesn't miss partial failure.
+            print(f"Error analyzing BOM file {file_path}: {e}")
+            file_error_count += 1
+            results["bom_files"][file_type] = {
+                "path": file_path,
+                "error": f"{type(e).__name__}: {e}",
+            }
+
+    # Surface partial-failure counts so callers don't have to scan the
+    # bom_files dict for "error" keys.
+    if file_error_count or file_parse_skipped:
+        results["file_error_count"] = file_error_count
+        results["file_parse_skipped"] = file_parse_skipped
+
+    if ctx:
+        await ctx.report_progress(70, 100)
+
+    if total_components > 0:
+        results["component_summary"] = {
+            "total_unique_components": total_unique_components,
+            "total_components": total_components,
+        }
+
+        all_categories: dict[str, int] = {}
+        for file_type, file_info in results["bom_files"].items():
+            if "analysis" in file_info and "categories" in file_info["analysis"]:
+                for category, count in file_info["analysis"]["categories"].items():
+                    if category not in all_categories:
+                        all_categories[category] = 0
+                    all_categories[category] += count
+
+        results["component_summary"]["categories"] = all_categories
+
+        total_cost = 0.0
+        cost_available = False
+        for file_type, file_info in results["bom_files"].items():
+            if "analysis" in file_info and "total_cost" in file_info["analysis"]:
+                if file_info["analysis"]["total_cost"] > 0:
+                    total_cost += file_info["analysis"]["total_cost"]
+                    cost_available = True
+
+        if cost_available:
+            results["component_summary"]["total_cost"] = round(total_cost, 2)
+            currency = next(
+                (
+                    file_info["analysis"].get("currency", "USD")
+                    for file_type, file_info in results["bom_files"].items()
+                    if "analysis" in file_info
+                    and "currency" in file_info["analysis"]
+                ),
+                "USD",
             )
-        except Exception as e:
-            print(f"Error exporting BOM with CLI: {e}")
-            if ctx:
-                ctx.info(f"Error using command-line tools: {e}")
-            export_result = {"success": False, "error": str(e)}
+            results["component_summary"]["currency"] = currency
 
+    if ctx:
+        await ctx.report_progress(100, 100)
+        ctx.info(f"BOM analysis complete: found {total_components} components")
+
+    return results
+
+
+async def _op_export_bom_csv(
+    project_path: str, ctx: Context | None
+) -> Dict[str, Any]:
+    """Export a CSV BOM from the project's schematic."""
+    print(f"Exporting BOM for project: {project_path}")
+
+    if not os.path.exists(project_path):
+        print(f"Project not found: {project_path}")
         if ctx:
-            await ctx.report_progress(100, 100)
+            ctx.info(f"Project not found: {project_path}")
+        return {"success": False, "error": f"Project not found: {project_path}"}
 
-        if export_result.get("success", False):
-            if ctx:
-                ctx.info(
-                    f"BOM exported successfully to "
-                    f"{export_result.get('output_file', 'unknown location')}"
-                )
-        else:
-            if ctx:
-                ctx.info(
-                    f"Failed to export BOM: "
-                    f"{export_result.get('error', 'Unknown error')}"
-                )
+    if ctx:
+        await ctx.report_progress(10, 100)
 
-        return export_result
+    files = get_project_files(project_path)
+
+    if "schematic" not in files:
+        print("Schematic file not found in project")
+        if ctx:
+            ctx.info("Schematic file not found in project")
+        return {"success": False, "error": "Schematic file not found"}
+
+    schematic_file = files["schematic"]
+    project_dir = os.path.dirname(project_path)
+    project_name = os.path.basename(project_path)[:-10]
+
+    if ctx:
+        await ctx.report_progress(20, 100)
+        ctx.info(f"Found schematic file: {os.path.basename(schematic_file)}")
+
+    try:
+        if ctx:
+            ctx.info("Attempting to export BOM using command-line tools...")
+        export_result = await _export_bom_with_cli(
+            schematic_file, project_dir, project_name, ctx
+        )
+    except Exception as e:
+        print(f"Error exporting BOM with CLI: {e}")
+        if ctx:
+            ctx.info(f"Error using command-line tools: {e}")
+        export_result = {"success": False, "error": str(e)}
+
+    if ctx:
+        await ctx.report_progress(100, 100)
+
+    if export_result.get("success", False):
+        if ctx:
+            ctx.info(
+                f"BOM exported successfully to "
+                f"{export_result.get('output_file', 'unknown location')}"
+            )
+    else:
+        if ctx:
+            ctx.info(
+                f"Failed to export BOM: "
+                f"{export_result.get('error', 'Unknown error')}"
+            )
+
+    return export_result
 
 
-# Helper functions for BOM processing
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
 def _parse_bom_file(
     file_path: str,
 ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
-    """Parse a BOM file and detect its format.
-
-    Args:
-        file_path: Path to the BOM file
-
-    Returns:
-        Tuple containing:
-            - List of component dictionaries
-            - Dictionary with format information
-    """
+    """Parse a BOM file and detect its format."""
     print(f"Parsing BOM file: {file_path}")
 
     _, ext = os.path.splitext(file_path)
@@ -428,19 +378,7 @@ def _analyze_bom_data(
     format_info: Dict[str, Any],
     column_map: Optional[Dict[str, str]] = None,
 ) -> Dict[str, Any]:
-    """Analyze component data from a BOM file.
-
-    Args:
-        components: List of component dictionaries
-        format_info: Dictionary with format information
-        column_map: Optional caller-supplied column-name overrides per
-            canonical field. See _BOM_FIELD_PROBES for valid keys. Fields
-            not in column_map fall back to heuristic detection.
-
-    Returns:
-        Dictionary with analysis results. Includes `detected_fields` and
-        `all_columns` so the caller can see the full BOM schema.
-    """
+    """Analyze component data from a BOM file."""
     import re
 
     print(f"Analyzing {len(components)} components")
@@ -559,7 +497,6 @@ def _analyze_bom_data(
                     str(k): int(v) for k, v in categories.items()
                 }
 
-        # Map reference prefixes to component types
         category_mapping = {
             "R": "Resistors",
             "C": "Capacitors",
@@ -619,10 +556,10 @@ def _analyze_bom_data(
                     if "$" in cost_str:
                         results["currency"] = "USD"
                         break
-                    elif "\u20ac" in cost_str:
+                    elif "€" in cost_str:
                         results["currency"] = "EUR"
                         break
-                    elif "\u00a3" in cost_str:
+                    elif "£" in cost_str:
                         results["currency"] = "GBP"
                         break
 
@@ -647,7 +584,6 @@ def _analyze_bom_data(
         except (KeyError, ValueError) as e:
             results["stage_errors"]["most_common_values"] = f"{type(e).__name__}: {e}"
 
-    # Drop the empty stage_errors dict if nothing went wrong (cleaner output).
     if not results["stage_errors"]:
         del results["stage_errors"]
 
@@ -660,17 +596,7 @@ async def _export_bom_with_cli(
     project_name: str,
     ctx: Context | None,
 ) -> Dict[str, Any]:
-    """Export a BOM using KiCad command-line tools.
-
-    Args:
-        schematic_file: Path to the schematic file
-        output_dir: Directory to save the BOM
-        project_name: Name of the project
-        ctx: MCP context for progress reporting
-
-    Returns:
-        Dictionary with export results
-    """
+    """Export a BOM using KiCad command-line tools."""
     import platform
 
     system = platform.system()

--- a/src/kicad_mcp/tools/export.py
+++ b/src/kicad_mcp/tools/export.py
@@ -1,14 +1,14 @@
-"""
-Export tools for KiCad projects.
+"""Export router — manufacturing and output files for KiCad projects.
+
+See docs/SPEC_Tool_Consolidation.md.
 """
 import asyncio
-import glob
 import logging
 import os
 import shutil
 import subprocess
 import zipfile
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from fastmcp import FastMCP, Context
 
@@ -19,246 +19,202 @@ from kicad_mcp.utils.kicad_cli import get_kicad_cli_path
 logger = logging.getLogger(__name__)
 
 
-def register_export_tools(mcp: FastMCP) -> None:
-    """Register export tools with the MCP server.
+# ---------------------------------------------------------------------------
+# gerbers
+# ---------------------------------------------------------------------------
 
-    Args:
-        mcp: The FastMCP server instance
-    """
+def _op_gerbers(
+    pcb_path: str,
+    output_dir: str = "",
+    create_zip: bool = True,
+) -> Dict[str, Any]:
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
 
-    @mcp.tool()
-    def export_gerbers(
-        pcb_path: str,
-        output_dir: str = "",
-        create_zip: bool = True,
-    ) -> Dict[str, Any]:
-        """Export Gerber fabrication files + Excellon drill files from a PCB.
+    try:
+        kicad_cli = get_kicad_cli_path(required=True)
+    except Exception as e:
+        return {"error": str(e)}
 
-        Generates all files needed for PCB fabrication (e.g., JLCPCB upload).
-        Exports all copper, mask, silkscreen, paste, and edge layers as
-        Gerber files, plus drill files in Excellon format with mm units.
+    if not output_dir:
+        pcb_dir = os.path.dirname(os.path.abspath(pcb_path))
+        output_dir = os.path.join(pcb_dir, "gerbers")
 
-        Optionally creates a ZIP file containing all outputs, ready for
-        direct upload to JLCPCB, PCBWay, OSH Park, etc.
+    os.makedirs(output_dir, exist_ok=True)
 
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-            output_dir: Directory for output files. Default: "gerbers/"
-                subdirectory next to the PCB file.
-            create_zip: Create a ZIP file of all outputs (default True).
+    errors = []
 
-        Returns:
-            Dictionary with output paths, file counts, and ZIP path.
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
+    gerber_cmd = [
+        kicad_cli, "pcb", "export", "gerbers",
+        "--output", output_dir + "/",
+        pcb_path,
+    ]
 
-        try:
-            kicad_cli = get_kicad_cli_path(required=True)
-        except Exception as e:
-            return {"error": str(e)}
+    def _cli_error_text(e: subprocess.CalledProcessError) -> str:
+        # Concatenate both streams — `or` would drop stderr entirely
+        # when empty, hiding stdout-only error reports (kicad-cli
+        # writes errors to stdout on some builds).
+        parts = [s.strip() for s in (e.stderr, e.stdout) if s and s.strip()]
+        return "\n".join(parts) or f"(no output; exit code {e.returncode})"
 
-        # Default output directory
-        if not output_dir:
-            pcb_dir = os.path.dirname(os.path.abspath(pcb_path))
-            output_dir = os.path.join(pcb_dir, "gerbers")
-
-        os.makedirs(output_dir, exist_ok=True)
-
-        errors = []
-
-        # Export Gerber files (all standard fab layers)
-        gerber_cmd = [
-            kicad_cli, "pcb", "export", "gerbers",
-            "--output", output_dir + "/",
-            pcb_path,
-        ]
-
-        def _cli_error_text(e: subprocess.CalledProcessError) -> str:
-            # Concatenate both streams — `or` would drop stderr entirely
-            # when empty, hiding stdout-only error reports (kicad-cli
-            # writes errors to stdout on some builds).
-            parts = [s.strip() for s in (e.stderr, e.stdout) if s and s.strip()]
-            return "\n".join(parts) or f"(no output; exit code {e.returncode})"
-
-        try:
-            result = subprocess.run(
-                gerber_cmd, capture_output=True, text=True,
-                check=True, timeout=30,
-            )
-            if result.stdout.strip():
-                logger.info("Gerber export: %s", result.stdout.strip())
-        except subprocess.CalledProcessError as e:
-            errors.append(f"Gerber export failed: {_cli_error_text(e)}")
-        except subprocess.TimeoutExpired:
-            errors.append("Gerber export timed out after 30s")
-
-        # Export drill files (Excellon format, mm units)
-        drill_cmd = [
-            kicad_cli, "pcb", "export", "drill",
-            "--output", output_dir + "/",
-            "--format", "excellon",
-            "--excellon-units", "mm",
-            pcb_path,
-        ]
-
-        try:
-            result = subprocess.run(
-                drill_cmd, capture_output=True, text=True,
-                check=True, timeout=30,
-            )
-            if result.stdout.strip():
-                logger.info("Drill export: %s", result.stdout.strip())
-        except subprocess.CalledProcessError as e:
-            errors.append(f"Drill export failed: {_cli_error_text(e)}")
-        except subprocess.TimeoutExpired:
-            errors.append("Drill export timed out after 30s")
-
-        if errors:
-            # Structured error list with count — caller can programmatically
-            # retry per-step instead of parsing a joined string.
-            return {"error": f"{len(errors)} export step(s) failed", "errors": errors, "error_count": len(errors)}
-
-        # Collect output files. output_dir is freshly created per export
-        # and contains only kicad-cli output, so globbing everything in it
-        # is correct — picks up *.gbr (modern KiCad), *.gtl/.gbl/.gto/etc.
-        # (RS-274X layer extensions), *.drl/.xln (drill), *.gbrjob (fab
-        # job manifest), and anything else kicad-cli produces. The earlier
-        # *.gbr-only glob silently shipped fab packages missing layers.
-        all_files = sorted(
-            os.path.join(output_dir, f)
-            for f in os.listdir(output_dir)
-            if os.path.isfile(os.path.join(output_dir, f))
+    try:
+        result = subprocess.run(
+            gerber_cmd, capture_output=True, text=True,
+            check=True, timeout=30,
         )
-        # Classify for the response — informational only; all files go into the ZIP.
-        gerber_files = [f for f in all_files if not (f.endswith(".drl") or f.endswith(".xln"))]
-        drill_files = [f for f in all_files if f.endswith(".drl") or f.endswith(".xln")]
+        if result.stdout.strip():
+            logger.info("Gerber export: %s", result.stdout.strip())
+    except subprocess.CalledProcessError as e:
+        errors.append(f"Gerber export failed: {_cli_error_text(e)}")
+    except subprocess.TimeoutExpired:
+        errors.append("Gerber export timed out after 30s")
 
-        if not all_files:
-            return {"error": "No output files generated — PCB may be empty"}
+    drill_cmd = [
+        kicad_cli, "pcb", "export", "drill",
+        "--output", output_dir + "/",
+        "--format", "excellon",
+        "--excellon-units", "mm",
+        pcb_path,
+    ]
 
-        result = {
-            "status": "ok",
-            "output_dir": output_dir,
-            "gerber_files": [os.path.basename(f) for f in gerber_files],
-            "drill_files": [os.path.basename(f) for f in drill_files],
-            "gerber_count": len(gerber_files),
-            "drill_count": len(drill_files),
-            "total_files": len(all_files),
-        }
+    try:
+        result = subprocess.run(
+            drill_cmd, capture_output=True, text=True,
+            check=True, timeout=30,
+        )
+        if result.stdout.strip():
+            logger.info("Drill export: %s", result.stdout.strip())
+    except subprocess.CalledProcessError as e:
+        errors.append(f"Drill export failed: {_cli_error_text(e)}")
+    except subprocess.TimeoutExpired:
+        errors.append("Drill export timed out after 30s")
 
-        # Create ZIP
-        if create_zip:
-            pcb_name = os.path.splitext(os.path.basename(pcb_path))[0]
-            zip_path = os.path.join(
-                os.path.dirname(output_dir), f"{pcb_name}-gerbers.zip"
-            )
-            with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
-                for f in all_files:
-                    zf.write(f, os.path.basename(f))
-            result["zip_path"] = zip_path
-            result["zip_size_bytes"] = os.path.getsize(zip_path)
+    if errors:
+        # Structured error list with count — caller can programmatically
+        # retry per-step instead of parsing a joined string.
+        return {"error": f"{len(errors)} export step(s) failed", "errors": errors, "error_count": len(errors)}
 
-        return result
+    # output_dir is freshly created per export and contains only kicad-cli
+    # output, so globbing everything is correct — picks up *.gbr (modern
+    # KiCad), *.gtl/.gbl/.gto/etc. (RS-274X layer extensions), *.drl/.xln
+    # (drill), *.gbrjob (fab job manifest), and anything else kicad-cli
+    # produces. The earlier *.gbr-only glob silently shipped fab packages
+    # missing layers.
+    all_files = sorted(
+        os.path.join(output_dir, f)
+        for f in os.listdir(output_dir)
+        if os.path.isfile(os.path.join(output_dir, f))
+    )
+    gerber_files = [f for f in all_files if not (f.endswith(".drl") or f.endswith(".xln"))]
+    drill_files = [f for f in all_files if f.endswith(".drl") or f.endswith(".xln")]
 
-    @mcp.tool()
-    async def generate_pcb_thumbnail(
-        project_path: str, ctx: Context | None
-    ):
-        """Generate a thumbnail image of a KiCad PCB layout using kicad-cli.
+    if not all_files:
+        return {"error": "No output files generated — PCB may be empty"}
 
-        Args:
-            project_path: Path to the KiCad project file (.kicad_pro)
-            ctx: Context for MCP communication
+    result = {
+        "status": "ok",
+        "output_dir": output_dir,
+        "gerber_files": [os.path.basename(f) for f in gerber_files],
+        "drill_files": [os.path.basename(f) for f in drill_files],
+        "gerber_count": len(gerber_files),
+        "drill_count": len(drill_files),
+        "total_files": len(all_files),
+    }
 
-        Returns:
-            Dictionary with thumbnail path and size, or error information
-        """
-        try:
-            print(f"Generating thumbnail via CLI for project: {project_path}")
+    if create_zip:
+        pcb_name = os.path.splitext(os.path.basename(pcb_path))[0]
+        zip_path = os.path.join(
+            os.path.dirname(output_dir), f"{pcb_name}-gerbers.zip"
+        )
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for f in all_files:
+                zf.write(f, os.path.basename(f))
+        result["zip_path"] = zip_path
+        result["zip_size_bytes"] = os.path.getsize(zip_path)
 
-            if not os.path.exists(project_path):
-                print(f"Project not found: {project_path}")
-                if ctx:
-                    await ctx.info(f"Project not found: {project_path}")
-                return {"error": f"Project not found: {project_path}"}
+    return result
 
-            # Get PCB file from project
-            files = get_project_files(project_path)
-            if "pcb" not in files:
-                print("PCB file not found in project")
-                if ctx:
-                    await ctx.info("PCB file not found in project")
-                return {"error": "PCB file not found in project"}
 
-            pcb_file = files["pcb"]
-            print(f"Found PCB file: {pcb_file}")
+# ---------------------------------------------------------------------------
+# thumbnail
+# ---------------------------------------------------------------------------
 
+async def _op_thumbnail(
+    project_path: str, ctx: Context | None
+) -> Dict[str, Any]:
+    try:
+        print(f"Generating thumbnail via CLI for project: {project_path}")
+
+        if not os.path.exists(project_path):
+            print(f"Project not found: {project_path}")
             if ctx:
-                await ctx.report_progress(10, 100)
-                await ctx.info(
-                    f"Generating thumbnail for {os.path.basename(pcb_file)} using kicad-cli"
-                )
+                await ctx.info(f"Project not found: {project_path}")
+            return {"error": f"Project not found: {project_path}"}
 
-            try:
-                result = await _generate_thumbnail_with_cli(pcb_file, ctx)
-                # Explicit success check — `result and "error" not in result`
-                # would falsely accept {} as success; require "status": "ok"
-                # so we can't confuse "no error key" with "success".
-                if isinstance(result, dict) and result.get("status") == "ok":
-                    print("Thumbnail generated successfully via CLI.")
-                    return result
-                else:
-                    print("_generate_thumbnail_with_cli returned error or empty result")
-                    if ctx:
-                        await ctx.info(
-                            "Failed to generate thumbnail using kicad-cli."
-                        )
-                    # Use the returned error if present, otherwise synthesize one.
-                    if isinstance(result, dict) and result:
-                        return result
-                    return {"error": "Failed to generate thumbnail using kicad-cli"}
-            except Exception as e:
-                print(f"Error calling _generate_thumbnail_with_cli: {e}")
+        files = get_project_files(project_path)
+        if "pcb" not in files:
+            print("PCB file not found in project")
+            if ctx:
+                await ctx.info("PCB file not found in project")
+            return {"error": "PCB file not found in project"}
+
+        pcb_file = files["pcb"]
+        print(f"Found PCB file: {pcb_file}")
+
+        if ctx:
+            await ctx.report_progress(10, 100)
+            await ctx.info(
+                f"Generating thumbnail for {os.path.basename(pcb_file)} using kicad-cli"
+            )
+
+        try:
+            result = await _generate_thumbnail_with_cli(pcb_file, ctx)
+            # Explicit success check — `result and "error" not in result`
+            # would falsely accept {} as success; require "status": "ok"
+            # so we can't confuse "no error key" with "success".
+            if isinstance(result, dict) and result.get("status") == "ok":
+                print("Thumbnail generated successfully via CLI.")
+                return result
+            else:
+                print("_generate_thumbnail_with_cli returned error or empty result")
                 if ctx:
                     await ctx.info(
-                        f"Error generating thumbnail with kicad-cli: {e}"
+                        "Failed to generate thumbnail using kicad-cli."
                     )
-                return {"error": f"Error generating thumbnail with kicad-cli: {e}"}
-
-        except asyncio.CancelledError:
-            print("Thumbnail generation cancelled")
-            raise
+                if isinstance(result, dict) and result:
+                    return result
+                return {"error": "Failed to generate thumbnail using kicad-cli"}
         except Exception as e:
-            print(f"Unexpected error in thumbnail generation: {e}")
+            print(f"Error calling _generate_thumbnail_with_cli: {e}")
             if ctx:
-                await ctx.info(f"Error: {e}")
-            return {"error": f"Unexpected error in thumbnail generation: {e}"}
+                await ctx.info(
+                    f"Error generating thumbnail with kicad-cli: {e}"
+                )
+            return {"error": f"Error generating thumbnail with kicad-cli: {e}"}
+
+    except asyncio.CancelledError:
+        print("Thumbnail generation cancelled")
+        raise
+    except Exception as e:
+        print(f"Unexpected error in thumbnail generation: {e}")
+        if ctx:
+            await ctx.info(f"Error: {e}")
+        return {"error": f"Unexpected error in thumbnail generation: {e}"}
 
 
 async def _generate_thumbnail_with_cli(
     pcb_file: str, ctx: Context | None
 ):
-    """Generate PCB thumbnail using command line tools.
-
-    Args:
-        pcb_file: Path to the PCB file (.kicad_pcb)
-        ctx: MCP context for progress reporting
-
-    Returns:
-        Dictionary with thumbnail path and size, or error information
-    """
+    """Generate PCB thumbnail using command line tools."""
     try:
         print("Attempting to generate thumbnail using KiCad CLI tools")
         if ctx:
             await ctx.report_progress(20, 100)
 
-        # Determine output path
         project_dir = os.path.dirname(pcb_file)
         project_name = os.path.splitext(os.path.basename(pcb_file))[0]
         output_file = os.path.join(project_dir, f"{project_name}_thumbnail.svg")
 
-        # Check for required command-line tools based on OS
         kicad_cli = None
         if system == "Darwin":
             kicad_cli_path = os.path.join(
@@ -370,3 +326,58 @@ async def _generate_thumbnail_with_cli(
         if ctx:
             await ctx.info(f"Unexpected error: {e}")
         return {"error": f"Unexpected error in CLI thumbnail generation: {e}"}
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+def register_export_tools(mcp: FastMCP) -> None:
+    """Register the export domain router."""
+
+    @mcp.tool()
+    async def export(
+        operation: str,
+        ctx: Context | None,
+        *,
+        pcb_path: Optional[str] = None,
+        project_path: Optional[str] = None,
+        output_dir: str = "",
+        create_zip: bool = True,
+    ) -> Dict[str, Any]:
+        """Manufacturing and output-file exports.
+
+        Operations:
+          gerbers(pcb_path, output_dir="", create_zip=True)
+              -> {status, gerber_files, drill_files, zip_path?, ...}
+              Export Gerber + Excellon drill files for fabrication. ZIP is
+              ready for JLCPCB / PCBWay / OSH Park upload.
+
+          bom_csv(project_path)
+              -> {success, output_file, file_size, ...}
+              Export a CSV BOM from the project's schematic via kicad-cli.
+
+          thumbnail(project_path)
+              -> {status, thumbnail_path, size_bytes}
+              Render an SVG thumbnail of the PCB using kicad-cli.
+        """
+        if operation == "gerbers":
+            if pcb_path is None:
+                return {"error": "operation='gerbers' requires 'pcb_path'"}
+            return _op_gerbers(pcb_path, output_dir=output_dir, create_zip=create_zip)
+        if operation == "bom_csv":
+            if project_path is None:
+                return {"error": "operation='bom_csv' requires 'project_path'"}
+            # Imported here to avoid circular import (bom.py imports nothing from us)
+            from kicad_mcp.tools.bom import _op_export_bom_csv
+            return await _op_export_bom_csv(project_path, ctx)
+        if operation == "thumbnail":
+            if project_path is None:
+                return {"error": "operation='thumbnail' requires 'project_path'"}
+            return await _op_thumbnail(project_path, ctx)
+        return {
+            "error": (
+                f"unknown operation {operation!r}; "
+                f"valid: gerbers|bom_csv|thumbnail"
+            )
+        }

--- a/src/kicad_mcp/tools/library.py
+++ b/src/kicad_mcp/tools/library.py
@@ -1,0 +1,119 @@
+"""Library router — symbol/footprint library search and index management.
+
+See docs/SPEC_Tool_Consolidation.md.
+"""
+import logging
+import sqlite3
+from typing import Any, Dict, Optional
+
+from fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
+
+
+def _op_search(
+    query: str,
+    type: str = "footprint",
+    library: Optional[str] = None,
+    limit: int = 20,
+) -> Dict[str, Any]:
+    if type not in ("footprint", "symbol"):
+        return {"error": f"type must be 'footprint' or 'symbol', got {type!r}"}
+
+    try:
+        from kicad_mcp.utils.library_index import get_library_index
+
+        index = get_library_index()
+
+        if type == "footprint":
+            if index.footprints_stale():
+                count = index.rebuild_footprints()
+                logger.info("Footprint index rebuilt: %d entries", count)
+            results = index.search_footprints(query, library=library, limit=limit)
+        else:
+            if index.symbols_stale():
+                index.rebuild_symbols()
+            results = index.search_symbols(query, library=library, limit=limit)
+
+        return {
+            "status": "ok",
+            "count": len(results),
+            "results": results,
+            # When count == limit there are likely more matches not shown.
+            # Without this flag, callers can't distinguish "5 total matches"
+            # from "top 5 of 500 matches."
+            "truncated": len(results) == limit,
+        }
+    except (sqlite3.Error, RuntimeError) as e:
+        # Library-index database error or other runtime failure.
+        # AttributeError/KeyError/ImportError propagate (programming bugs).
+        logger.error("Search failed (%s): %s", e.__class__.__name__, e)
+        return {"error": f"Search failed: {e.__class__.__name__}: {e}"}
+
+
+def _op_rebuild_index(kind: str = "both") -> Dict[str, Any]:
+    valid = ("symbols", "footprints", "both")
+    if kind not in valid:
+        return {"error": f"kind must be one of {valid}; got {kind!r}"}
+
+    try:
+        from kicad_mcp.utils.library_index import get_library_index
+
+        index = get_library_index()
+        result: Dict[str, Any] = {"status": "ok"}
+
+        if kind in ("symbols", "both"):
+            result["symbols_indexed"] = index.rebuild_symbols()
+            logger.info("Symbol index rebuilt: %d entries", result["symbols_indexed"])
+
+        if kind in ("footprints", "both"):
+            result["footprints_indexed"] = index.rebuild_footprints()
+            logger.info("Footprint index rebuilt: %d entries", result["footprints_indexed"])
+
+        return result
+    except (sqlite3.Error, RuntimeError, OSError) as e:
+        logger.error("Library rebuild failed (%s): %s", type(e).__name__, e)
+        return {"error": f"Library rebuild failed: {type(e).__name__}: {e}"}
+
+
+def register_library_tools(mcp: FastMCP) -> None:
+    """Register the library domain router."""
+
+    @mcp.tool()
+    def library(
+        operation: str,
+        *,
+        query: Optional[str] = None,
+        type: str = "footprint",
+        library: Optional[str] = None,
+        limit: int = 20,
+        kind: str = "both",
+    ) -> Dict[str, Any]:
+        """Symbol/footprint library operations.
+
+        Operations:
+          search(query, type="footprint"|"symbol", library=None, limit=20)
+              -> {status, count, results, truncated}
+              Search KiCad libraries via the SQLite FTS5 index. Results are
+              suitable for use with add_component (symbols) or place_footprint
+              (footprints). The index auto-rebuilds when stale.
+
+          rebuild_index(kind="symbols"|"footprints"|"both")
+              -> {status, symbols_indexed?, footprints_indexed?}
+              Force-rebuild the index. Use when the staleness check misses an
+              edit (e.g. you edited a .kicad_mod without bumping mtime in a
+              way the scanner noticed), or after installing/updating a
+              third-party library.
+        """
+        if operation == "search":
+            if query is None:
+                return {"error": "operation='search' requires 'query'"}
+            return _op_search(query, type=type, library=library, limit=limit)
+        if operation == "rebuild_index":
+            return _op_rebuild_index(kind=kind)
+        return {
+            "error": (
+                f"unknown operation {operation!r}; "
+                f"valid: search|rebuild_index"
+            )
+        }

--- a/src/kicad_mcp/tools/netlist.py
+++ b/src/kicad_mcp/tools/netlist.py
@@ -1,5 +1,9 @@
-"""
-Netlist extraction and analysis tools for KiCad schematics.
+"""Netlist extraction and analysis implementations.
+
+`extract_netlist` and `analyze_schematic_connections` are exposed as the
+`analyze` router's `netlist` and `connections` operations.
+`find_component_connections` is still a standalone tool (folds into the
+schematic router in phase 5).
 """
 import logging
 import os
@@ -14,232 +18,216 @@ from kicad_mcp.utils.file_utils import get_project_files
 from kicad_mcp.utils.netlist_parser import analyze_netlist, extract_netlist as _parse_netlist
 
 
-def register_netlist_tools(mcp: FastMCP) -> None:
-    """Register netlist-related tools with the MCP server.
+async def _op_extract_netlist(
+    path: str, ctx: Context | None
+) -> Dict[str, Any]:
+    """Extract netlist information from a KiCad schematic or project.
 
-    Args:
-        mcp: The FastMCP server instance
+    Dispatches on file extension: ``.kicad_sch`` is parsed directly;
+    ``.kicad_pro`` is resolved to its associated schematic first.
     """
-
-    @mcp.tool()
-    async def extract_netlist(
-        path: str, ctx: Context | None
-    ) -> Dict[str, Any]:
-        """Extract netlist information from a KiCad schematic or project.
-
-        Dispatches on file extension: ``.kicad_sch`` is parsed directly;
-        ``.kicad_pro`` is resolved to its associated schematic first.
-        Returns components, nets, and analysis (see analyze_netlist).
-
-        Args:
-            path: Path to a ``.kicad_sch`` schematic or ``.kicad_pro`` project file.
-            ctx: MCP context for progress reporting.
-        """
-        if not os.path.exists(path):
-            logger.warning(f"File not found: {path}")
-            if ctx:
-                ctx.info(f"File not found: {path}")
-            return {"success": False, "error": f"File not found: {path}"}
-
-        ext = os.path.splitext(path)[1].lower()
-        project_path: str | None = None
-        schematic_path: str
-
-        if ext == ".kicad_pro":
-            project_path = path
-            try:
-                files = get_project_files(path)
-            except Exception as e:
-                logger.warning(f"Error reading project: {e}")
-                if ctx:
-                    ctx.info(f"Error reading project: {e}")
-                return {"success": False, "error": str(e)}
-            if "schematic" not in files:
-                return {"success": False, "error": "Schematic file not found in project"}
-            schematic_path = files["schematic"]
-        elif ext == ".kicad_sch":
-            schematic_path = path
-        else:
-            return {
-                "success": False,
-                "error": f"Unsupported file type {ext!r} (expected .kicad_sch or .kicad_pro)",
-            }
-
-        logger.debug(f"Extracting netlist from schematic: {schematic_path}")
+    if not os.path.exists(path):
+        logger.warning(f"File not found: {path}")
         if ctx:
-            await ctx.report_progress(10, 100)
-            ctx.info(f"Loading schematic file: {os.path.basename(schematic_path)}")
+            ctx.info(f"File not found: {path}")
+        return {"success": False, "error": f"File not found: {path}"}
 
+    ext = os.path.splitext(path)[1].lower()
+    project_path: str | None = None
+    schematic_path: str
+
+    if ext == ".kicad_pro":
+        project_path = path
         try:
-            if ctx:
-                await ctx.report_progress(20, 100)
-                ctx.info("Parsing schematic structure...")
-
-            netlist_data = _parse_netlist(schematic_path)
-
-            if "error" in netlist_data:
-                logger.warning(f"Error extracting netlist: {netlist_data['error']}")
-                if ctx:
-                    ctx.info(f"Error extracting netlist: {netlist_data['error']}")
-                return {"success": False, "error": netlist_data["error"]}
-
-            if ctx:
-                await ctx.report_progress(60, 100)
-                ctx.info(
-                    f"Extracted {netlist_data['component_count']} components "
-                    f"and {netlist_data['net_count']} nets"
-                )
-
-            if ctx:
-                await ctx.report_progress(70, 100)
-                ctx.info("Analyzing netlist data...")
-
-            analysis_results = analyze_netlist(netlist_data)
-
-            if ctx:
-                await ctx.report_progress(90, 100)
-
-            result: Dict[str, Any] = {
-                "success": True,
-                "schematic_path": schematic_path,
-                "component_count": netlist_data["component_count"],
-                "net_count": netlist_data["net_count"],
-                "components": netlist_data["components"],
-                "nets": netlist_data["nets"],
-                "analysis": analysis_results,
-            }
-            if project_path is not None:
-                result["project_path"] = project_path
-
-            if ctx:
-                await ctx.report_progress(100, 100)
-                ctx.info("Netlist extraction complete")
-
-            return result
-
+            files = get_project_files(path)
         except Exception as e:
-            logger.warning(f"Error extracting netlist: {e}")
+            logger.warning(f"Error reading project: {e}")
             if ctx:
-                ctx.info(f"Error extracting netlist: {e}")
+                ctx.info(f"Error reading project: {e}")
             return {"success": False, "error": str(e)}
+        if "schematic" not in files:
+            return {"success": False, "error": "Schematic file not found in project"}
+        schematic_path = files["schematic"]
+    elif ext == ".kicad_sch":
+        schematic_path = path
+    else:
+        return {
+            "success": False,
+            "error": f"Unsupported file type {ext!r} (expected .kicad_sch or .kicad_pro)",
+        }
 
-    @mcp.tool()
-    async def analyze_schematic_connections(
-        schematic_path: str, ctx: Context | None
-    ) -> Dict[str, Any]:
-        """Analyze connections in a KiCad schematic.
+    logger.debug(f"Extracting netlist from schematic: {schematic_path}")
+    if ctx:
+        await ctx.report_progress(10, 100)
+        ctx.info(f"Loading schematic file: {os.path.basename(schematic_path)}")
 
-        This tool provides detailed analysis of component connections,
-        including power nets, signal paths, and potential issues.
+    try:
+        if ctx:
+            await ctx.report_progress(20, 100)
+            ctx.info("Parsing schematic structure...")
 
-        Args:
-            schematic_path: Path to the KiCad schematic file (.kicad_sch)
-            ctx: MCP context for progress reporting
+        netlist_data = _parse_netlist(schematic_path)
 
-        Returns:
-            Dictionary with connection analysis
-        """
-        logger.debug(f"Analyzing connections in schematic: {schematic_path}")
-
-        if not os.path.exists(schematic_path):
-            logger.warning(f"Schematic file not found: {schematic_path}")
+        if "error" in netlist_data:
+            logger.warning(f"Error extracting netlist: {netlist_data['error']}")
             if ctx:
-                ctx.info(f"Schematic file not found: {schematic_path}")
-            return {
-                "success": False,
-                "error": f"Schematic file not found: {schematic_path}",
-            }
+                ctx.info(f"Error extracting netlist: {netlist_data['error']}")
+            return {"success": False, "error": netlist_data["error"]}
 
         if ctx:
-            await ctx.report_progress(10, 100)
+            await ctx.report_progress(60, 100)
             ctx.info(
-                f"Extracting netlist from: {os.path.basename(schematic_path)}"
+                f"Extracted {netlist_data['component_count']} components "
+                f"and {netlist_data['net_count']} nets"
             )
 
-        try:
-            netlist_data = _parse_netlist(schematic_path)
+        if ctx:
+            await ctx.report_progress(70, 100)
+            ctx.info("Analyzing netlist data...")
 
-            if "error" in netlist_data:
-                logger.warning(f"Error extracting netlist: {netlist_data['error']}")
-                if ctx:
-                    ctx.info(f"Error extracting netlist: {netlist_data['error']}")
-                return {"success": False, "error": netlist_data["error"]}
+        analysis_results = analyze_netlist(netlist_data)
 
+        if ctx:
+            await ctx.report_progress(90, 100)
+
+        result: Dict[str, Any] = {
+            "success": True,
+            "schematic_path": schematic_path,
+            "component_count": netlist_data["component_count"],
+            "net_count": netlist_data["net_count"],
+            "components": netlist_data["components"],
+            "nets": netlist_data["nets"],
+            "analysis": analysis_results,
+        }
+        if project_path is not None:
+            result["project_path"] = project_path
+
+        if ctx:
+            await ctx.report_progress(100, 100)
+            ctx.info("Netlist extraction complete")
+
+        return result
+
+    except Exception as e:
+        logger.warning(f"Error extracting netlist: {e}")
+        if ctx:
+            ctx.info(f"Error extracting netlist: {e}")
+        return {"success": False, "error": str(e)}
+
+
+async def _op_analyze_schematic_connections(
+    schematic_path: str, ctx: Context | None
+) -> Dict[str, Any]:
+    """Analyze connections in a KiCad schematic."""
+    logger.debug(f"Analyzing connections in schematic: {schematic_path}")
+
+    if not os.path.exists(schematic_path):
+        logger.warning(f"Schematic file not found: {schematic_path}")
+        if ctx:
+            ctx.info(f"Schematic file not found: {schematic_path}")
+        return {
+            "success": False,
+            "error": f"Schematic file not found: {schematic_path}",
+        }
+
+    if ctx:
+        await ctx.report_progress(10, 100)
+        ctx.info(
+            f"Extracting netlist from: {os.path.basename(schematic_path)}"
+        )
+
+    try:
+        netlist_data = _parse_netlist(schematic_path)
+
+        if "error" in netlist_data:
+            logger.warning(f"Error extracting netlist: {netlist_data['error']}")
             if ctx:
-                await ctx.report_progress(40, 100)
-                ctx.info("Performing connection analysis...")
+                ctx.info(f"Error extracting netlist: {netlist_data['error']}")
+            return {"success": False, "error": netlist_data["error"]}
 
-            analysis: Dict[str, Any] = {
-                "component_count": netlist_data["component_count"],
-                "net_count": netlist_data["net_count"],
-                "component_types": {},
-                "power_nets": [],
-                "signal_nets": [],
-                "potential_issues": [],
-            }
+        if ctx:
+            await ctx.report_progress(40, 100)
+            ctx.info("Performing connection analysis...")
 
-            components = netlist_data.get("components", {})
-            for ref in components:
-                comp_type_match = re.match(r"^([A-Za-z_]+)", ref)
-                if comp_type_match:
-                    comp_type = comp_type_match.group(1)
-                    if comp_type not in analysis["component_types"]:
-                        analysis["component_types"][comp_type] = 0
-                    analysis["component_types"][comp_type] += 1
+        analysis: Dict[str, Any] = {
+            "component_count": netlist_data["component_count"],
+            "net_count": netlist_data["net_count"],
+            "component_types": {},
+            "power_nets": [],
+            "signal_nets": [],
+            "potential_issues": [],
+        }
 
-            if ctx:
-                await ctx.report_progress(60, 100)
+        components = netlist_data.get("components", {})
+        for ref in components:
+            comp_type_match = re.match(r"^([A-Za-z_]+)", ref)
+            if comp_type_match:
+                comp_type = comp_type_match.group(1)
+                if comp_type not in analysis["component_types"]:
+                    analysis["component_types"][comp_type] = 0
+                analysis["component_types"][comp_type] += 1
 
-            # Use the canonical is_power_net classifier — the previous
-            # inline 6-prefix list (VCC/VDD/GND/+5V/+3V3/+12V) diverged
-            # from netlist_parser's _POWER_NET_PREFIXES (which adds
-            # VSS/VBUS/-) and silently misclassified those rails as
-            # signal nets, then re-misclassified them as floating.
-            from kicad_mcp.utils.netlist_parser import is_power_net
+        if ctx:
+            await ctx.report_progress(60, 100)
 
-            nets = netlist_data.get("nets", {})
-            for net_name, pins in nets.items():
-                entry = {"name": net_name, "pin_count": len(pins)}
-                if is_power_net(net_name):
-                    analysis["power_nets"].append(entry)
-                else:
-                    analysis["signal_nets"].append(entry)
+        # Use the canonical is_power_net classifier — the previous inline
+        # 6-prefix list (VCC/VDD/GND/+5V/+3V3/+12V) diverged from
+        # netlist_parser's _POWER_NET_PREFIXES (which adds VSS/VBUS/-)
+        # and silently misclassified those rails as signal nets, then
+        # re-misclassified them as floating.
+        from kicad_mcp.utils.netlist_parser import is_power_net
 
-            if ctx:
-                await ctx.report_progress(80, 100)
+        nets = netlist_data.get("nets", {})
+        for net_name, pins in nets.items():
+            entry = {"name": net_name, "pin_count": len(pins)}
+            if is_power_net(net_name):
+                analysis["power_nets"].append(entry)
+            else:
+                analysis["signal_nets"].append(entry)
 
-            # Check for floating nets (signal nets with 0 or 1 pin).
-            for net_name, pins in nets.items():
-                if len(pins) <= 1 and not is_power_net(net_name):
-                    analysis["potential_issues"].append({
-                        "type": "floating_net",
-                        "net": net_name,
-                        "description": (
-                            f"Net '{net_name}' appears to be floating "
-                            f"(only has {len(pins)} connection)"
-                        ),
-                    })
+        if ctx:
+            await ctx.report_progress(80, 100)
 
-            if ctx:
-                await ctx.report_progress(90, 100)
+        # Check for floating nets (signal nets with 0 or 1 pin).
+        for net_name, pins in nets.items():
+            if len(pins) <= 1 and not is_power_net(net_name):
+                analysis["potential_issues"].append({
+                    "type": "floating_net",
+                    "net": net_name,
+                    "description": (
+                        f"Net '{net_name}' appears to be floating "
+                        f"(only has {len(pins)} connection)"
+                    ),
+                })
 
-            result = {
-                "success": True,
-                "schematic_path": schematic_path,
-                "analysis": analysis,
-            }
+        if ctx:
+            await ctx.report_progress(90, 100)
 
-            if ctx:
-                await ctx.report_progress(100, 100)
-                ctx.info("Connection analysis complete")
+        result = {
+            "success": True,
+            "schematic_path": schematic_path,
+            "analysis": analysis,
+        }
 
-            return result
+        if ctx:
+            await ctx.report_progress(100, 100)
+            ctx.info("Connection analysis complete")
 
-        except Exception as e:
-            logger.warning(f"Error analyzing connections: {e}")
-            if ctx:
-                ctx.info(f"Error analyzing connections: {e}")
-            return {"success": False, "error": str(e)}
+        return result
+
+    except Exception as e:
+        logger.warning(f"Error analyzing connections: {e}")
+        if ctx:
+            ctx.info(f"Error analyzing connections: {e}")
+        return {"success": False, "error": str(e)}
+
+
+def register_netlist_tools(mcp: FastMCP) -> None:
+    """Register netlist tools not yet folded into a router.
+
+    Only ``find_component_connections`` is registered here; it moves to
+    the schematic router in phase 5.
+    """
 
     @mcp.tool()
     async def find_component_connections(

--- a/src/kicad_mcp/tools/patterns.py
+++ b/src/kicad_mcp/tools/patterns.py
@@ -1,10 +1,12 @@
-"""
-Circuit pattern recognition tools for KiCad schematics.
+"""Circuit pattern recognition implementations.
+
+Tool surface lives on the `analyze` router
+(operation="circuit_patterns" and "project_patterns").
 """
 import os
 from typing import Any, Dict
 
-from fastmcp import FastMCP, Context
+from fastmcp import Context
 
 from kicad_mcp.utils.file_utils import get_project_files
 from kicad_mcp.utils.netlist_parser import extract_netlist
@@ -19,201 +21,169 @@ from kicad_mcp.utils.pattern_recognition import (
 )
 
 
-def register_pattern_tools(mcp: FastMCP) -> None:
-    """Register circuit pattern recognition tools with the MCP server.
+async def _op_identify_circuit_patterns(
+    schematic_path: str, ctx: Context | None
+) -> Dict[str, Any]:
+    """Identify common circuit patterns in a KiCad schematic."""
+    if not os.path.exists(schematic_path):
+        if ctx:
+            ctx.info(f"Schematic file not found: {schematic_path}")
+        return {
+            "success": False,
+            "error": f"Schematic file not found: {schematic_path}",
+        }
 
-    Args:
-        mcp: The FastMCP server instance
-    """
+    if ctx:
+        await ctx.report_progress(10, 100)
+        ctx.info(
+            f"Loading schematic file: {os.path.basename(schematic_path)}"
+        )
 
-    @mcp.tool()
-    async def identify_circuit_patterns(
-        schematic_path: str, ctx: Context | None
-    ) -> Dict[str, Any]:
-        """Identify common circuit patterns in a KiCad schematic.
+    try:
+        if ctx:
+            await ctx.report_progress(20, 100)
+            ctx.info("Parsing schematic structure...")
 
-        This tool analyzes a schematic to recognize common circuit blocks such as:
-        - Power supply circuits (linear regulators, switching converters)
-        - Amplifier circuits (op-amps, transistor amplifiers)
-        - Filter circuits (RC, LC, active filters)
-        - Digital interfaces (I2C, SPI, UART)
-        - Microcontroller circuits
-        - And more
+        netlist_data = extract_netlist(schematic_path)
 
-        Args:
-            schematic_path: Path to the KiCad schematic file (.kicad_sch)
-            ctx: MCP context for progress reporting
-
-        Returns:
-            Dictionary with identified circuit patterns
-        """
-        if not os.path.exists(schematic_path):
+        if "error" in netlist_data:
             if ctx:
-                ctx.info(f"Schematic file not found: {schematic_path}")
-            return {
-                "success": False,
-                "error": f"Schematic file not found: {schematic_path}",
-            }
+                ctx.info(
+                    f"Error extracting netlist: {netlist_data['error']}"
+                )
+            return {"success": False, "error": netlist_data["error"]}
 
         if ctx:
-            await ctx.report_progress(10, 100)
+            await ctx.report_progress(30, 100)
+            ctx.info("Analyzing components and connections...")
+
+        components = netlist_data.get("components", {})
+        nets = netlist_data.get("nets", {})
+
+        if ctx:
+            await ctx.report_progress(50, 100)
+            ctx.info("Identifying circuit patterns...")
+
+        identified_patterns: Dict[str, list] = {
+            "power_supply_circuits": [],
+            "amplifier_circuits": [],
+            "filter_circuits": [],
+            "oscillator_circuits": [],
+            "digital_interface_circuits": [],
+            "microcontroller_circuits": [],
+            "sensor_interface_circuits": [],
+            "other_patterns": [],
+        }
+
+        if ctx:
+            await ctx.report_progress(60, 100)
+        identified_patterns["power_supply_circuits"] = identify_power_supplies(
+            components, nets
+        )
+
+        if ctx:
+            await ctx.report_progress(70, 100)
+        identified_patterns["amplifier_circuits"] = identify_amplifiers(
+            components, nets
+        )
+
+        if ctx:
+            await ctx.report_progress(75, 100)
+        identified_patterns["filter_circuits"] = identify_filters(
+            components, nets
+        )
+
+        if ctx:
+            await ctx.report_progress(80, 100)
+        identified_patterns["oscillator_circuits"] = identify_oscillators(
+            components, nets
+        )
+
+        if ctx:
+            await ctx.report_progress(85, 100)
+        identified_patterns["digital_interface_circuits"] = (
+            identify_digital_interfaces(components, nets)
+        )
+
+        if ctx:
+            await ctx.report_progress(90, 100)
+        identified_patterns["microcontroller_circuits"] = (
+            identify_microcontrollers(components)
+        )
+
+        if ctx:
+            await ctx.report_progress(95, 100)
+        identified_patterns["sensor_interface_circuits"] = (
+            identify_sensor_interfaces(components, nets)
+        )
+
+        result = {
+            "success": True,
+            "schematic_path": schematic_path,
+            "component_count": netlist_data["component_count"],
+            "identified_patterns": identified_patterns,
+        }
+
+        total_patterns = sum(
+            len(patterns) for patterns in identified_patterns.values()
+        )
+        result["total_patterns_found"] = total_patterns
+
+        if ctx:
+            await ctx.report_progress(100, 100)
             ctx.info(
-                f"Loading schematic file: {os.path.basename(schematic_path)}"
+                f"Pattern recognition complete. "
+                f"Found {total_patterns} circuit patterns."
             )
 
-        try:
+        return result
+
+    except Exception as e:
+        if ctx:
+            ctx.info(f"Error identifying circuit patterns: {e}")
+        return {"success": False, "error": str(e)}
+
+
+async def _op_analyze_project_circuit_patterns(
+    project_path: str, ctx: Context | None
+) -> Dict[str, Any]:
+    """Identify circuit patterns in a KiCad project's schematic."""
+    if not os.path.exists(project_path):
+        if ctx:
+            ctx.info(f"Project not found: {project_path}")
+        return {
+            "success": False,
+            "error": f"Project not found: {project_path}",
+        }
+
+    if ctx:
+        await ctx.report_progress(10, 100)
+
+    try:
+        files = get_project_files(project_path)
+
+        if "schematic" not in files:
             if ctx:
-                await ctx.report_progress(20, 100)
-                ctx.info("Parsing schematic structure...")
-
-            netlist_data = extract_netlist(schematic_path)
-
-            if "error" in netlist_data:
-                if ctx:
-                    ctx.info(
-                        f"Error extracting netlist: {netlist_data['error']}"
-                    )
-                return {"success": False, "error": netlist_data["error"]}
-
-            if ctx:
-                await ctx.report_progress(30, 100)
-                ctx.info("Analyzing components and connections...")
-
-            components = netlist_data.get("components", {})
-            nets = netlist_data.get("nets", {})
-
-            if ctx:
-                await ctx.report_progress(50, 100)
-                ctx.info("Identifying circuit patterns...")
-
-            identified_patterns: Dict[str, list] = {
-                "power_supply_circuits": [],
-                "amplifier_circuits": [],
-                "filter_circuits": [],
-                "oscillator_circuits": [],
-                "digital_interface_circuits": [],
-                "microcontroller_circuits": [],
-                "sensor_interface_circuits": [],
-                "other_patterns": [],
-            }
-
-            if ctx:
-                await ctx.report_progress(60, 100)
-            identified_patterns["power_supply_circuits"] = identify_power_supplies(
-                components, nets
-            )
-
-            if ctx:
-                await ctx.report_progress(70, 100)
-            identified_patterns["amplifier_circuits"] = identify_amplifiers(
-                components, nets
-            )
-
-            if ctx:
-                await ctx.report_progress(75, 100)
-            identified_patterns["filter_circuits"] = identify_filters(
-                components, nets
-            )
-
-            if ctx:
-                await ctx.report_progress(80, 100)
-            identified_patterns["oscillator_circuits"] = identify_oscillators(
-                components, nets
-            )
-
-            if ctx:
-                await ctx.report_progress(85, 100)
-            identified_patterns["digital_interface_circuits"] = (
-                identify_digital_interfaces(components, nets)
-            )
-
-            if ctx:
-                await ctx.report_progress(90, 100)
-            identified_patterns["microcontroller_circuits"] = (
-                identify_microcontrollers(components)
-            )
-
-            if ctx:
-                await ctx.report_progress(95, 100)
-            identified_patterns["sensor_interface_circuits"] = (
-                identify_sensor_interfaces(components, nets)
-            )
-
-            result = {
-                "success": True,
-                "schematic_path": schematic_path,
-                "component_count": netlist_data["component_count"],
-                "identified_patterns": identified_patterns,
-            }
-
-            total_patterns = sum(
-                len(patterns) for patterns in identified_patterns.values()
-            )
-            result["total_patterns_found"] = total_patterns
-
-            if ctx:
-                await ctx.report_progress(100, 100)
-                ctx.info(
-                    f"Pattern recognition complete. "
-                    f"Found {total_patterns} circuit patterns."
-                )
-
-            return result
-
-        except Exception as e:
-            if ctx:
-                ctx.info(f"Error identifying circuit patterns: {e}")
-            return {"success": False, "error": str(e)}
-
-    @mcp.tool()
-    async def analyze_project_circuit_patterns(
-        project_path: str, ctx: Context | None
-    ) -> Dict[str, Any]:
-        """Identify circuit patterns in a KiCad project's schematic.
-
-        Args:
-            project_path: Path to the KiCad project file (.kicad_pro)
-            ctx: MCP context for progress reporting
-
-        Returns:
-            Dictionary with identified circuit patterns
-        """
-        if not os.path.exists(project_path):
-            if ctx:
-                ctx.info(f"Project not found: {project_path}")
+                ctx.info("Schematic file not found in project")
             return {
                 "success": False,
-                "error": f"Project not found: {project_path}",
+                "error": "Schematic file not found in project",
             }
 
+        schematic_path = files["schematic"]
         if ctx:
-            await ctx.report_progress(10, 100)
+            ctx.info(
+                f"Found schematic file: {os.path.basename(schematic_path)}"
+            )
 
-        try:
-            files = get_project_files(project_path)
+        result = await _op_identify_circuit_patterns(schematic_path, ctx)
 
-            if "schematic" not in files:
-                if ctx:
-                    ctx.info("Schematic file not found in project")
-                return {
-                    "success": False,
-                    "error": "Schematic file not found in project",
-                }
+        if "success" in result and result["success"]:
+            result["project_path"] = project_path
 
-            schematic_path = files["schematic"]
-            if ctx:
-                ctx.info(
-                    f"Found schematic file: {os.path.basename(schematic_path)}"
-                )
+        return result
 
-            result = await identify_circuit_patterns(schematic_path, ctx)
-
-            if "success" in result and result["success"]:
-                result["project_path"] = project_path
-
-            return result
-
-        except Exception as e:
-            if ctx:
-                ctx.info(f"Error analyzing project circuit patterns: {e}")
-            return {"success": False, "error": str(e)}
+    except Exception as e:
+        if ctx:
+            ctx.info(f"Error analyzing project circuit patterns: {e}")
+        return {"success": False, "error": str(e)}

--- a/src/kicad_mcp/tools/pcb_footprints.py
+++ b/src/kicad_mcp/tools/pcb_footprints.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-import sqlite3
 from typing import Any, Dict, List, Optional
 
 from fastmcp import FastMCP
@@ -589,92 +588,3 @@ print(json.dumps(result))
             "footprint_name": footprint_name,
             "rotation_deg": rotation_deg,
         })
-
-    @mcp.tool()
-    def search(
-        query: str,
-        type: str = "footprint",
-        library: Optional[str] = None,
-        limit: int = 20,
-    ) -> Dict[str, Any]:
-        """Search KiCad libraries for symbols (schematic) or footprints (PCB).
-
-        Backed by a SQLite FTS5 index that auto-rebuilds when the underlying
-        KiCad libraries change. Results are suitable for use with
-        add_component (symbols) or place_footprint (footprints).
-
-        Args:
-            query: Search terms (e.g., "SOT-23", "0603 resistor", "op amp", "555").
-            type: "footprint" or "symbol".
-            library: Optional library name to restrict search.
-            limit: Maximum number of results (default 20).
-        """
-        if type not in ("footprint", "symbol"):
-            return {"error": f"type must be 'footprint' or 'symbol', got {type!r}"}
-
-        try:
-            from kicad_mcp.utils.library_index import get_library_index
-
-            index = get_library_index()
-
-            if type == "footprint":
-                if index.footprints_stale():
-                    count = index.rebuild_footprints()
-                    logger.info("Footprint index rebuilt: %d entries", count)
-                results = index.search_footprints(query, library=library, limit=limit)
-            else:
-                if index.symbols_stale():
-                    index.rebuild_symbols()
-                results = index.search_symbols(query, library=library, limit=limit)
-
-            return {
-                "status": "ok",
-                "count": len(results),
-                "results": results,
-                # When count == limit there are likely more matches not shown.
-                # Without this flag, callers can't distinguish "5 total matches"
-                # from "top 5 of 500 matches."
-                "truncated": len(results) == limit,
-            }
-        except (sqlite3.Error, RuntimeError) as e:
-            # Library-index database error or other runtime failure.
-            # AttributeError/KeyError/ImportError propagate (programming bugs).
-            logger.error("Search failed (%s): %s", e.__class__.__name__, e)
-            return {"error": f"Search failed: {e.__class__.__name__}: {e}"}
-
-    @mcp.tool()
-    def rebuild_library_index(
-        kind: str = "both",
-    ) -> Dict[str, Any]:
-        """Force a rebuild of the symbol and/or footprint library index.
-
-        The index normally auto-rebuilds when staleness is detected. Use this
-        tool when the staleness check misses an edit (e.g. you edited a
-        ``.kicad_mod`` file in a way that didn't bump its mtime in a way the
-        scanner noticed), or after installing/updating a third-party library.
-
-        Args:
-            kind: ``"symbols"``, ``"footprints"``, or ``"both"`` (default).
-        """
-        valid = ("symbols", "footprints", "both")
-        if kind not in valid:
-            return {"error": f"kind must be one of {valid}; got {kind!r}"}
-
-        try:
-            from kicad_mcp.utils.library_index import get_library_index
-
-            index = get_library_index()
-            result: Dict[str, Any] = {"status": "ok"}
-
-            if kind in ("symbols", "both"):
-                result["symbols_indexed"] = index.rebuild_symbols()
-                logger.info("Symbol index rebuilt: %d entries", result["symbols_indexed"])
-
-            if kind in ("footprints", "both"):
-                result["footprints_indexed"] = index.rebuild_footprints()
-                logger.info("Footprint index rebuilt: %d entries", result["footprints_indexed"])
-
-            return result
-        except (sqlite3.Error, RuntimeError, OSError) as e:
-            logger.error("Library rebuild failed (%s): %s", type(e).__name__, e)
-            return {"error": f"Library rebuild failed: {type(e).__name__}: {e}"}

--- a/tests/integration/test_kicad_versions.py
+++ b/tests/integration/test_kicad_versions.py
@@ -94,8 +94,8 @@ def workspace(tmp_path):
 
 def test_search_symbols(mcp_server):
     """Library DB rebuild + lib_id stability across KiCad versions."""
-    fn = _get_tool(mcp_server, "search")
-    result = _run(fn({"query": "op amp", "type": "symbol"}))
+    fn = _get_tool(mcp_server, "library")
+    result = _run(fn({"operation": "search", "query": "op amp", "type": "symbol"}))
     assert result.get("status") == "ok"
     components = result.get("results", [])
     assert len(components) > 0
@@ -109,8 +109,8 @@ def test_search_symbols(mcp_server):
 
 def test_search_footprints(mcp_server):
     """Footprint library search."""
-    fn = _get_tool(mcp_server, "search")
-    result = _run(fn({"query": "0603 resistor"}))
+    fn = _get_tool(mcp_server, "library")
+    result = _run(fn({"operation": "search", "query": "0603 resistor"}))
     assert result.get("status") == "ok"
     footprints = result.get("results", [])
     assert len(footprints) > 0
@@ -138,8 +138,8 @@ def test_schematic_create_and_save(mcp_server, workspace):
     assert result.get("status") == "ok"
 
     # Find a real resistor lib_id before adding
-    search = _get_tool(mcp_server, "search")
-    sr = search({"query": "resistor", "type": "symbol"})
+    search = _get_tool(mcp_server, "library")
+    sr = search({"operation": "search", "query": "resistor", "type": "symbol"})
     assert sr.get("status") == "ok" and sr.get("results")
     lib_id = sr["results"][0]["lib_id"]
 
@@ -196,8 +196,8 @@ def test_place_footprint_and_audit(mcp_server, workspace):
     }))
 
     # Find a real footprint
-    search = _get_tool(mcp_server, "search")
-    sr = _run(search({"query": "0603 resistor"}))
+    search = _get_tool(mcp_server, "library")
+    sr = _run(search({"operation": "search", "query": "0603 resistor"}))
     assert sr.get("status") == "ok" and sr.get("results")
     fp = sr["results"][0]
 
@@ -258,8 +258,8 @@ def test_autoroute_smoke(mcp_server, workspace):
     }))
 
     # Place two footprints and connect them via a net
-    search = _get_tool(mcp_server, "search")
-    sr = _run(search({"query": "0603 resistor"}))
+    search = _get_tool(mcp_server, "library")
+    sr = _run(search({"operation": "search", "query": "0603 resistor"}))
     fp = sr["results"][0]
 
     for ref, x in [("R1", 15), ("R2", 35)]:
@@ -302,7 +302,7 @@ def test_export_gerbers(mcp_server, workspace):
         "pcb_path": pcb_path, "x_mm": 0, "y_mm": 0, "width_mm": 40, "height_mm": 30,
     }))
 
-    export = _get_tool(mcp_server, "export_gerbers")
-    result = _run(export({"pcb_path": pcb_path, "output_dir": output_dir}))
+    export = _get_tool(mcp_server, "export")
+    result = export({"operation": "gerbers", "pcb_path": pcb_path, "output_dir": output_dir})
     assert result.get("status") == "ok"
     assert "files" in result or "output_dir" in result

--- a/tests/test_bom.py
+++ b/tests/test_bom.py
@@ -1,27 +1,35 @@
 """
-Tests for BOM (Bill of Materials) tools.
+Tests for BOM operations.
 
-Tests bom.py tools and the export_bom_csv tool.
+After tool consolidation (phase 1): analyze_bom lives on the `analyze`
+router (operation="bom"), export_bom_csv on the `export` router
+(operation="bom_csv").
 """
 
 import asyncio
 import csv
 import json
-import os
-from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
 from fastmcp import FastMCP
 
-from kicad_mcp.tools.bom import register_bom_tools
+from kicad_mcp.tools.analyze import register_analyze_tools
+from kicad_mcp.tools.export import register_export_tools
 
 
 # -- Fixtures ----------------------------------------------------------------
 
 @pytest.fixture
-def bom_server():
-    mcp = FastMCP("test-bom")
-    register_bom_tools(mcp)
+def analyze_server():
+    mcp = FastMCP("test-analyze")
+    register_analyze_tools(mcp)
+    return mcp
+
+
+@pytest.fixture
+def export_server():
+    mcp = FastMCP("test-export")
+    register_export_tools(mcp)
     return mcp
 
 
@@ -36,7 +44,6 @@ def project_with_bom(tmp_path):
     sch = tmp_path / f"{name}.kicad_sch"
     sch.write_text('(kicad_sch)\n')
 
-    # Create a BOM CSV file
     bom = tmp_path / f"{name}-bom.csv"
     with open(bom, "w", newline="") as f:
         writer = csv.writer(f)
@@ -56,42 +63,67 @@ def _get_tool_fn(mcp_server, tool_name):
     return tool.fn
 
 
-# -- analyze_bom tests -------------------------------------------------------
+# -- analyze router → bom operation ------------------------------------------
 
 class TestAnalyzeBom:
 
-    def test_project_not_found(self, bom_server):
-        fn = _get_tool_fn(bom_server, "analyze_bom")
-        result = asyncio.run(fn("/nonexistent/project.kicad_pro", None))
+    def test_project_not_found(self, analyze_server):
+        fn = _get_tool_fn(analyze_server, "analyze")
+        result = asyncio.run(fn(
+            operation="bom", ctx=None,
+            project_path="/nonexistent/project.kicad_pro",
+        ))
         assert result["success"] is False
 
-    def test_no_bom_files(self, bom_server, tmp_path):
+    def test_no_bom_files(self, analyze_server, tmp_path):
         pro = tmp_path / "empty.kicad_pro"
         pro.write_text("{}")
-        fn = _get_tool_fn(bom_server, "analyze_bom")
-        result = asyncio.run(fn(str(pro), None))
+        fn = _get_tool_fn(analyze_server, "analyze")
+        result = asyncio.run(fn(
+            operation="bom", ctx=None, project_path=str(pro),
+        ))
         assert result["success"] is False
         assert "No BOM" in result["error"]
 
-    def test_analyzes_bom(self, bom_server, project_with_bom):
-        fn = _get_tool_fn(bom_server, "analyze_bom")
-        result = asyncio.run(fn(project_with_bom["project_path"], None))
+    def test_analyzes_bom(self, analyze_server, project_with_bom):
+        fn = _get_tool_fn(analyze_server, "analyze")
+        result = asyncio.run(fn(
+            operation="bom", ctx=None,
+            project_path=project_with_bom["project_path"],
+        ))
         assert result["success"] is True
 
+    def test_missing_project_path(self, analyze_server):
+        fn = _get_tool_fn(analyze_server, "analyze")
+        result = asyncio.run(fn(operation="bom", ctx=None))
+        assert "error" in result
+        assert "project_path" in result["error"]
 
-# -- export_bom_csv tests ---------------------------------------------------
+
+# -- export router → bom_csv operation ---------------------------------------
 
 class TestExportBomCsv:
 
-    def test_project_not_found(self, bom_server):
-        fn = _get_tool_fn(bom_server, "export_bom_csv")
-        result = asyncio.run(fn("/nonexistent/project.kicad_pro", None))
+    def test_project_not_found(self, export_server):
+        fn = _get_tool_fn(export_server, "export")
+        result = asyncio.run(fn(
+            operation="bom_csv", ctx=None,
+            project_path="/nonexistent/project.kicad_pro",
+        ))
         assert result["success"] is False
 
-    def test_no_schematic(self, bom_server, tmp_path):
-        """export_bom_csv needs a schematic to generate from."""
+    def test_no_schematic(self, export_server, tmp_path):
+        """bom_csv needs a schematic to generate from."""
         pro = tmp_path / "noschem.kicad_pro"
         pro.write_text("{}")
-        fn = _get_tool_fn(bom_server, "export_bom_csv")
-        result = asyncio.run(fn(str(pro), None))
+        fn = _get_tool_fn(export_server, "export")
+        result = asyncio.run(fn(
+            operation="bom_csv", ctx=None, project_path=str(pro),
+        ))
         assert result["success"] is False
+
+    def test_missing_project_path(self, export_server):
+        fn = _get_tool_fn(export_server, "export")
+        result = asyncio.run(fn(operation="bom_csv", ctx=None))
+        assert "error" in result
+        assert "project_path" in result["error"]

--- a/tests/test_export_thumbnail.py
+++ b/tests/test_export_thumbnail.py
@@ -54,7 +54,7 @@ def _mock_run_ok(svg_bytes, project_dir):
 
 class TestGeneratePcbThumbnailSuccess:
     def test_returns_dict_with_path(self, mcp_server, project_path, monkeypatch):
-        fn = get_tool_fn(mcp_server, "generate_pcb_thumbnail")
+        fn = get_tool_fn(mcp_server, "export")
         monkeypatch.setattr(
             "kicad_mcp.tools.export.subprocess.run",
             _mock_run_ok(FAKE_SVG, os.path.dirname(project_path)),
@@ -64,14 +64,16 @@ class TestGeneratePcbThumbnailSuccess:
         )
         monkeypatch.setattr("kicad_mcp.tools.export.system", "Linux")
 
-        result = asyncio.run(fn(project_path=project_path, ctx=None))
+        result = asyncio.run(fn(
+            operation="thumbnail", ctx=None, project_path=project_path,
+        ))
         assert isinstance(result, dict)
         assert result["status"] == "ok"
         assert "thumbnail_path" in result
         assert result["thumbnail_path"].endswith(".svg")
 
     def test_returns_file_size(self, mcp_server, project_path, monkeypatch):
-        fn = get_tool_fn(mcp_server, "generate_pcb_thumbnail")
+        fn = get_tool_fn(mcp_server, "export")
         monkeypatch.setattr(
             "kicad_mcp.tools.export.subprocess.run",
             _mock_run_ok(FAKE_SVG, os.path.dirname(project_path)),
@@ -81,12 +83,14 @@ class TestGeneratePcbThumbnailSuccess:
         )
         monkeypatch.setattr("kicad_mcp.tools.export.system", "Linux")
 
-        result = asyncio.run(fn(project_path=project_path, ctx=None))
+        result = asyncio.run(fn(
+            operation="thumbnail", ctx=None, project_path=project_path,
+        ))
         assert result["size_bytes"] == len(FAKE_SVG)
 
     def test_no_image_data_in_result(self, mcp_server, project_path, monkeypatch):
         """Ensure base64 image data is NOT returned (it causes API errors)."""
-        fn = get_tool_fn(mcp_server, "generate_pcb_thumbnail")
+        fn = get_tool_fn(mcp_server, "export")
         monkeypatch.setattr(
             "kicad_mcp.tools.export.subprocess.run",
             _mock_run_ok(FAKE_SVG, os.path.dirname(project_path)),
@@ -96,7 +100,9 @@ class TestGeneratePcbThumbnailSuccess:
         )
         monkeypatch.setattr("kicad_mcp.tools.export.system", "Linux")
 
-        result = asyncio.run(fn(project_path=project_path, ctx=None))
+        result = asyncio.run(fn(
+            operation="thumbnail", ctx=None, project_path=project_path,
+        ))
         assert "image_data" not in result
         assert "mime_type" not in result
 
@@ -107,10 +113,11 @@ class TestGeneratePcbThumbnailSuccess:
 
 class TestGeneratePcbThumbnailErrors:
     def test_missing_project_file(self, mcp_server, tmp_path):
-        fn = get_tool_fn(mcp_server, "generate_pcb_thumbnail")
-        result = asyncio.run(
-            fn(project_path=str(tmp_path / "nonexistent.kicad_pro"), ctx=None)
-        )
+        fn = get_tool_fn(mcp_server, "export")
+        result = asyncio.run(fn(
+            operation="thumbnail", ctx=None,
+            project_path=str(tmp_path / "nonexistent.kicad_pro"),
+        ))
         assert isinstance(result, dict)
         assert "error" in result
 
@@ -118,22 +125,26 @@ class TestGeneratePcbThumbnailErrors:
         """Project file exists but has no .kicad_pcb companion."""
         pro = tmp_path / "test.kicad_pro"
         pro.write_text('{"meta": {"version": 1}}')
-        fn = get_tool_fn(mcp_server, "generate_pcb_thumbnail")
-        result = asyncio.run(fn(project_path=str(pro), ctx=None))
+        fn = get_tool_fn(mcp_server, "export")
+        result = asyncio.run(fn(
+            operation="thumbnail", ctx=None, project_path=str(pro),
+        ))
         assert isinstance(result, dict)
         assert "error" in result
 
     def test_kicad_cli_not_found(self, mcp_server, project_path, monkeypatch):
-        fn = get_tool_fn(mcp_server, "generate_pcb_thumbnail")
+        fn = get_tool_fn(mcp_server, "export")
         monkeypatch.setattr("kicad_mcp.tools.export.shutil.which", lambda _: None)
         monkeypatch.setattr("kicad_mcp.tools.export.system", "Linux")
 
-        result = asyncio.run(fn(project_path=project_path, ctx=None))
+        result = asyncio.run(fn(
+            operation="thumbnail", ctx=None, project_path=project_path,
+        ))
         assert isinstance(result, dict)
         assert "error" in result
 
     def test_kicad_cli_fails(self, mcp_server, project_path, monkeypatch):
-        fn = get_tool_fn(mcp_server, "generate_pcb_thumbnail")
+        fn = get_tool_fn(mcp_server, "export")
         monkeypatch.setattr(
             "kicad_mcp.tools.export.shutil.which", lambda _: "/usr/bin/kicad-cli"
         )
@@ -144,6 +155,8 @@ class TestGeneratePcbThumbnailErrors:
 
         monkeypatch.setattr("kicad_mcp.tools.export.subprocess.run", _fail)
 
-        result = asyncio.run(fn(project_path=project_path, ctx=None))
+        result = asyncio.run(fn(
+            operation="thumbnail", ctx=None, project_path=project_path,
+        ))
         assert isinstance(result, dict)
         assert "error" in result

--- a/tests/test_netlist_tools.py
+++ b/tests/test_netlist_tools.py
@@ -1,32 +1,30 @@
 """
-Tests for netlist extraction tools and pattern recognition tools.
+Tests for netlist extraction and pattern recognition operations.
 
-Tests netlist.py and patterns.py tools via error paths and mocking.
+After tool consolidation (phase 1):
+  - extract_netlist → analyze router, operation="netlist"
+  - identify_circuit_patterns → analyze router, operation="circuit_patterns"
+  - analyze_project_circuit_patterns → analyze router, operation="project_patterns"
+
+`find_component_connections` still lives on `netlist` module until phase 5
+(schematic router).
 """
 
 import asyncio
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 from fastmcp import FastMCP
 
-from kicad_mcp.tools.netlist import register_netlist_tools
-from kicad_mcp.tools.patterns import register_pattern_tools
+from kicad_mcp.tools.analyze import register_analyze_tools
 
 
 # -- Fixtures ----------------------------------------------------------------
 
 @pytest.fixture
-def netlist_server():
-    mcp = FastMCP("test-netlist")
-    register_netlist_tools(mcp)
-    return mcp
-
-
-@pytest.fixture
-def pattern_server():
-    mcp = FastMCP("test-patterns")
-    register_pattern_tools(mcp)
+def analyze_server():
+    mcp = FastMCP("test-analyze")
+    register_analyze_tools(mcp)
     return mcp
 
 
@@ -48,19 +46,22 @@ def _get_tool_fn(mcp_server, tool_name):
     return tool.fn
 
 
-# -- extract_netlist tests (schematic input) ---------------------------------
+# -- analyze.netlist (was: extract_netlist) — schematic input ---------------
 
 class TestExtractNetlistSchematic:
 
-    def test_file_not_found(self, netlist_server):
-        fn = _get_tool_fn(netlist_server, "extract_netlist")
-        result = asyncio.run(fn("/nonexistent/test.kicad_sch", None))
+    def test_file_not_found(self, analyze_server):
+        fn = _get_tool_fn(analyze_server, "analyze")
+        result = asyncio.run(fn(
+            operation="netlist", ctx=None,
+            path="/nonexistent/test.kicad_sch",
+        ))
         assert result["success"] is False
         assert "not found" in result["error"]
 
     @patch("kicad_mcp.tools.netlist.analyze_netlist")
     @patch("kicad_mcp.tools.netlist._parse_netlist")
-    def test_returns_netlist(self, mock_extract, mock_analyze, netlist_server, sch_file):
+    def test_returns_netlist(self, mock_extract, mock_analyze, analyze_server, sch_file):
         mock_extract.return_value = {
             "component_count": 3,
             "net_count": 5,
@@ -68,55 +69,61 @@ class TestExtractNetlistSchematic:
             "nets": {"GND": [], "VCC": []},
         }
         mock_analyze.return_value = {"summary": "3 components, 5 nets"}
-        fn = _get_tool_fn(netlist_server, "extract_netlist")
-        result = asyncio.run(fn(sch_file, None))
+        fn = _get_tool_fn(analyze_server, "analyze")
+        result = asyncio.run(fn(operation="netlist", ctx=None, path=sch_file))
         assert result["success"] is True
 
     @patch("kicad_mcp.tools.netlist._parse_netlist")
-    def test_handles_extraction_error(self, mock_extract, netlist_server, sch_file):
+    def test_handles_extraction_error(self, mock_extract, analyze_server, sch_file):
         mock_extract.return_value = {"error": "Failed to parse schematic"}
-        fn = _get_tool_fn(netlist_server, "extract_netlist")
-        result = asyncio.run(fn(sch_file, None))
+        fn = _get_tool_fn(analyze_server, "analyze")
+        result = asyncio.run(fn(operation="netlist", ctx=None, path=sch_file))
         assert result["success"] is False
 
 
-# -- extract_netlist tests (project input) -----------------------------------
+# -- analyze.netlist — project input ----------------------------------------
 
 class TestExtractNetlistProject:
 
-    def test_project_not_found(self, netlist_server):
-        fn = _get_tool_fn(netlist_server, "extract_netlist")
-        result = asyncio.run(fn("/nonexistent/project.kicad_pro", None))
+    def test_project_not_found(self, analyze_server):
+        fn = _get_tool_fn(analyze_server, "analyze")
+        result = asyncio.run(fn(
+            operation="netlist", ctx=None,
+            path="/nonexistent/project.kicad_pro",
+        ))
         assert result["success"] is False
 
-    def test_no_schematic(self, netlist_server, tmp_path):
+    def test_no_schematic(self, analyze_server, tmp_path):
         pro = tmp_path / "test.kicad_pro"
         pro.write_text("{}")
-        fn = _get_tool_fn(netlist_server, "extract_netlist")
-        result = asyncio.run(fn(str(pro), None))
+        fn = _get_tool_fn(analyze_server, "analyze")
+        result = asyncio.run(fn(operation="netlist", ctx=None, path=str(pro)))
         assert result["success"] is False
         assert "schematic" in result["error"].lower()
 
-    def test_unsupported_extension(self, netlist_server, tmp_path):
+    def test_unsupported_extension(self, analyze_server, tmp_path):
         other = tmp_path / "test.txt"
         other.write_text("not a kicad file")
-        fn = _get_tool_fn(netlist_server, "extract_netlist")
-        result = asyncio.run(fn(str(other), None))
+        fn = _get_tool_fn(analyze_server, "analyze")
+        result = asyncio.run(fn(operation="netlist", ctx=None, path=str(other)))
         assert result["success"] is False
         assert "Unsupported" in result["error"]
 
 
-# -- identify_circuit_patterns tests -----------------------------------------
+# -- analyze.circuit_patterns (was: identify_circuit_patterns) ---------------
 
 class TestIdentifyCircuitPatterns:
 
-    def test_file_not_found(self, pattern_server):
-        fn = _get_tool_fn(pattern_server, "identify_circuit_patterns")
-        result = asyncio.run(fn("/nonexistent/test.kicad_sch", None))
+    def test_file_not_found(self, analyze_server):
+        fn = _get_tool_fn(analyze_server, "analyze")
+        result = asyncio.run(fn(
+            operation="circuit_patterns", ctx=None,
+            schematic_path="/nonexistent/test.kicad_sch",
+        ))
         assert result["success"] is False
 
     @patch("kicad_mcp.tools.patterns.extract_netlist")
-    def test_identifies_patterns(self, mock_extract, pattern_server, sch_file):
+    def test_identifies_patterns(self, mock_extract, analyze_server, sch_file):
         mock_extract.return_value = {
             "component_count": 5,
             "net_count": 4,
@@ -129,30 +136,39 @@ class TestIdentifyCircuitPatterns:
             "nets": {"GND": [], "VCC": [], "+5V": []},
             "labels": [],
         }
-        fn = _get_tool_fn(pattern_server, "identify_circuit_patterns")
-        result = asyncio.run(fn(sch_file, None))
+        fn = _get_tool_fn(analyze_server, "analyze")
+        result = asyncio.run(fn(
+            operation="circuit_patterns", ctx=None, schematic_path=sch_file,
+        ))
         assert result["success"] is True
 
     @patch("kicad_mcp.tools.patterns.extract_netlist")
-    def test_handles_extraction_error(self, mock_extract, pattern_server, sch_file):
+    def test_handles_extraction_error(self, mock_extract, analyze_server, sch_file):
         mock_extract.return_value = {"error": "Parse failure"}
-        fn = _get_tool_fn(pattern_server, "identify_circuit_patterns")
-        result = asyncio.run(fn(sch_file, None))
+        fn = _get_tool_fn(analyze_server, "analyze")
+        result = asyncio.run(fn(
+            operation="circuit_patterns", ctx=None, schematic_path=sch_file,
+        ))
         assert result["success"] is False
 
 
-# -- analyze_project_circuit_patterns tests ----------------------------------
+# -- analyze.project_patterns (was: analyze_project_circuit_patterns) -------
 
 class TestAnalyzeProjectPatterns:
 
-    def test_project_not_found(self, pattern_server):
-        fn = _get_tool_fn(pattern_server, "analyze_project_circuit_patterns")
-        result = asyncio.run(fn("/nonexistent/project.kicad_pro", None))
+    def test_project_not_found(self, analyze_server):
+        fn = _get_tool_fn(analyze_server, "analyze")
+        result = asyncio.run(fn(
+            operation="project_patterns", ctx=None,
+            project_path="/nonexistent/project.kicad_pro",
+        ))
         assert result["success"] is False
 
-    def test_no_schematic(self, pattern_server, tmp_path):
+    def test_no_schematic(self, analyze_server, tmp_path):
         pro = tmp_path / "test.kicad_pro"
         pro.write_text("{}")
-        fn = _get_tool_fn(pattern_server, "analyze_project_circuit_patterns")
-        result = asyncio.run(fn(str(pro), None))
+        fn = _get_tool_fn(analyze_server, "analyze")
+        result = asyncio.run(fn(
+            operation="project_patterns", ctx=None, project_path=str(pro),
+        ))
         assert result["success"] is False

--- a/tests/test_new_tools.py
+++ b/tests/test_new_tools.py
@@ -387,12 +387,15 @@ class TestExportGerbers:
         return mcp
 
     def test_tool_registered(self, export_server):
-        fn = _get_tool_fn(export_server, "export_gerbers")
+        fn = _get_tool_fn(export_server, "export")
         assert fn is not None
 
     def test_file_not_found(self, export_server):
-        fn = _get_tool_fn(export_server, "export_gerbers")
-        result = fn("/nonexistent/board.kicad_pcb")
+        fn = _get_tool_fn(export_server, "export")
+        result = asyncio.run(fn(
+            operation="gerbers", ctx=None,
+            pcb_path="/nonexistent/board.kicad_pcb",
+        ))
         assert "error" in result
 
     @patch("kicad_mcp.tools.export.get_kicad_cli_path")
@@ -420,8 +423,11 @@ class TestExportGerbers:
 
         mock_run.side_effect = fake_run
 
-        fn = _get_tool_fn(export_server, "export_gerbers")
-        result = fn(str(pcb), output_dir=str(gerber_dir))
+        fn = _get_tool_fn(export_server, "export")
+        result = asyncio.run(fn(
+            operation="gerbers", ctx=None,
+            pcb_path=str(pcb), output_dir=str(gerber_dir),
+        ))
 
         assert result["status"] == "ok"
         assert result["gerber_count"] == 3
@@ -456,8 +462,11 @@ class TestExportGerbers:
 
         mock_run.side_effect = fake_run
 
-        fn = _get_tool_fn(export_server, "export_gerbers")
-        result = fn(str(pcb), output_dir=str(gerber_dir), create_zip=False)
+        fn = _get_tool_fn(export_server, "export")
+        result = asyncio.run(fn(
+            operation="gerbers", ctx=None,
+            pcb_path=str(pcb), output_dir=str(gerber_dir), create_zip=False,
+        ))
 
         assert result["status"] == "ok"
         assert "zip_path" not in result
@@ -484,8 +493,10 @@ class TestExportGerbers:
 
         mock_run.side_effect = fake_run
 
-        fn = _get_tool_fn(export_server, "export_gerbers")
-        result = fn(str(pcb))
+        fn = _get_tool_fn(export_server, "export")
+        result = asyncio.run(fn(
+            operation="gerbers", ctx=None, pcb_path=str(pcb),
+        ))
 
         assert result["status"] == "ok"
         assert result["output_dir"] == str(tmp_path / "gerbers")

--- a/tests/test_pcb_footprints.py
+++ b/tests/test_pcb_footprints.py
@@ -12,6 +12,7 @@ import pytest
 from fastmcp import FastMCP
 
 from kicad_mcp.tools.pcb_footprints import register_pcb_footprint_tools
+from kicad_mcp.tools.library import register_library_tools
 
 
 # -- Fixtures ----------------------------------------------------------------
@@ -20,6 +21,13 @@ from kicad_mcp.tools.pcb_footprints import register_pcb_footprint_tools
 def fp_server():
     mcp = FastMCP("test-footprints")
     register_pcb_footprint_tools(mcp)
+    return mcp
+
+
+@pytest.fixture
+def library_server():
+    mcp = FastMCP("test-library")
+    register_library_tools(mcp)
     return mcp
 
 
@@ -281,12 +289,12 @@ class TestGetFootprintDimensions:
         assert result["keepout_count"] == 1
 
 
-# -- search (unified footprint/symbol) tests --------------------------------
+# -- library router → search operation (was: search tool) ------------------
 
 class TestSearch:
 
     @patch("kicad_mcp.utils.library_index.get_library_index")
-    def test_returns_footprint_results(self, mock_get_index, fp_server):
+    def test_returns_footprint_results(self, mock_get_index, library_server):
         mock_index = MagicMock()
         mock_index.footprints_stale.return_value = False
         mock_index.search_footprints.return_value = [
@@ -295,45 +303,45 @@ class TestSearch:
         ]
         mock_get_index.return_value = mock_index
 
-        fn = _get_tool_fn(fp_server, "search")
-        result = fn("0805 resistor")
+        fn = _get_tool_fn(library_server, "library")
+        result = fn(operation="search", query="0805 resistor")
         assert result["status"] == "ok"
         assert result["count"] == 1
 
     @patch("kicad_mcp.utils.library_index.get_library_index")
-    def test_rebuilds_stale_footprint_index(self, mock_get_index, fp_server):
+    def test_rebuilds_stale_footprint_index(self, mock_get_index, library_server):
         mock_index = MagicMock()
         mock_index.footprints_stale.return_value = True
         mock_index.rebuild_footprints.return_value = 500
         mock_index.search_footprints.return_value = []
         mock_get_index.return_value = mock_index
 
-        fn = _get_tool_fn(fp_server, "search")
-        fn("something")
+        fn = _get_tool_fn(library_server, "library")
+        fn(operation="search", query="something")
         mock_index.rebuild_footprints.assert_called_once()
 
     @patch("kicad_mcp.utils.library_index.get_library_index")
-    def test_with_library_filter(self, mock_get_index, fp_server):
+    def test_with_library_filter(self, mock_get_index, library_server):
         mock_index = MagicMock()
         mock_index.footprints_stale.return_value = False
         mock_index.search_footprints.return_value = []
         mock_get_index.return_value = mock_index
 
-        fn = _get_tool_fn(fp_server, "search")
-        fn("0805", library="Resistor_SMD", limit=5)
+        fn = _get_tool_fn(library_server, "library")
+        fn(operation="search", query="0805", library="Resistor_SMD", limit=5)
         mock_index.search_footprints.assert_called_once_with(
             "0805", library="Resistor_SMD", limit=5
         )
 
     @patch("kicad_mcp.utils.library_index.get_library_index")
-    def test_handles_exception(self, mock_get_index, fp_server):
+    def test_handles_exception(self, mock_get_index, library_server):
         mock_get_index.side_effect = RuntimeError("DB locked")
-        fn = _get_tool_fn(fp_server, "search")
-        result = fn("anything")
+        fn = _get_tool_fn(library_server, "library")
+        result = fn(operation="search", query="anything")
         assert "error" in result
 
     @patch("kicad_mcp.utils.library_index.get_library_index")
-    def test_symbol_type_uses_symbol_search(self, mock_get_index, fp_server):
+    def test_symbol_type_uses_symbol_search(self, mock_get_index, library_server):
         mock_index = MagicMock()
         mock_index.symbols_stale.return_value = False
         mock_index.search_symbols.return_value = [
@@ -341,8 +349,8 @@ class TestSearch:
         ]
         mock_get_index.return_value = mock_index
 
-        fn = _get_tool_fn(fp_server, "search")
-        result = fn("resistor", type="symbol")
+        fn = _get_tool_fn(library_server, "library")
+        result = fn(operation="search", query="resistor", type="symbol")
         assert result["status"] == "ok"
         assert result["count"] == 1
         mock_index.search_symbols.assert_called_once_with(
@@ -350,8 +358,20 @@ class TestSearch:
         )
         mock_index.search_footprints.assert_not_called()
 
-    def test_rejects_invalid_type(self, fp_server):
-        fn = _get_tool_fn(fp_server, "search")
-        result = fn("anything", type="garbage")
+    def test_rejects_invalid_type(self, library_server):
+        fn = _get_tool_fn(library_server, "library")
+        result = fn(operation="search", query="anything", type="garbage")
         assert "error" in result
         assert "footprint" in result["error"] and "symbol" in result["error"]
+
+    def test_missing_query(self, library_server):
+        fn = _get_tool_fn(library_server, "library")
+        result = fn(operation="search")
+        assert "error" in result
+        assert "query" in result["error"]
+
+    def test_unknown_operation(self, library_server):
+        fn = _get_tool_fn(library_server, "library")
+        result = fn(operation="bogus")
+        assert "error" in result
+        assert "unknown operation" in result["error"]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -19,17 +19,22 @@ class TestCreateServer:
         server = create_server()
         assert server.name == "KiCad"
 
-    def test_at_least_60_tools_registered(self, mcp_server):
+    def test_at_least_14_tools_registered(self, mcp_server):
+        """Floor — the consolidated surface targets 14 tools."""
         tools = asyncio.run(mcp_server.list_tools())
-        assert len(tools) >= 60, (
-            f"Expected at least 60 tools, got {len(tools)}"
+        assert len(tools) >= 14, (
+            f"Expected at least 14 tools, got {len(tools)}"
         )
 
     def test_current_tool_count(self, mcp_server):
-        """Snapshot test: update when tools are intentionally added or removed."""
+        """Snapshot test: update when tools are intentionally added or removed.
+
+        Tool-consolidation in progress (see docs/SPEC_Tool_Consolidation.md).
+        Target: 14 tools. Current count tracks the in-progress migration.
+        """
         tools = asyncio.run(mcp_server.list_tools())
-        assert len(tools) == 97, (
-            f"Expected 97 tools, got {len(tools)}. "
+        assert len(tools) == 90, (
+            f"Expected 90 tools, got {len(tools)}. "
             "Update this test if tools were intentionally added or removed."
         )
 
@@ -48,7 +53,6 @@ class TestExpectedToolsExist:
         "list_pcb_footprints",
         "get_pad_positions",
         "get_footprint_dimensions",
-        "search",
         # PCB net tools
         "add_net",
         "assign_pad_net",
@@ -95,15 +99,12 @@ class TestExpectedToolsExist:
         "get_project_structure",
         "open_project",
         "validate_project",
-        # Export / DRC / BOM / netlist / patterns
-        "export_gerbers",
-        "generate_pcb_thumbnail",
+        # Phase 1 routers (library + analyze + export)
+        "library",
+        "analyze",
+        "export",
+        # DRC (still standalone until phase 2)
         "run_drc_check",
-        "analyze_bom",
-        "export_bom_csv",
-        "extract_netlist",
-        "identify_circuit_patterns",
-        "analyze_project_circuit_patterns",
         # Schematic tools
         "create_schematic",
         "load_schematic",


### PR DESCRIPTION
## Summary
- First phase of the Tool Consolidation spec ([docs/SPEC_Tool_Consolidation.md](docs/SPEC_Tool_Consolidation.md)).
- Folds 10 read-only tools into 3 domain routers, validating the router pattern before the larger editing routers go in (phases 4–5).
- Establishes the implementation pattern reused by phases 2–6.

## Folds (10 → 3)
- **`library`** ← `search`, `rebuild_library_index`
- **`analyze`** ← `extract_netlist`, `analyze_schematic_connections`, `identify_circuit_patterns`, `analyze_project_circuit_patterns`, `analyze_bom`
- **`export`** ← `export_gerbers`, `export_bom_csv`, `generate_pcb_thumbnail`

## Pattern
- Each op body becomes a module-level ``_op_<name>`` helper.
- Router is one ``@mcp.tool()`` function dispatching on ``operation=``.
- Missing-required-arg returns ``{"error": ...}`` naming the op + arg.
- Unknown op returns ``{"error": ...}`` enumerating valid ops.
- ``find_component_connections`` stays in ``netlist.py`` until phase 5 (schematic router).

## Test plan
- [x] All 651 existing tests pass under the new surface (rewritten as needed).
- [x] Tool count: 97 → 90 (snapshot test ``test_current_tool_count`` updated).
- [x] ``test_at_least_60`` renamed to ``test_at_least_14`` (the final target).
- [x] Per-router tests in test_bom.py, test_netlist_tools.py, test_export_thumbnail.py, test_pcb_footprints.py, test_new_tools.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)