### PR TITLE
ci: park integration workflow until end-to-end setup is completed

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,10 +1,18 @@
 name: Integration Tests (KiCad multi-version)
 
+# Parked: scaffolded by adf7f4c (multi-version KiCad regression testing
+# phases 1–4) but never fully wired up.  At time of parking the workflow
+# had never produced a successful run — runner was unregistered, KiCad
+# apps weren't at expected paths, pytest-timeout was missing from deps,
+# and the integration tests themselves had never executed past the
+# prereq checks.  Auto-triggers (pull_request, push) are disabled so
+# the workflow stops emailing PR authors on every failed rerun.
+#
+# To complete the setup: see docs/MULTI_VERSION_TESTING.md and the
+# follow-up task spawned 2026-05-26.  Once green end-to-end, restore
+# the `pull_request` and `push` triggers below.
 on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
Disables `pull_request` + `push` triggers on the Integration Tests (KiCad multi-version) workflow. Workflow remains runnable via `workflow_dispatch` for ad-hoc verification.

## Why
This workflow was scaffolded by [adf7f4c](https://github.com/blwfish/kicad-mcp/commit/adf7f4c) but never completed. **0 successful runs in 50 attempts.** Every PR push triggers it, fails in ~3 seconds at a prereq check, and emails the PR author per matrix entry per rerun — a real spam source.

Known gaps:
- ~~Self-hosted macOS runner not registered~~ (fixed)
- ~~KiCad 9.0 / 10.0 apps not at expected paths~~ (fixed)
- `pytest-timeout` not declared in dev deps (still broken)
- The integration tests themselves have never actually executed — unknown what they need

## Follow-up
A separate session is planned to walk `docs/MULTI_VERSION_TESTING.md` through end-to-end and bring at least one matrix entry to green. The `pull_request` + `push` triggers should be restored in that same PR.

## Test plan
- [ ] Confirm no integration-workflow runs are triggered by this PR's CI
- [ ] Confirm `workflow_dispatch` still appears as a manual run option in Actions UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)