### PR TITLE
Phase 2: project + drc + autoroute routers (90 → 81)

### DIFF
--- a/AGENT-INSTALL.md
+++ b/AGENT-INSTALL.md
@@ -4,7 +4,7 @@ This file is for you, the AI agent. It tells you what needs to be true on this s
 
 ## What This Is
 
-kicad-mcp is a Model Context Protocol (MCP) server providing 90 tools for KiCad electronic design automation — schematic capture, PCB layout, autorouting, DRC, and more. Once installed and registered, these tools appear in your tool list and you can design circuit boards conversationally.
+kicad-mcp is a Model Context Protocol (MCP) server providing 81 tools for KiCad electronic design automation — schematic capture, PCB layout, autorouting, DRC, and more. Once installed and registered, these tools appear in your tool list and you can design circuit boards conversationally.
 
 **Origin:** Built by one person for personal use, on a Mac, with Claude Code. Other platforms *should* work (the code handles macOS, Windows, and Linux) but are untested. PRs for other agents and platforms will be considered.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This tool enables your AI agent to use [KiCad](https://www.kicad.org/) — the i
 
 ## What This Does
 
-You describe what you need — "design a board for this ESP32 circuit" or "here's the schematic, lay out the PCB" — and your AI agent does the rest: drawing the schematic, choosing components, placing them on the board, routing traces, checking for errors, and producing manufacturing-ready files. All using the same KiCad that professional engineers use, with 90 tools covering the full design workflow.
+You describe what you need — "design a board for this ESP32 circuit" or "here's the schematic, lay out the PCB" — and your AI agent does the rest: drawing the schematic, choosing components, placing them on the board, routing traces, checking for errors, and producing manufacturing-ready files. All using the same KiCad that professional engineers use, with 81 tools covering the full design workflow.
 
 You don't need to know KiCad. You don't need to know what a PCB layout tool does. You just need an AI agent (like [Claude](https://claude.ai/)).
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1,5 +1,5 @@
 # Tool Summary
 
-This MCP server exposes 90 MCP tools for KiCad EDA.
+This MCP server exposes 81 MCP tools for KiCad EDA.
 
 See [README.md](README.md) for the full tool list and usage guide.

--- a/src/kicad_mcp/server.py
+++ b/src/kicad_mcp/server.py
@@ -46,13 +46,16 @@ def create_server() -> FastMCP:
     register_analyze_tools(mcp)
     register_export_tools(mcp)
 
-    # Tools not yet consolidated into routers
+    # Domain routers (phase 2: project + drc + autoroute)
     from kicad_mcp.tools.project import register_project_tools
     from kicad_mcp.tools.drc import register_drc_tools
-    from kicad_mcp.tools.netlist import register_netlist_tools
 
     register_project_tools(mcp)
     register_drc_tools(mcp)
+
+    # Tools not yet consolidated into routers
+    from kicad_mcp.tools.netlist import register_netlist_tools
+
     register_netlist_tools(mcp)
 
     # Schematic tools (wrapping kicad-sch-api)

--- a/src/kicad_mcp/tools/drc.py
+++ b/src/kicad_mcp/tools/drc.py
@@ -1,12 +1,14 @@
-"""
-Design Rule Check (DRC) tools for KiCad PCB files.
+"""DRC router — Design Rule Check operations for KiCad PCB files.
+
+See docs/SPEC_Tool_Consolidation.md.
 """
 import os
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from fastmcp import FastMCP, Context
 
 from kicad_mcp.tools.drc_impl.cli_drc import run_drc_via_cli
+from kicad_mcp.tools.pcb_drc_fix import _op_autofix
 from kicad_mcp.utils.drc_history import (
     compare_with_previous,
     get_drc_history,
@@ -15,121 +17,158 @@ from kicad_mcp.utils.drc_history import (
 from kicad_mcp.utils.file_utils import get_project_files
 
 
+def _op_history(project_path: str) -> Dict[str, Any]:
+    print(f"Getting DRC history for project: {project_path}")
+
+    if not os.path.exists(project_path):
+        print(f"Project not found: {project_path}")
+        return {"success": False, "error": f"Project not found: {project_path}"}
+
+    history_entries = get_drc_history(project_path)
+
+    # Calculate trend information
+    trend = None
+    if len(history_entries) >= 2:
+        first = history_entries[-1]  # Oldest entry
+        last = history_entries[0]  # Newest entry
+
+        first_violations = first.get("total_violations", 0)
+        last_violations = last.get("total_violations", 0)
+
+        if first_violations > last_violations:
+            trend = "improving"
+        elif first_violations < last_violations:
+            trend = "degrading"
+        else:
+            trend = "stable"
+
+    return {
+        "success": True,
+        "project_path": project_path,
+        "history_entries": history_entries,
+        "entry_count": len(history_entries),
+        "trend": trend,
+    }
+
+
+async def _op_run(project_path: str, ctx: Context | None) -> Dict[str, Any]:
+    print(f"Running DRC check for project: {project_path}")
+
+    if not os.path.exists(project_path):
+        print(f"Project not found: {project_path}")
+        return {"success": False, "error": f"Project not found: {project_path}"}
+
+    files = get_project_files(project_path)
+    if "pcb" not in files:
+        print("PCB file not found in project")
+        return {"success": False, "error": "PCB file not found in project"}
+
+    pcb_file = files["pcb"]
+    print(f"Found PCB file: {pcb_file}")
+
+    if ctx:
+        await ctx.report_progress(10, 100)
+        ctx.info(f"Starting DRC check on {os.path.basename(pcb_file)}")
+
+    drc_results = None
+
+    print("Using kicad-cli for DRC")
+    if ctx:
+        ctx.info("Using KiCad CLI for DRC check...")
+    drc_results = await run_drc_via_cli(pcb_file, ctx)
+
+    # Process and save results if successful
+    if drc_results and drc_results.get("success", False):
+        save_drc_result(project_path, drc_results)
+
+        comparison = compare_with_previous(project_path, drc_results)
+        if comparison:
+            drc_results["comparison"] = comparison
+
+            if ctx:
+                if comparison["change"] < 0:
+                    ctx.info(
+                        f"Great progress! You've fixed {abs(comparison['change'])} "
+                        f"DRC violations since the last check."
+                    )
+                elif comparison["change"] > 0:
+                    ctx.info(
+                        f"Found {comparison['change']} new DRC violations "
+                        f"since the last check."
+                    )
+                else:
+                    ctx.info(
+                        "No change in the number of DRC violations since the last check."
+                    )
+
+    if ctx:
+        await ctx.report_progress(100, 100)
+
+    return drc_results or {
+        "success": False,
+        "error": "DRC check failed with an unknown error",
+    }
+
+
 def register_drc_tools(mcp: FastMCP) -> None:
-    """Register DRC tools with the MCP server.
-
-    Args:
-        mcp: The FastMCP server instance
-    """
+    """Register the DRC domain router."""
 
     @mcp.tool()
-    def get_drc_history_tool(project_path: str) -> Dict[str, Any]:
-        """Get the DRC check history for a KiCad project.
-
-        Args:
-            project_path: Path to the KiCad project file (.kicad_pro)
-
-        Returns:
-            Dictionary with DRC history entries
-        """
-        print(f"Getting DRC history for project: {project_path}")
-
-        if not os.path.exists(project_path):
-            print(f"Project not found: {project_path}")
-            return {"success": False, "error": f"Project not found: {project_path}"}
-
-        history_entries = get_drc_history(project_path)
-
-        # Calculate trend information
-        trend = None
-        if len(history_entries) >= 2:
-            first = history_entries[-1]  # Oldest entry
-            last = history_entries[0]  # Newest entry
-
-            first_violations = first.get("total_violations", 0)
-            last_violations = last.get("total_violations", 0)
-
-            if first_violations > last_violations:
-                trend = "improving"
-            elif first_violations < last_violations:
-                trend = "degrading"
-            else:
-                trend = "stable"
-
-        return {
-            "success": True,
-            "project_path": project_path,
-            "history_entries": history_entries,
-            "entry_count": len(history_entries),
-            "trend": trend,
-        }
-
-    @mcp.tool()
-    async def run_drc_check(
-        project_path: str, ctx: Context | None
+    async def drc(
+        operation: str,
+        ctx: Context | None,
+        *,
+        project_path: Optional[str] = None,
+        pcb_path: Optional[str] = None,
+        fix_routing: bool = True,
+        fix_silkscreen: bool = True,
+        fix_placement: bool = True,
+        autoroute_passes: int = 2,
     ) -> Dict[str, Any]:
-        """Run a Design Rule Check on a KiCad PCB file.
+        """Design Rule Check operations for KiCad PCB files.
 
-        Args:
-            project_path: Path to the KiCad project file (.kicad_pro)
-            ctx: MCP context for progress reporting
+        Operations:
+          run(project_path)
+              -> {success, violations, violation_categories, comparison?, ...}
+              Run a full DRC check on a project's PCB via kicad-cli. Saves
+              the result to history so subsequent runs can show a trend.
 
-        Returns:
-            Dictionary with DRC results and statistics
+          autofix(pcb_path, project_path="", fix_routing=True,
+                  fix_silkscreen=True, fix_placement=True, autoroute_passes=2)
+              -> {status, before, after, actions_taken, improvement}
+              Automatically fix common DRC violations. Runs DRC, categorizes
+              violations, and applies fixes in order: placement (courtyard
+              overlaps), routing (clearance/crossing/shorts), silkscreen
+              (silk over copper/pads), zone fill. Re-runs DRC afterward to
+              verify improvement and returns a before/after comparison.
+
+          history(project_path)
+              -> {success, history_entries, entry_count, trend}
+              Get the DRC check history for a KiCad project. trend is
+              "improving"|"degrading"|"stable"|null (null if < 2 entries).
         """
-        print(f"Running DRC check for project: {project_path}")
-
-        if not os.path.exists(project_path):
-            print(f"Project not found: {project_path}")
-            return {"success": False, "error": f"Project not found: {project_path}"}
-
-        files = get_project_files(project_path)
-        if "pcb" not in files:
-            print("PCB file not found in project")
-            return {"success": False, "error": "PCB file not found in project"}
-
-        pcb_file = files["pcb"]
-        print(f"Found PCB file: {pcb_file}")
-
-        if ctx:
-            await ctx.report_progress(10, 100)
-            ctx.info(f"Starting DRC check on {os.path.basename(pcb_file)}")
-
-        drc_results = None
-
-        print("Using kicad-cli for DRC")
-        if ctx:
-            ctx.info("Using KiCad CLI for DRC check...")
-        drc_results = await run_drc_via_cli(pcb_file, ctx)
-
-        # Process and save results if successful
-        if drc_results and drc_results.get("success", False):
-            save_drc_result(project_path, drc_results)
-
-            comparison = compare_with_previous(project_path, drc_results)
-            if comparison:
-                drc_results["comparison"] = comparison
-
-                if ctx:
-                    if comparison["change"] < 0:
-                        ctx.info(
-                            f"Great progress! You've fixed {abs(comparison['change'])} "
-                            f"DRC violations since the last check."
-                        )
-                    elif comparison["change"] > 0:
-                        ctx.info(
-                            f"Found {comparison['change']} new DRC violations "
-                            f"since the last check."
-                        )
-                    else:
-                        ctx.info(
-                            "No change in the number of DRC violations since the last check."
-                        )
-
-        if ctx:
-            await ctx.report_progress(100, 100)
-
-        return drc_results or {
-            "success": False,
-            "error": "DRC check failed with an unknown error",
+        if operation == "run":
+            if project_path is None:
+                return {"error": "operation='run' requires 'project_path'"}
+            return await _op_run(project_path, ctx)
+        if operation == "autofix":
+            if pcb_path is None:
+                return {"error": "operation='autofix' requires 'pcb_path'"}
+            return await _op_autofix(
+                pcb_path=pcb_path,
+                project_path=project_path or "",
+                fix_routing=fix_routing,
+                fix_silkscreen=fix_silkscreen,
+                fix_placement=fix_placement,
+                autoroute_passes=autoroute_passes,
+            )
+        if operation == "history":
+            if project_path is None:
+                return {"error": "operation='history' requires 'project_path'"}
+            return _op_history(project_path)
+        return {
+            "error": (
+                f"unknown operation {operation!r}; "
+                f"valid: run|autofix|history"
+            )
         }

--- a/src/kicad_mcp/tools/pcb_autoroute.py
+++ b/src/kicad_mcp/tools/pcb_autoroute.py
@@ -688,393 +688,413 @@ print(json.dumps({
     })
 
 
+def _op_run(
+    pcb_path: str,
+    freerouter_jar: str = "",
+    passes: int = 1,
+    remove_zones: bool = True,
+    net_classes: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Synchronous autoroute — runs the full pipeline and waits for completion."""
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
+
+    if not (1 <= passes <= 10):
+        return {"error": f"passes must be between 1 and 10, got {passes}"}
+
+    jar_path = _find_freerouter_jar(freerouter_jar or None)
+    if not jar_path:
+        return {
+            "error": (
+                "FreeRouter JAR not found. Provide freerouter_jar path, "
+                "set FREEROUTER_JAR env var, or place freerouting-2.1.0.jar "
+                "in a known location."
+            )
+        }
+
+    java_path = _find_java()
+    if not java_path:
+        return {"error": "Java runtime not found. Install Java 17+ (e.g. Amazon Corretto)."}
+
+    # Apply net classes before routing (so DSN export includes them)
+    net_class_results = []
+    if net_classes:
+        from kicad_mcp.tools.pcb_nets import _default_net_class
+        stem = os.path.splitext(pcb_path)[0]
+        pro_path = stem + ".kicad_pro"
+        if not os.path.exists(pro_path):
+            return {
+                "error": (
+                    f"net_classes requires a .kicad_pro file at {pro_path}. "
+                    "Create one or use set_net_class separately."
+                )
+            }
+
+        import json as _json
+
+        with open(pro_path, "r") as f:
+            project = _json.load(f)
+
+        if "net_settings" not in project:
+            project["net_settings"] = {
+                "classes": [_default_net_class()],
+                "meta": {"version": 4},
+                "net_colors": None,
+                "netclass_assignments": None,
+                "netclass_patterns": [],
+            }
+
+        ns = project["net_settings"]
+        classes = ns.get("classes", [])
+        _raw_assignments = ns.get("netclass_assignments")
+        assignments = _raw_assignments if _raw_assignments is not None else {}
+
+        for cls_name, cls_def in net_classes.items():
+            nets = cls_def.get("nets", [])
+            tw = cls_def.get("track_width_mm", 0.25)
+            cl = cls_def.get("clearance_mm", 0.2)
+            vd = cls_def.get("via_diameter_mm", 0.6)
+            vr = cls_def.get("via_drill_mm", 0.3)
+
+            # Find or create class
+            existing = None
+            for c in classes:
+                if c.get("name") == cls_name:
+                    existing = c
+                    break
+            if existing:
+                existing["track_width"] = tw
+                existing["clearance"] = cl
+                existing["via_diameter"] = vd
+                existing["via_drill"] = vr
+            else:
+                nc = _default_net_class()
+                nc["name"] = cls_name
+                nc["track_width"] = tw
+                nc["clearance"] = cl
+                nc["via_diameter"] = vd
+                nc["via_drill"] = vr
+                classes.append(nc)
+
+            for net_name in nets:
+                assignments[net_name] = cls_name
+
+            net_class_results.append({
+                "class": cls_name,
+                "track_width_mm": tw,
+                "nets_assigned": len(nets),
+            })
+
+        ns["classes"] = classes
+        ns["netclass_assignments"] = assignments
+
+        with open(pro_path, "w") as f:
+            _json.dump(project, f, indent=2)
+            f.write("\n")
+
+    # Pre-flight placement check — catch issues before spending time on FreeRouter
+    preflight = _run_pre_route_check(pcb_path)
+    preflight_info = {}
+
+    if preflight.get("status") == "ok" and not preflight.get("route_ready", True):
+        overlaps = preflight.get("courtyard_overlaps", 0)
+
+        if overlaps > 0:
+            # Auto-fix courtyard overlaps by nudging footprints apart
+            logger.info("Pre-route: %d courtyard overlap(s), auto-fixing", overlaps)
+            fix_result = _run_auto_fix_placement(pcb_path)
+            preflight_info["auto_fix_applied"] = True
+            preflight_info["components_moved"] = fix_result.get("components_moved", 0)
+
+            # Re-check after fix
+            recheck = _run_pre_route_check(pcb_path)
+            if recheck.get("status") == "ok" and not recheck.get("route_ready", True):
+                # Still have issues (likely pad clearance, not just courtyards)
+                _errors_raw = recheck.get("errors", [])
+                preflight_info["errors_after_fix"] = _errors_raw[:10]
+                preflight_info["errors_after_fix_truncated"] = len(_errors_raw) > 10
+                preflight_info["route_ready_after_fix"] = False
+                # Continue anyway — FreeRouter may still produce a usable result
+                logger.warning("Pre-route: still %d error(s) after fix, routing anyway",
+                               recheck.get("error_count", 0))
+            else:
+                preflight_info["route_ready_after_fix"] = True
+        else:
+            # Pad clearance issues only — can't auto-fix, but warn and continue
+            preflight_info["pad_violations"] = preflight.get("pad_violations", 0)
+            _errors_raw = preflight.get("errors", [])
+            preflight_info["errors"] = _errors_raw[:10]
+            preflight_info["errors_truncated"] = len(_errors_raw) > 10
+            logger.warning("Pre-route: %d error(s) (no courtyard overlaps to fix)",
+                           preflight.get("error_count", 0))
+
+    result = _run_full_autoroute(
+        pcb_path=pcb_path,
+        jar_path=jar_path,
+        java_path=java_path,
+        passes=passes,
+        remove_zones=remove_zones,
+    )
+
+    if net_class_results:
+        result["net_classes_applied"] = net_class_results
+    if preflight_info:
+        result["preflight"] = preflight_info
+
+    return result
+
+
+def _op_start(
+    pcb_path: str,
+    freerouter_jar: str = "",
+    passes: int = 1,
+    remove_zones: bool = True,
+) -> Dict[str, Any]:
+    """Start autorouting in the background. Returns a job_id immediately."""
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
+
+    if not (1 <= passes <= 10):
+        return {"error": f"passes must be between 1 and 10, got {passes}"}
+
+    jar_path = _find_freerouter_jar(freerouter_jar or None)
+    if not jar_path:
+        return {
+            "error": (
+                "FreeRouter JAR not found. Provide freerouter_jar path, "
+                "set FREEROUTER_JAR env var, or place freerouting-2.1.0.jar "
+                "in a known location."
+            )
+        }
+
+    java_path = _find_java()
+    if not java_path:
+        return {"error": "Java runtime not found. Install Java 17+ (e.g. Amazon Corretto)."}
+
+    # Enforce concurrent job limit and clean up stale jobs
+    with _autoroute_lock:
+        _cleanup_stale_jobs()
+        active = sum(
+            1 for j in _autoroute_jobs.values() if j["status"] == "running"
+        )
+        if active >= MAX_CONCURRENT_JOBS:
+            return {
+                "error": (
+                    f"Too many concurrent autoroute jobs ({active}). "
+                    f"Maximum is {MAX_CONCURRENT_JOBS}. "
+                    "Wait for a job to finish or cancel one."
+                )
+            }
+
+    job_id = uuid.uuid4().hex[:8]
+
+    with _autoroute_lock:
+        _autoroute_jobs[job_id] = {
+            "status": "running",
+            "started": time.time(),
+            "pcb_path": pcb_path,
+            "passes": passes,
+            "phase": "exporting",
+            "current_pass": 0,
+            "pid": None,
+        }
+
+    thread = threading.Thread(
+        target=_autoroute_worker,
+        kwargs={
+            "job_id": job_id,
+            "pcb_path": pcb_path,
+            "jar_path": jar_path,
+            "java_path": java_path,
+            "passes": passes,
+            "remove_zones": remove_zones,
+        },
+        daemon=True,
+    )
+    thread.start()
+
+    return {
+        "job_id": job_id,
+        "status": "submitted",
+        "pcb_path": pcb_path,
+        "passes": passes,
+        "note": "Use autoroute(operation='poll', job_id=...) to check progress.",
+    }
+
+
+def _op_poll(job_id: str) -> Dict[str, Any]:
+    """Check the status of an async autoroute job."""
+    with _autoroute_lock:
+        if job_id not in _autoroute_jobs:
+            return {
+                "error": (
+                    f"Unknown job_id: {job_id!r}. "
+                    "Already retrieved or never submitted."
+                )
+            }
+
+        job = _autoroute_jobs[job_id]
+        elapsed = round(time.time() - job["started"], 1)
+
+        if job["status"] == "running":
+            return {
+                "status": "running",
+                "elapsed_s": elapsed,
+                "phase": job.get("phase", "unknown"),
+                "current_pass": job.get("current_pass", 0),
+                "total_passes": job["passes"],
+            }
+
+        # Done, error, or cancelled — retrieve and clean up
+        result = dict(job)
+        del _autoroute_jobs[job_id]
+
+    return {
+        "status": result["status"],
+        "elapsed_s": result.get("elapsed", elapsed),
+        "result": result.get("result", {}),
+    }
+
+
+def _op_cancel(job_id: str) -> Dict[str, Any]:
+    """Cancel a running async autoroute job."""
+    with _autoroute_lock:
+        if job_id not in _autoroute_jobs:
+            return {
+                "error": (
+                    f"Unknown job_id: {job_id!r}. "
+                    "Already retrieved or never submitted."
+                )
+            }
+
+        job = _autoroute_jobs[job_id]
+        if job["status"] != "running":
+            return {
+                "error": (
+                    f"Job {job_id} is not running "
+                    f"(status: {job['status']})"
+                )
+            }
+
+        elapsed = round(time.time() - job["started"], 1)
+        job["status"] = "cancelled"
+        job["elapsed"] = elapsed
+        job["result"] = {"error": f"Cancelled by user after {elapsed}s"}
+
+        # Kill the FreeRouter subprocess
+        pid = job.get("pid")
+
+    if pid:
+        try:
+            os.kill(pid, signal.SIGTERM)
+            logger.info("Sent SIGTERM to FreeRouter PID %d", pid)
+        except ProcessLookupError:
+            pass  # Already exited
+        except Exception as exc:
+            logger.warning("Failed to kill PID %d: %s", pid, exc)
+
+    return {
+        "status": "cancelled",
+        "job_id": job_id,
+        "elapsed_s": elapsed,
+    }
+
+
+def _op_list_jobs() -> Dict[str, Any]:
+    """List all tracked autoroute jobs and their current status."""
+    now = time.time()
+    with _autoroute_lock:
+        jobs = {
+            jid: {
+                "status": j["status"],
+                "elapsed_s": round(now - j["started"], 1),
+                "pcb_path": j.get("pcb_path", ""),
+                "phase": j.get("phase", ""),
+                "current_pass": j.get("current_pass", 0),
+                "total_passes": j.get("passes", 1),
+            }
+            for jid, j in _autoroute_jobs.items()
+        }
+    return {"jobs": jobs, "count": len(jobs)}
+
+
 def register_pcb_autoroute_tools(mcp: FastMCP) -> None:
-    """Register PCB autorouting tools."""
+    """Register the autoroute domain router."""
 
     @mcp.tool()
-    def autoroute_pcb(
-        pcb_path: str,
+    def autoroute(
+        operation: str,
+        *,
+        pcb_path: Optional[str] = None,
         freerouter_jar: str = "",
         passes: int = 1,
         remove_zones: bool = True,
         net_classes: Optional[Dict[str, Any]] = None,
+        job_id: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Autoroute a PCB using FreeRouter (Specctra DSN/SES pipeline).
+        """PCB autorouting via FreeRouter (Specctra DSN/SES pipeline).
 
-        Runs the full autorouting pipeline:
-        1. Optionally sets up net classes for per-net trace widths
-        2. Optionally removes copper pour zones (FreeRouter doesn't understand them)
-        3. Exports the board as a Specctra DSN file
-        4. Runs FreeRouter headless autorouter
-        5. Imports the routed SES session file back into the PCB
+        Operations:
+          run(pcb_path, freerouter_jar="", passes=1, remove_zones=True,
+              net_classes=None)
+              -> {status, pcb_path, tracks_after, vias_after, unconnected_after_routing,
+                  passes_run, best_incomplete, note, net_classes_applied?, preflight?}
+              Synchronous autoroute — waits for completion. Use for short
+              routes. FreeRouter is non-deterministic; set passes > 1 to
+              run multiple times and keep the best result.
 
-        After autorouting, re-add copper zones with add_copper_zone and
-        fill them with fill_zones.
+          start(pcb_path, freerouter_jar="", passes=1, remove_zones=True)
+              -> {job_id, status, pcb_path, passes, note}
+              Start autorouting in the background. Returns immediately.
+              Use poll(job_id) to check progress.
 
-        FreeRouter is non-deterministic. Set passes > 1 to run multiple
-        times and keep the result with the fewest incomplete connections.
+          poll(job_id)
+              -> {status: "running"|"done"|"error"|"cancelled",
+                  elapsed_s, phase?, result?}
+              Check the status of an async autoroute job. Completed/failed
+              jobs are removed from tracking after retrieval.
 
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-            freerouter_jar: Path to freerouting JAR file. Auto-detected if empty.
-            passes: Number of autoroute attempts (best result kept). Default 1.
-            remove_zones: Remove copper pour zones before routing (recommended). Default True.
-            net_classes: Optional dict of net class definitions to apply before
-                routing.  Format: ``{"ClassName": {"nets": [...], "track_width_mm": 0.5,
-                "clearance_mm": 0.3, "via_diameter_mm": 0.8, "via_drill_mm": 0.4}}``.
-                FreeRouter reads these from the DSN export and routes each net
-                at the specified width.  Requires a .kicad_pro file alongside
-                the PCB.
+          cancel(job_id)
+              -> {status: "cancelled", job_id, elapsed_s}
+              Cancel a running async autoroute job. Kills the FreeRouter
+              subprocess if it is still running.
+
+          list_jobs()
+              -> {jobs: {job_id: {...}}, count}
+              List all tracked autoroute jobs and their current status.
         """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
-
-        if not (1 <= passes <= 10):
-            return {"error": f"passes must be between 1 and 10, got {passes}"}
-
-        jar_path = _find_freerouter_jar(freerouter_jar or None)
-        if not jar_path:
-            return {
-                "error": (
-                    "FreeRouter JAR not found. Provide freerouter_jar path, "
-                    "set FREEROUTER_JAR env var, or place freerouting-2.1.0.jar "
-                    "in a known location."
-                )
-            }
-
-        java_path = _find_java()
-        if not java_path:
-            return {"error": "Java runtime not found. Install Java 17+ (e.g. Amazon Corretto)."}
-
-        # Apply net classes before routing (so DSN export includes them)
-        net_class_results = []
-        if net_classes:
-            from kicad_mcp.tools.pcb_nets import _default_net_class
-            stem = os.path.splitext(pcb_path)[0]
-            pro_path = stem + ".kicad_pro"
-            if not os.path.exists(pro_path):
-                return {
-                    "error": (
-                        f"net_classes requires a .kicad_pro file at {pro_path}. "
-                        "Create one or use set_net_class separately."
-                    )
-                }
-
-            import json as _json
-
-            with open(pro_path, "r") as f:
-                project = _json.load(f)
-
-            if "net_settings" not in project:
-                project["net_settings"] = {
-                    "classes": [_default_net_class()],
-                    "meta": {"version": 4},
-                    "net_colors": None,
-                    "netclass_assignments": None,
-                    "netclass_patterns": [],
-                }
-
-            ns = project["net_settings"]
-            classes = ns.get("classes", [])
-            _raw_assignments = ns.get("netclass_assignments")
-            assignments = _raw_assignments if _raw_assignments is not None else {}
-
-            for cls_name, cls_def in net_classes.items():
-                nets = cls_def.get("nets", [])
-                tw = cls_def.get("track_width_mm", 0.25)
-                cl = cls_def.get("clearance_mm", 0.2)
-                vd = cls_def.get("via_diameter_mm", 0.6)
-                vr = cls_def.get("via_drill_mm", 0.3)
-
-                # Find or create class
-                existing = None
-                for c in classes:
-                    if c.get("name") == cls_name:
-                        existing = c
-                        break
-                if existing:
-                    existing["track_width"] = tw
-                    existing["clearance"] = cl
-                    existing["via_diameter"] = vd
-                    existing["via_drill"] = vr
-                else:
-                    nc = _default_net_class()
-                    nc["name"] = cls_name
-                    nc["track_width"] = tw
-                    nc["clearance"] = cl
-                    nc["via_diameter"] = vd
-                    nc["via_drill"] = vr
-                    classes.append(nc)
-
-                for net_name in nets:
-                    assignments[net_name] = cls_name
-
-                net_class_results.append({
-                    "class": cls_name,
-                    "track_width_mm": tw,
-                    "nets_assigned": len(nets),
-                })
-
-            ns["classes"] = classes
-            ns["netclass_assignments"] = assignments
-
-            with open(pro_path, "w") as f:
-                _json.dump(project, f, indent=2)
-                f.write("\n")
-
-        # Pre-flight placement check — catch issues before spending time on FreeRouter
-        preflight = _run_pre_route_check(pcb_path)
-        preflight_info = {}
-
-        if preflight.get("status") == "ok" and not preflight.get("route_ready", True):
-            overlaps = preflight.get("courtyard_overlaps", 0)
-
-            if overlaps > 0:
-                # Auto-fix courtyard overlaps by nudging footprints apart
-                logger.info("Pre-route: %d courtyard overlap(s), auto-fixing", overlaps)
-                fix_result = _run_auto_fix_placement(pcb_path)
-                preflight_info["auto_fix_applied"] = True
-                preflight_info["components_moved"] = fix_result.get("components_moved", 0)
-
-                # Re-check after fix
-                recheck = _run_pre_route_check(pcb_path)
-                if recheck.get("status") == "ok" and not recheck.get("route_ready", True):
-                    # Still have issues (likely pad clearance, not just courtyards)
-                    _errors_raw = recheck.get("errors", [])
-                    preflight_info["errors_after_fix"] = _errors_raw[:10]
-                    preflight_info["errors_after_fix_truncated"] = len(_errors_raw) > 10
-                    preflight_info["route_ready_after_fix"] = False
-                    # Continue anyway — FreeRouter may still produce a usable result
-                    logger.warning("Pre-route: still %d error(s) after fix, routing anyway",
-                                   recheck.get("error_count", 0))
-                else:
-                    preflight_info["route_ready_after_fix"] = True
-            else:
-                # Pad clearance issues only — can't auto-fix, but warn and continue
-                preflight_info["pad_violations"] = preflight.get("pad_violations", 0)
-                _errors_raw = preflight.get("errors", [])
-                preflight_info["errors"] = _errors_raw[:10]
-                preflight_info["errors_truncated"] = len(_errors_raw) > 10
-                logger.warning("Pre-route: %d error(s) (no courtyard overlaps to fix)",
-                               preflight.get("error_count", 0))
-
-        result = _run_full_autoroute(
-            pcb_path=pcb_path,
-            jar_path=jar_path,
-            java_path=java_path,
-            passes=passes,
-            remove_zones=remove_zones,
-        )
-
-        if net_class_results:
-            result["net_classes_applied"] = net_class_results
-        if preflight_info:
-            result["preflight"] = preflight_info
-
-        return result
-
-    @mcp.tool()
-    def autoroute_pcb_async(
-        pcb_path: str,
-        freerouter_jar: str = "",
-        passes: int = 1,
-        remove_zones: bool = True,
-    ) -> Dict[str, Any]:
-        """Start autorouting in the background.  Returns a job_id immediately.
-
-        Use ``poll_autoroute(job_id)`` to check progress and retrieve
-        results.  Use ``cancel_autoroute(job_id)`` to abort.
-
-        FreeRouter can take 10-30+ minutes on complex boards.  This async
-        variant avoids MCP call timeouts by returning immediately and
-        running FreeRouter in a background thread.
-
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-            freerouter_jar: Path to freerouting JAR file. Auto-detected if empty.
-            passes: Number of autoroute attempts (best result kept). Default 1.
-            remove_zones: Remove copper pour zones before routing (recommended). Default True.
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
-
-        if not (1 <= passes <= 10):
-            return {"error": f"passes must be between 1 and 10, got {passes}"}
-
-        jar_path = _find_freerouter_jar(freerouter_jar or None)
-        if not jar_path:
-            return {
-                "error": (
-                    "FreeRouter JAR not found. Provide freerouter_jar path, "
-                    "set FREEROUTER_JAR env var, or place freerouting-2.1.0.jar "
-                    "in a known location."
-                )
-            }
-
-        java_path = _find_java()
-        if not java_path:
-            return {"error": "Java runtime not found. Install Java 17+ (e.g. Amazon Corretto)."}
-
-        # Enforce concurrent job limit and clean up stale jobs
-        with _autoroute_lock:
-            _cleanup_stale_jobs()
-            active = sum(
-                1 for j in _autoroute_jobs.values() if j["status"] == "running"
+        if operation == "run":
+            if pcb_path is None:
+                return {"error": "operation='run' requires 'pcb_path'"}
+            return _op_run(
+                pcb_path=pcb_path,
+                freerouter_jar=freerouter_jar,
+                passes=passes,
+                remove_zones=remove_zones,
+                net_classes=net_classes,
             )
-            if active >= MAX_CONCURRENT_JOBS:
-                return {
-                    "error": (
-                        f"Too many concurrent autoroute jobs ({active}). "
-                        f"Maximum is {MAX_CONCURRENT_JOBS}. "
-                        "Wait for a job to finish or cancel one."
-                    )
-                }
-
-        job_id = uuid.uuid4().hex[:8]
-
-        with _autoroute_lock:
-            _autoroute_jobs[job_id] = {
-                "status": "running",
-                "started": time.time(),
-                "pcb_path": pcb_path,
-                "passes": passes,
-                "phase": "exporting",
-                "current_pass": 0,
-                "pid": None,
-            }
-
-        thread = threading.Thread(
-            target=_autoroute_worker,
-            kwargs={
-                "job_id": job_id,
-                "pcb_path": pcb_path,
-                "jar_path": jar_path,
-                "java_path": java_path,
-                "passes": passes,
-                "remove_zones": remove_zones,
-            },
-            daemon=True,
-        )
-        thread.start()
-
+        if operation == "start":
+            if pcb_path is None:
+                return {"error": "operation='start' requires 'pcb_path'"}
+            return _op_start(
+                pcb_path=pcb_path,
+                freerouter_jar=freerouter_jar,
+                passes=passes,
+                remove_zones=remove_zones,
+            )
+        if operation == "poll":
+            if job_id is None:
+                return {"error": "operation='poll' requires 'job_id'"}
+            return _op_poll(job_id)
+        if operation == "cancel":
+            if job_id is None:
+                return {"error": "operation='cancel' requires 'job_id'"}
+            return _op_cancel(job_id)
+        if operation == "list_jobs":
+            return _op_list_jobs()
         return {
-            "job_id": job_id,
-            "status": "submitted",
-            "pcb_path": pcb_path,
-            "passes": passes,
-            "note": "Use poll_autoroute(job_id) to check progress.",
+            "error": (
+                f"unknown operation {operation!r}; "
+                f"valid: run|start|poll|cancel|list_jobs"
+            )
         }
-
-    @mcp.tool()
-    def poll_autoroute(job_id: str) -> Dict[str, Any]:
-        """Check the status of an async autoroute job.
-
-        Returns:
-          - ``{"status": "running", ...}`` while FreeRouter is working
-          - ``{"status": "done", "result": {...}}`` when complete
-          - ``{"status": "error", "result": {"error": "..."}}`` on failure
-
-        Completed/failed jobs are removed from tracking after retrieval.
-
-        Args:
-            job_id: The job ID returned by autoroute_pcb_async.
-        """
-        with _autoroute_lock:
-            if job_id not in _autoroute_jobs:
-                return {
-                    "error": (
-                        f"Unknown job_id: {job_id!r}. "
-                        "Already retrieved or never submitted."
-                    )
-                }
-
-            job = _autoroute_jobs[job_id]
-            elapsed = round(time.time() - job["started"], 1)
-
-            if job["status"] == "running":
-                return {
-                    "status": "running",
-                    "elapsed_s": elapsed,
-                    "phase": job.get("phase", "unknown"),
-                    "current_pass": job.get("current_pass", 0),
-                    "total_passes": job["passes"],
-                }
-
-            # Done, error, or cancelled — retrieve and clean up
-            result = dict(job)
-            del _autoroute_jobs[job_id]
-
-        return {
-            "status": result["status"],
-            "elapsed_s": result.get("elapsed", elapsed),
-            "result": result.get("result", {}),
-        }
-
-    @mcp.tool()
-    def cancel_autoroute(job_id: str) -> Dict[str, Any]:
-        """Cancel a running async autoroute job.
-
-        Marks the job as cancelled and kills the FreeRouter subprocess
-        if it is running.
-
-        Args:
-            job_id: The job ID returned by autoroute_pcb_async.
-        """
-        with _autoroute_lock:
-            if job_id not in _autoroute_jobs:
-                return {
-                    "error": (
-                        f"Unknown job_id: {job_id!r}. "
-                        "Already retrieved or never submitted."
-                    )
-                }
-
-            job = _autoroute_jobs[job_id]
-            if job["status"] != "running":
-                return {
-                    "error": (
-                        f"Job {job_id} is not running "
-                        f"(status: {job['status']})"
-                    )
-                }
-
-            elapsed = round(time.time() - job["started"], 1)
-            job["status"] = "cancelled"
-            job["elapsed"] = elapsed
-            job["result"] = {"error": f"Cancelled by user after {elapsed}s"}
-
-            # Kill the FreeRouter subprocess
-            pid = job.get("pid")
-
-        if pid:
-            try:
-                os.kill(pid, signal.SIGTERM)
-                logger.info("Sent SIGTERM to FreeRouter PID %d", pid)
-            except ProcessLookupError:
-                pass  # Already exited
-            except Exception as exc:
-                logger.warning("Failed to kill PID %d: %s", pid, exc)
-
-        return {
-            "status": "cancelled",
-            "job_id": job_id,
-            "elapsed_s": elapsed,
-        }
-
-    @mcp.tool()
-    def list_autoroute_jobs() -> Dict[str, Any]:
-        """List all tracked autoroute jobs and their current status."""
-        now = time.time()
-        with _autoroute_lock:
-            jobs = {
-                jid: {
-                    "status": j["status"],
-                    "elapsed_s": round(now - j["started"], 1),
-                    "pcb_path": j.get("pcb_path", ""),
-                    "phase": j.get("phase", ""),
-                    "current_pass": j.get("current_pass", 0),
-                    "total_passes": j.get("passes", 1),
-                }
-                for jid, j in _autoroute_jobs.items()
-            }
-        return {"jobs": jobs, "count": len(jobs)}

--- a/src/kicad_mcp/tools/pcb_drc_fix.py
+++ b/src/kicad_mcp/tools/pcb_drc_fix.py
@@ -87,82 +87,63 @@ def _categorize_violations(categories: Dict[str, int]) -> Dict[str, list]:
     }
 
 
-def register_pcb_drc_fix_tools(mcp: FastMCP) -> None:
-    """Register DRC auto-fix tools."""
+async def _op_autofix(
+    pcb_path: str,
+    project_path: str = "",
+    fix_routing: bool = True,
+    fix_silkscreen: bool = True,
+    fix_placement: bool = True,
+    autoroute_passes: int = 2,
+) -> Dict[str, Any]:
+    """Automatically fix common DRC violations.
 
-    @mcp.tool()
-    async def drc_autofix(
-        pcb_path: str,
-        project_path: str = "",
-        fix_routing: bool = True,
-        fix_silkscreen: bool = True,
-        fix_placement: bool = True,
-        autoroute_passes: int = 2,
-    ) -> Dict[str, Any]:
-        """Automatically fix common DRC violations.
+    Used by the drc router's autofix operation.
+    """
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
 
-        Runs DRC, categorizes violations, and applies fixes in order:
-        1. Placement fixes (courtyard overlaps) — nudges footprints apart
-        2. Routing fixes (clearance, crossing, shorts) — clears and re-autoroutes
-        3. Silkscreen fixes (silk over copper/pads) — repositions text
-        4. Zone fill — refills copper pours after changes
+    # Derive project_path if not provided
+    if not project_path:
+        base = os.path.splitext(pcb_path)[0]
+        project_path = base + ".kicad_pro"
 
-        Runs DRC again afterward to verify improvement and returns a
-        before/after comparison.
+    if not os.path.exists(project_path):
+        return {"error": f"Project file not found: {project_path}. Provide project_path explicitly."}
 
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-            project_path: Path to .kicad_pro file (auto-derived from pcb_path if empty).
-            fix_routing: Clear routing and re-autoroute for track violations (default True).
-            fix_silkscreen: Auto-fix silkscreen overlaps (default True).
-            fix_placement: Auto-fix courtyard overlaps (default True).
-            autoroute_passes: Number of autoroute passes when fixing routing (default 2).
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
+    # Lazy imports to avoid circular dependencies
+    from kicad_mcp.tools.drc_impl.cli_drc import run_drc_via_cli
+    from kicad_mcp.utils.pcbnew_bridge import run_pcbnew_script
 
-        # Derive project_path if not provided
-        if not project_path:
-            base = os.path.splitext(pcb_path)[0]
-            project_path = base + ".kicad_pro"
+    actions_taken = []
 
-        if not os.path.exists(project_path):
-            return {"error": f"Project file not found: {project_path}. Provide project_path explicitly."}
+    # --- Run initial DRC ---
+    before_drc = await run_drc_via_cli(pcb_path, ctx=None)
+    if not before_drc.get("success"):
+        return {"error": f"Initial DRC failed: {before_drc.get('error', 'unknown')}"}
 
-        # Lazy imports to avoid circular dependencies
-        from kicad_mcp.tools.drc_impl.cli_drc import run_drc_via_cli
-        from kicad_mcp.utils.pcbnew_bridge import run_pcbnew_script
+    # DRC result schema: success=True implies total_violations present.
+    # Default 0 here would silently misreport "fully clean" if the key
+    # ever goes missing (schema change, partial result, etc.).
+    if "total_violations" not in before_drc:
+        return {"error": f"DRC result missing 'total_violations' key (have: {sorted(before_drc.keys())})"}
+    before_total = before_drc["total_violations"]
+    before_cats = before_drc.get("violation_categories", {})  # empty dict is a legitimate value
+    groups = _categorize_violations(before_cats)
 
-        actions_taken = []
+    if before_total == 0:
+        return {
+            "status": "ok",
+            "message": "No DRC violations found — nothing to fix",
+            "before": {"total": 0, "categories": {}},
+            "after": {"total": 0, "categories": {}},
+            "actions_taken": [],
+        }
 
-        # --- Run initial DRC ---
-        before_drc = await run_drc_via_cli(pcb_path, ctx=None)
-        if not before_drc.get("success"):
-            return {"error": f"Initial DRC failed: {before_drc.get('error', 'unknown')}"}
-
-        # DRC result schema: success=True implies total_violations present.
-        # Default 0 here would silently misreport "fully clean" if the key
-        # ever goes missing (schema change, partial result, etc.).
-        if "total_violations" not in before_drc:
-            return {"error": f"DRC result missing 'total_violations' key (have: {sorted(before_drc.keys())})"}
-        before_total = before_drc["total_violations"]
-        before_cats = before_drc.get("violation_categories", {})  # empty dict is a legitimate value
-        groups = _categorize_violations(before_cats)
-
-        if before_total == 0:
-            return {
-                "status": "ok",
-                "message": "No DRC violations found — nothing to fix",
-                "before": {"total": 0, "categories": {}},
-                "after": {"total": 0, "categories": {}},
-                "actions_taken": [],
-            }
-
-        # --- 1. Fix placement (courtyard overlaps) ---
-        if fix_placement and groups["placement"]:
-            # Call auto_fix_placement via its pcbnew script
-            # (we inline the tool call to avoid MCP dispatch overhead)
-            result = run_pcbnew_script("""
+    # --- 1. Fix placement (courtyard overlaps) ---
+    if fix_placement and groups["placement"]:
+        # Call auto_fix_placement via its pcbnew script
+        # (we inline the tool call to avoid MCP dispatch overhead)
+        result = run_pcbnew_script("""
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -243,13 +224,13 @@ for pass_num in range(1, max_passes + 1):
 board.Save(params["pcb_path"])
 print(json.dumps({"status": "ok", "move_count": move_count}))
 """, params={"pcb_path": pcb_path})
-            if result.get("status") == "ok" and result.get("move_count", 0) > 0:
-                actions_taken.append(f"placement: nudged {result['move_count']} footprint(s)")
+        if result.get("status") == "ok" and result.get("move_count", 0) > 0:
+            actions_taken.append(f"placement: nudged {result['move_count']} footprint(s)")
 
-        # --- 2. Fix routing violations ---
-        if fix_routing and groups["routing"]:
-            # Clear existing routing
-            clear_result = run_pcbnew_script("""
+    # --- 2. Fix routing violations ---
+    if fix_routing and groups["routing"]:
+        # Clear existing routing
+        clear_result = run_pcbnew_script("""
 import pcbnew, json, sys
 params = json.loads(open(sys.argv[1]).read())
 board = pcbnew.LoadBoard(params["pcb_path"])
@@ -263,44 +244,44 @@ for item in to_remove:
 board.Save(params["pcb_path"])
 print(json.dumps({"status": "ok", "removed": removed}))
 """, params={"pcb_path": pcb_path})
-            # Subprocess returned {"status": "ok", "removed": N} or {"error": ...}.
-            # Default-to-0 would silently re-autoroute an uncleared board, masking
-            # the failure with an optimistic action log entry.
-            if "error" in clear_result:
-                return {"error": f"Failed to clear existing routing: {clear_result['error']}"}
-            tracks_cleared = clear_result["removed"]
+        # Subprocess returned {"status": "ok", "removed": N} or {"error": ...}.
+        # Default-to-0 would silently re-autoroute an uncleared board, masking
+        # the failure with an optimistic action log entry.
+        if "error" in clear_result:
+            return {"error": f"Failed to clear existing routing: {clear_result['error']}"}
+        tracks_cleared = clear_result["removed"]
 
-            # Re-autoroute
-            from kicad_mcp.tools.pcb_autoroute import (
-                _find_freerouter_jar,
-                _find_java,
-                _run_full_autoroute,
+        # Re-autoroute
+        from kicad_mcp.tools.pcb_autoroute import (
+            _find_freerouter_jar,
+            _find_java,
+            _run_full_autoroute,
+        )
+
+        jar_path = _find_freerouter_jar(None)
+        java_path = _find_java()
+        if jar_path and java_path:
+            route_result = _run_full_autoroute(
+                pcb_path=pcb_path,
+                jar_path=jar_path,
+                java_path=java_path,
+                passes=autoroute_passes,
+                remove_zones=True,
+            )
+            incomplete = route_result.get("best_incomplete", "?")
+            actions_taken.append(
+                f"routing: cleared {tracks_cleared} tracks/vias, "
+                f"re-autorouted ({autoroute_passes} passes, {incomplete} incomplete)"
+            )
+        else:
+            actions_taken.append(
+                f"routing: cleared {tracks_cleared} tracks/vias but "
+                "FreeRouter/Java not available for re-autoroute"
             )
 
-            jar_path = _find_freerouter_jar(None)
-            java_path = _find_java()
-            if jar_path and java_path:
-                route_result = _run_full_autoroute(
-                    pcb_path=pcb_path,
-                    jar_path=jar_path,
-                    java_path=java_path,
-                    passes=autoroute_passes,
-                    remove_zones=True,
-                )
-                incomplete = route_result.get("best_incomplete", "?")
-                actions_taken.append(
-                    f"routing: cleared {tracks_cleared} tracks/vias, "
-                    f"re-autorouted ({autoroute_passes} passes, {incomplete} incomplete)"
-                )
-            else:
-                actions_taken.append(
-                    f"routing: cleared {tracks_cleared} tracks/vias but "
-                    "FreeRouter/Java not available for re-autoroute"
-                )
-
-        # --- 3. Fix silkscreen ---
-        if fix_silkscreen and groups["silkscreen"]:
-            silk_result = run_pcbnew_script("""
+    # --- 3. Fix silkscreen ---
+    if fix_silkscreen and groups["silkscreen"]:
+        silk_result = run_pcbnew_script("""
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -420,25 +401,33 @@ board.Save(params["pcb_path"])
 print(json.dumps({"status": "ok", "moved": moved, "hidden": hidden_count,
                     "zones_filled": len(copper_zones)}))
 """, params={"pcb_path": pcb_path}, timeout=120.0)
-            if silk_result.get("status") == "ok":
-                m = silk_result.get("moved", 0)
-                h = silk_result.get("hidden", 0)
-                z = silk_result.get("zones_filled", 0)
-                parts = []
-                if m: parts.append(f"moved {m}")
-                if h: parts.append(f"hidden {h}")
-                if z: parts.append(f"filled {z} zone(s)")
-                actions_taken.append(f"silkscreen: {', '.join(parts)}" if parts else "silkscreen: no changes needed")
+        if silk_result.get("status") == "ok":
+            m = silk_result.get("moved", 0)
+            h = silk_result.get("hidden", 0)
+            z = silk_result.get("zones_filled", 0)
+            parts = []
+            if m: parts.append(f"moved {m}")
+            if h: parts.append(f"hidden {h}")
+            if z: parts.append(f"filled {z} zone(s)")
+            actions_taken.append(f"silkscreen: {', '.join(parts)}" if parts else "silkscreen: no changes needed")
 
-        # --- 4. Re-run DRC to verify ---
-        after_drc = await run_drc_via_cli(pcb_path, ctx=None)
-        after_total = after_drc.get("total_violations", 0) if after_drc.get("success") else "error"
-        after_cats = after_drc.get("violation_categories", {}) if after_drc.get("success") else {}
+    # --- 4. Re-run DRC to verify ---
+    after_drc = await run_drc_via_cli(pcb_path, ctx=None)
+    after_total = after_drc.get("total_violations", 0) if after_drc.get("success") else "error"
+    after_cats = after_drc.get("violation_categories", {}) if after_drc.get("success") else {}
 
-        return {
-            "status": "ok",
-            "before": {"total": before_total, "categories": before_cats},
-            "after": {"total": after_total, "categories": after_cats},
-            "actions_taken": actions_taken,
-            "improvement": before_total - after_total if isinstance(after_total, int) else None,
-        }
+    return {
+        "status": "ok",
+        "before": {"total": before_total, "categories": before_cats},
+        "after": {"total": after_total, "categories": after_cats},
+        "actions_taken": actions_taken,
+        "improvement": before_total - after_total if isinstance(after_total, int) else None,
+    }
+
+
+def register_pcb_drc_fix_tools(mcp: FastMCP) -> None:
+    """No-op: drc_autofix has moved to the drc router (see drc.py).
+
+    Kept so server.py import/call doesn't break during migration.
+    """
+    pass

--- a/src/kicad_mcp/tools/project.py
+++ b/src/kicad_mcp/tools/project.py
@@ -1,9 +1,10 @@
-"""
-Project management tools for KiCad.
+"""Project router — KiCad project file management.
+
+See docs/SPEC_Tool_Consolidation.md.
 """
 import logging
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from fastmcp import FastMCP
 
@@ -13,67 +14,106 @@ from kicad_mcp.utils.kicad_utils import find_kicad_projects, open_kicad_project
 logger = logging.getLogger(__name__)
 
 
+def _op_list() -> List[Dict[str, Any]]:
+    logger.info("Executing project list...")
+    projects = find_kicad_projects()
+    logger.info("project list returning %d projects.", len(projects))
+    return projects
+
+
+def _op_get_structure(project_path: str) -> Dict[str, Any]:
+    if not os.path.exists(project_path):
+        return {"error": f"Project not found: {project_path}"}
+
+    project_dir = os.path.dirname(project_path)
+    project_name = os.path.basename(project_path)[:-10]  # Remove .kicad_pro
+
+    files = get_project_files(project_path)
+
+    metadata = {}
+    project_data = load_project_json(project_path)
+    if project_data and "metadata" in project_data:
+        metadata = project_data["metadata"]
+
+    return {
+        "name": project_name,
+        "path": project_path,
+        "directory": project_dir,
+        "files": files,
+        "metadata": metadata,
+    }
+
+
+def _op_open(project_path: str) -> Dict[str, Any]:
+    return open_kicad_project(project_path)
+
+
+def _op_validate(project_path: str) -> Dict[str, Any]:
+    if not os.path.exists(project_path):
+        return {"success": False, "error": f"Project not found: {project_path}"}
+
+    files = get_project_files(project_path)
+    issues: list[str] = []
+
+    if "schematic" not in files:
+        issues.append("No schematic file found")
+    if "pcb" not in files:
+        issues.append("No PCB file found")
+
+    return {
+        "success": len(issues) == 0,
+        "project_path": project_path,
+        "files_found": list(files.keys()),
+        "issues": issues,
+    }
+
+
 def register_project_tools(mcp: FastMCP) -> None:
-    """Register project management tools with the MCP server.
-
-    Args:
-        mcp: The FastMCP server instance
-    """
+    """Register the project domain router."""
 
     @mcp.tool()
-    def list_projects() -> List[Dict[str, Any]]:
-        """Find and list all KiCad projects on this system."""
-        logger.info("Executing list_projects tool...")
-        projects = find_kicad_projects()
-        logger.info("list_projects tool returning %d projects.", len(projects))
-        return projects
+    def project(
+        operation: str,
+        *,
+        project_path: Optional[str] = None,
+    ) -> Any:
+        """KiCad project management operations.
 
-    @mcp.tool()
-    def get_project_structure(project_path: str) -> Dict[str, Any]:
-        """Get the structure and files of a KiCad project."""
-        if not os.path.exists(project_path):
-            return {"error": f"Project not found: {project_path}"}
+        Operations:
+          list()
+              -> [{name, path, ...}, ...]
+              Find and list all KiCad projects on this system.
 
-        project_dir = os.path.dirname(project_path)
-        project_name = os.path.basename(project_path)[:-10]  # Remove .kicad_pro
+          get_structure(project_path)
+              -> {name, path, directory, files, metadata}
+              Get the structure and files of a KiCad project.
 
-        files = get_project_files(project_path)
+          open(project_path)
+              -> {success, command, ...}
+              Open a KiCad project in KiCad.
 
-        metadata = {}
-        project_data = load_project_json(project_path)
-        if project_data and "metadata" in project_data:
-            metadata = project_data["metadata"]
-
+          validate(project_path)
+              -> {success, project_path, files_found, issues}
+              Basic validation of a KiCad project — checks that schematic
+              and PCB files are present.
+        """
+        if operation == "list":
+            return _op_list()
+        if operation == "get_structure":
+            if project_path is None:
+                return {"error": "operation='get_structure' requires 'project_path'"}
+            return _op_get_structure(project_path)
+        if operation == "open":
+            if project_path is None:
+                return {"error": "operation='open' requires 'project_path'"}
+            return _op_open(project_path)
+        if operation == "validate":
+            if project_path is None:
+                return {"error": "operation='validate' requires 'project_path'"}
+            return _op_validate(project_path)
         return {
-            "name": project_name,
-            "path": project_path,
-            "directory": project_dir,
-            "files": files,
-            "metadata": metadata,
-        }
-
-    @mcp.tool()
-    def open_project(project_path: str) -> Dict[str, Any]:
-        """Open a KiCad project in KiCad."""
-        return open_kicad_project(project_path)
-
-    @mcp.tool()
-    def validate_project(project_path: str) -> Dict[str, Any]:
-        """Basic validation of a KiCad project."""
-        if not os.path.exists(project_path):
-            return {"success": False, "error": f"Project not found: {project_path}"}
-
-        files = get_project_files(project_path)
-        issues: list[str] = []
-
-        if "schematic" not in files:
-            issues.append("No schematic file found")
-        if "pcb" not in files:
-            issues.append("No PCB file found")
-
-        return {
-            "success": len(issues) == 0,
-            "project_path": project_path,
-            "files_found": list(files.keys()),
-            "issues": issues,
+            "error": (
+                f"unknown operation {operation!r}; "
+                f"valid: list|get_structure|open|validate"
+            )
         }

--- a/tests/test_drc.py
+++ b/tests/test_drc.py
@@ -1,7 +1,7 @@
 """
 Tests for DRC tools and DRC history utilities.
 
-Tests drc.py tools and utils/drc_history.py functions.
+Tests drc.py router and utils/drc_history.py functions.
 """
 
 import asyncio
@@ -135,14 +135,20 @@ class TestCompareWithPrevious:
         assert "resolved_categories" in comparison
 
 
-# -- get_drc_history_tool tests ----------------------------------------------
+# -- drc router: history operation tests -------------------------------------
 
-class TestGetDrcHistoryTool:
+class TestDrcHistoryOperation:
 
     def test_project_not_found(self, drc_server):
-        fn = _get_tool_fn(drc_server, "get_drc_history_tool")
-        result = fn("/nonexistent/project.kicad_pro")
+        fn = _get_tool_fn(drc_server, "drc")
+        result = asyncio.run(fn("history", None, project_path="/nonexistent/project.kicad_pro"))
         assert result["success"] is False
+
+    def test_requires_project_path(self, drc_server):
+        fn = _get_tool_fn(drc_server, "drc")
+        result = asyncio.run(fn("history", None))
+        assert "error" in result
+        assert "project_path" in result["error"]
 
     @patch("kicad_mcp.tools.drc.get_drc_history")
     def test_returns_history(self, mock_hist, drc_server, tmp_path):
@@ -152,8 +158,8 @@ class TestGetDrcHistoryTool:
             {"timestamp": 1000, "total_violations": 5},
             {"timestamp": 900, "total_violations": 10},
         ]
-        fn = _get_tool_fn(drc_server, "get_drc_history_tool")
-        result = fn(str(pro))
+        fn = _get_tool_fn(drc_server, "drc")
+        result = asyncio.run(fn("history", None, project_path=str(pro)))
         assert result["success"] is True
         assert result["entry_count"] == 2
         assert result["trend"] == "improving"
@@ -163,24 +169,42 @@ class TestGetDrcHistoryTool:
         pro = tmp_path / "test.kicad_pro"
         pro.write_text("{}")
         mock_hist.return_value = [{"timestamp": 1000, "total_violations": 5}]
-        fn = _get_tool_fn(drc_server, "get_drc_history_tool")
-        result = fn(str(pro))
+        fn = _get_tool_fn(drc_server, "drc")
+        result = asyncio.run(fn("history", None, project_path=str(pro)))
         assert result["trend"] is None
 
 
-# -- run_drc_check tests -----------------------------------------------------
+# -- drc router: run operation tests -----------------------------------------
 
-class TestRunDrcCheck:
+class TestDrcRunOperation:
 
     def test_project_not_found(self, drc_server):
-        fn = _get_tool_fn(drc_server, "run_drc_check")
-        result = asyncio.run(fn("/nonexistent/project.kicad_pro", None))
+        fn = _get_tool_fn(drc_server, "drc")
+        result = asyncio.run(fn("run", None, project_path="/nonexistent/project.kicad_pro"))
         assert result["success"] is False
+
+    def test_requires_project_path(self, drc_server):
+        fn = _get_tool_fn(drc_server, "drc")
+        result = asyncio.run(fn("run", None))
+        assert "error" in result
+        assert "project_path" in result["error"]
 
     def test_no_pcb_file(self, drc_server, tmp_path):
         pro = tmp_path / "test.kicad_pro"
         pro.write_text("{}")
-        fn = _get_tool_fn(drc_server, "run_drc_check")
-        result = asyncio.run(fn(str(pro), None))
+        fn = _get_tool_fn(drc_server, "drc")
+        result = asyncio.run(fn("run", None, project_path=str(pro)))
         assert result["success"] is False
         assert "PCB file not found" in result["error"]
+
+
+# -- drc router: unknown operation -------------------------------------------
+
+class TestDrcUnknownOperation:
+
+    def test_unknown_op(self, drc_server):
+        fn = _get_tool_fn(drc_server, "drc")
+        result = asyncio.run(fn("bogus", None))
+        assert "error" in result
+        assert "bogus" in result["error"]
+        assert "run|autofix|history" in result["error"]

--- a/tests/test_new_tools.py
+++ b/tests/test_new_tools.py
@@ -523,8 +523,8 @@ class TestAutoroutePreflight:
         }
         mock_route.return_value = {"status": "ok", "tracks_after": 100, "vias_after": 10}
 
-        fn = _get_tool_fn(mcp_server, "autoroute_pcb")
-        result = fn(pcb_file)
+        fn = _get_tool_fn(mcp_server, "autoroute")
+        result = fn("run", pcb_path=pcb_file)
 
         assert result["status"] == "ok"
         mock_fix.assert_not_called()
@@ -557,8 +557,8 @@ class TestAutoroutePreflight:
         mock_fix.return_value = {"status": "ok", "components_moved": 1, "moved": ["R1"]}
         mock_route.return_value = {"status": "ok", "tracks_after": 100, "vias_after": 10}
 
-        fn = _get_tool_fn(mcp_server, "autoroute_pcb")
-        result = fn(pcb_file)
+        fn = _get_tool_fn(mcp_server, "autoroute")
+        result = fn("run", pcb_path=pcb_file)
 
         assert result["status"] == "ok"
         mock_fix.assert_called_once()
@@ -582,8 +582,8 @@ class TestAutoroutePreflight:
         }
         mock_route.return_value = {"status": "ok", "tracks_after": 100, "vias_after": 10}
 
-        fn = _get_tool_fn(mcp_server, "autoroute_pcb")
-        result = fn(pcb_file)
+        fn = _get_tool_fn(mcp_server, "autoroute")
+        result = fn("run", pcb_path=pcb_file)
 
         assert result["status"] == "ok"
         mock_fix.assert_not_called()  # No overlaps, so no fix attempted

--- a/tests/test_pcb_autoroute.py
+++ b/tests/test_pcb_autoroute.py
@@ -110,30 +110,36 @@ class TestCleanupStaleJobs:
             assert "running-job" in _autoroute_jobs
 
 
-# -- autoroute_pcb tool tests -----------------------------------------------
+# -- autoroute router: run operation tests -----------------------------------
 
-class TestAutoroutePcb:
+class TestAutorouteRun:
 
     def test_file_not_found(self, route_server):
-        fn = _get_tool_fn(route_server, "autoroute_pcb")
-        result = fn("/nonexistent/board.kicad_pcb")
+        fn = _get_tool_fn(route_server, "autoroute")
+        result = fn("run", pcb_path="/nonexistent/board.kicad_pcb")
         assert "error" in result
+
+    def test_requires_pcb_path(self, route_server):
+        fn = _get_tool_fn(route_server, "autoroute")
+        result = fn("run")
+        assert "error" in result
+        assert "pcb_path" in result["error"]
 
     @patch("kicad_mcp.tools.pcb_autoroute._find_freerouter_jar", return_value=None)
     def test_no_freerouter(self, mock_jar, route_server, pcb_file):
-        fn = _get_tool_fn(route_server, "autoroute_pcb")
-        result = fn(pcb_file)
+        fn = _get_tool_fn(route_server, "autoroute")
+        result = fn("run", pcb_path=pcb_file)
         assert "error" in result
         assert "FreeRouter" in result["error"] or "freerouter" in result["error"].lower()
 
 
-# -- list_autoroute_jobs tool tests ------------------------------------------
+# -- autoroute router: list_jobs operation tests -----------------------------
 
-class TestListAutorouteJobs:
+class TestAutorouteListJobs:
 
     def test_empty_job_list(self, route_server):
-        fn = _get_tool_fn(route_server, "list_autoroute_jobs")
-        result = fn()
+        fn = _get_tool_fn(route_server, "autoroute")
+        result = fn("list_jobs")
         assert result["count"] == 0
         assert result["jobs"] == {}
 
@@ -145,20 +151,26 @@ class TestListAutorouteJobs:
                 "pcb_path": "/tmp/test.kicad_pcb",
                 "passes": 2,
             }
-        fn = _get_tool_fn(route_server, "list_autoroute_jobs")
-        result = fn()
+        fn = _get_tool_fn(route_server, "autoroute")
+        result = fn("list_jobs")
         assert result["count"] == 1
         assert "test-job" in result["jobs"]
 
 
-# -- cancel_autoroute tool tests --------------------------------------------
+# -- autoroute router: cancel operation tests --------------------------------
 
-class TestCancelAutoroute:
+class TestAutorouteCancel:
 
     def test_cancel_nonexistent_job(self, route_server):
-        fn = _get_tool_fn(route_server, "cancel_autoroute")
-        result = fn("nonexistent-job-id")
+        fn = _get_tool_fn(route_server, "autoroute")
+        result = fn("cancel", job_id="nonexistent-job-id")
         assert "error" in result
+
+    def test_cancel_requires_job_id(self, route_server):
+        fn = _get_tool_fn(route_server, "autoroute")
+        result = fn("cancel")
+        assert "error" in result
+        assert "job_id" in result["error"]
 
     def test_cancel_running_job(self, route_server):
         with _autoroute_lock:
@@ -169,19 +181,25 @@ class TestCancelAutoroute:
                 "passes": 2,
                 "process": MagicMock(),
             }
-        fn = _get_tool_fn(route_server, "cancel_autoroute")
-        result = fn("test-cancel")
+        fn = _get_tool_fn(route_server, "autoroute")
+        result = fn("cancel", job_id="test-cancel")
         assert result["status"] == "ok" or "cancel" in str(result).lower()
 
 
-# -- poll_autoroute tool tests -----------------------------------------------
+# -- autoroute router: poll operation tests ----------------------------------
 
-class TestPollAutoroute:
+class TestAutoroutePoll:
 
     def test_poll_nonexistent_job(self, route_server):
-        fn = _get_tool_fn(route_server, "poll_autoroute")
-        result = fn("nonexistent-job-id")
+        fn = _get_tool_fn(route_server, "autoroute")
+        result = fn("poll", job_id="nonexistent-job-id")
         assert "error" in result
+
+    def test_poll_requires_job_id(self, route_server):
+        fn = _get_tool_fn(route_server, "autoroute")
+        result = fn("poll")
+        assert "error" in result
+        assert "job_id" in result["error"]
 
     def test_poll_running_job(self, route_server):
         with _autoroute_lock:
@@ -191,8 +209,8 @@ class TestPollAutoroute:
                 "pcb_path": "/tmp/test.kicad_pcb",
                 "passes": 2,
             }
-        fn = _get_tool_fn(route_server, "poll_autoroute")
-        result = fn("running")
+        fn = _get_tool_fn(route_server, "autoroute")
+        result = fn("poll", job_id="running")
         assert result["status"] == "running"
 
     def test_poll_completed_job(self, route_server):
@@ -204,6 +222,18 @@ class TestPollAutoroute:
                 "passes": 2,
                 "result": {"traces_added": 50, "unrouted": 0},
             }
-        fn = _get_tool_fn(route_server, "poll_autoroute")
-        result = fn("done")
+        fn = _get_tool_fn(route_server, "autoroute")
+        result = fn("poll", job_id="done")
         assert result["status"] == "done"
+
+
+# -- autoroute router: unknown operation -------------------------------------
+
+class TestAutorouteUnknownOperation:
+
+    def test_unknown_op(self, route_server):
+        fn = _get_tool_fn(route_server, "autoroute")
+        result = fn("bogus")
+        assert "error" in result
+        assert "bogus" in result["error"]
+        assert "run|start|poll|cancel|list_jobs" in result["error"]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -31,10 +31,11 @@ class TestCreateServer:
 
         Tool-consolidation in progress (see docs/SPEC_Tool_Consolidation.md).
         Target: 14 tools. Current count tracks the in-progress migration.
+        Phase 2 consolidated project (4→1) + drc (3→1) + autoroute (5→1) = 90-12+3=81.
         """
         tools = asyncio.run(mcp_server.list_tools())
-        assert len(tools) == 90, (
-            f"Expected 90 tools, got {len(tools)}. "
+        assert len(tools) == 81, (
+            f"Expected 81 tools, got {len(tools)}. "
             "Update this test if tools were intentionally added or removed."
         )
 
@@ -72,12 +73,6 @@ class TestExpectedToolsExist:
         "check_silkscreen_overlaps",
         "auto_fix_silkscreen",
         "add_text_to_pcb",
-        # PCB autoroute tools
-        "autoroute_pcb",
-        "autoroute_pcb_async",
-        "poll_autoroute",
-        "cancel_autoroute",
-        "list_autoroute_jobs",
         # PCB panelize tools
         "panelize_pcb",
         # PCB keepout tools
@@ -89,22 +84,17 @@ class TestExpectedToolsExist:
         "audit_all",
         "pre_route_check",
         "auto_fix_placement",
-        # PCB DRC fix tools
-        "drc_autofix",
         # PCB planning tools
         "estimate_board_size",
         "suggest_placement",
-        # Project tools
-        "list_projects",
-        "get_project_structure",
-        "open_project",
-        "validate_project",
         # Phase 1 routers (library + analyze + export)
         "library",
         "analyze",
         "export",
-        # DRC (still standalone until phase 2)
-        "run_drc_check",
+        # Phase 2 routers (project + drc + autoroute)
+        "project",
+        "drc",
+        "autoroute",
         # Schematic tools
         "create_schematic",
         "load_schematic",


### PR DESCRIPTION
## Summary
Phase 2 of the Tool Consolidation spec ([docs/SPEC_Tool_Consolidation.md](docs/SPEC_Tool_Consolidation.md)). Stacked on top of [phase 1 (#21)](https://github.com/blwfish/kicad-mcp/pull/21).

Folds 12 self-contained tools into 3 domain routers — low-risk per the spec's phase ordering.

## Folds (12 → 3)
- **`project`** ← list_projects, open_project, get_project_structure, validate_project
- **`drc`** ← run_drc_check, drc_autofix, get_drc_history_tool
- **`autoroute`** ← autoroute_pcb (sync), autoroute_pcb_async (start), poll_autoroute, cancel_autoroute, list_autoroute_jobs

## Notes
- ``drc_autofix`` impl stays in pcb_drc_fix.py and is imported by the drc router (same pattern as analyze importing from bom/netlist/patterns). pcb_drc_fix's register function is now a no-op stub — full removal lands in phase 6 cleanup.
- ``autoroute`` router carries both sync ``run`` and background-job ``start`` per Resolved Q4 in the spec — different return shapes per op are fine and well-documented in the router's docstring.
- All 5 autoroute op impls are sync Python functions (``_op_start`` starts a background thread but returns immediately); the router itself is sync.

## Test plan
- [x] 650 tests pass.
- [x] Tool count: 90 → 81 (snapshot ``test_current_tool_count`` updated).
- [x] All 12 old tool names absent from registry; all 3 new router names present.
- [x] test_drc.py, test_pcb_autoroute.py, test_new_tools.py, test_project.py rewritten to call via routers with ``operation=``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)