### PR TITLE
Phase 4: pcb router (73 → 45)

### DIFF
--- a/AGENT-INSTALL.md
+++ b/AGENT-INSTALL.md
@@ -4,7 +4,7 @@ This file is for you, the AI agent. It tells you what needs to be true on this s
 
 ## What This Is
 
-kicad-mcp is a Model Context Protocol (MCP) server providing 73 tools for KiCad electronic design automation — schematic capture, PCB layout, autorouting, DRC, and more. Once installed and registered, these tools appear in your tool list and you can design circuit boards conversationally.
+kicad-mcp is a Model Context Protocol (MCP) server providing 45 tools for KiCad electronic design automation — schematic capture, PCB layout, autorouting, DRC, and more. Once installed and registered, these tools appear in your tool list and you can design circuit boards conversationally.
 
 **Origin:** Built by one person for personal use, on a Mac, with Claude Code. Other platforms *should* work (the code handles macOS, Windows, and Linux) but are untested. PRs for other agents and platforms will be considered.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This tool enables your AI agent to use [KiCad](https://www.kicad.org/) — the i
 
 ## What This Does
 
-You describe what you need — "design a board for this ESP32 circuit" or "here's the schematic, lay out the PCB" — and your AI agent does the rest: drawing the schematic, choosing components, placing them on the board, routing traces, checking for errors, and producing manufacturing-ready files. All using the same KiCad that professional engineers use, with 73 tools covering the full design workflow.
+You describe what you need — "design a board for this ESP32 circuit" or "here's the schematic, lay out the PCB" — and your AI agent does the rest: drawing the schematic, choosing components, placing them on the board, routing traces, checking for errors, and producing manufacturing-ready files. All using the same KiCad that professional engineers use, with 45 tools covering the full design workflow.
 
 You don't need to know KiCad. You don't need to know what a PCB layout tool does. You just need an AI agent (like [Claude](https://claude.ai/)).
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1,5 +1,5 @@
 # Tool Summary
 
-This MCP server exposes 73 MCP tools for KiCad EDA.
+This MCP server exposes 45 MCP tools for KiCad EDA.
 
 See [README.md](README.md) for the full tool list and usage guide.

--- a/src/kicad_mcp/server.py
+++ b/src/kicad_mcp/server.py
@@ -10,13 +10,8 @@ def create_server() -> FastMCP:
     """Create and configure the KiCad MCP server."""
     mcp = FastMCP("KiCad")
 
-    # PCB tools (split from former monolithic pcb_tools.py)
-    from kicad_mcp.tools.pcb_board import register_pcb_board_tools
-    from kicad_mcp.tools.pcb_footprints import register_pcb_footprint_tools
-    from kicad_mcp.tools.pcb_nets import register_pcb_net_tools
-    from kicad_mcp.tools.pcb_routing import register_pcb_routing_tools
-    from kicad_mcp.tools.pcb_zones import register_pcb_zone_tools
-    from kicad_mcp.tools.pcb_silkscreen import register_pcb_silkscreen_tools
+    # PCB domain router (phase 4: replaces 27 individual pcb_* tools)
+    from kicad_mcp.tools.pcb import register_pcb_tools
     from kicad_mcp.tools.pcb_keepout import register_pcb_keepout_tools
     from kicad_mcp.tools.pcb_autoroute import register_pcb_autoroute_tools
     from kicad_mcp.tools.pcb_panelize import register_pcb_panelize_tools
@@ -24,12 +19,7 @@ def create_server() -> FastMCP:
     from kicad_mcp.tools.pcb_drc_fix import register_pcb_drc_fix_tools
     from kicad_mcp.tools.pcb_pipeline import register_pipeline_tools
 
-    register_pcb_board_tools(mcp)
-    register_pcb_footprint_tools(mcp)
-    register_pcb_net_tools(mcp)
-    register_pcb_routing_tools(mcp)
-    register_pcb_zone_tools(mcp)
-    register_pcb_silkscreen_tools(mcp)
+    register_pcb_tools(mcp)
     register_pcb_keepout_tools(mcp)
     register_pcb_autoroute_tools(mcp)
     register_pcb_panelize_tools(mcp)
@@ -54,8 +44,7 @@ def create_server() -> FastMCP:
     register_drc_tools(mcp)
 
     # Domain routers (phase 3: audit)
-    # Note: register_pcb_keepout_tools is imported above and already called;
-    # it now registers the audit router instead of 9 individual tools.
+    # Note: register_pcb_keepout_tools is imported above and already called.
 
     # Tools not yet consolidated into routers
     from kicad_mcp.tools.netlist import register_netlist_tools

--- a/src/kicad_mcp/tools/pcb.py
+++ b/src/kicad_mcp/tools/pcb.py
@@ -1,0 +1,556 @@
+"""PCB domain router — all PCB editing operations.
+
+See docs/SPEC_Tool_Consolidation.md §2.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Op imports — each source module exposes module-level _op_* helpers
+# ---------------------------------------------------------------------------
+
+from kicad_mcp.tools.pcb_board import (
+    _op_create,
+    _op_load,
+    _op_set_outline,
+    _op_set_design_rules,
+    _op_finalize,
+)
+from kicad_mcp.tools.pcb_footprints import (
+    _op_place_footprint,
+    _op_move_footprint,
+    _op_list_footprints,
+    _op_get_pad_positions,
+    _op_get_footprint_dimensions,
+)
+from kicad_mcp.tools.pcb_nets import (
+    _op_add_net,
+    _op_rename_net,
+    _op_list_nets,
+    _op_set_net_class,
+    _op_assign_pad_net,
+    _op_bulk_assign_pad_nets,
+)
+from kicad_mcp.tools.pcb_routing import (
+    _op_add_trace,
+    _op_add_via,
+    _op_clear_routing,
+    _op_edit_trace_width,
+)
+from kicad_mcp.tools.pcb_zones import (
+    _op_add_zone,
+    _op_fill_zones,
+)
+from kicad_mcp.tools.pcb_silkscreen import (
+    _op_add_text,
+    _op_list_silkscreen,
+    _op_update_silkscreen,
+    _op_auto_fix_silkscreen,
+    _op_check_silkscreen_overlaps,
+)
+# get_constraints shares impl with audit router (single source of truth)
+from kicad_mcp.tools.pcb_keepout import _op_constraints as _op_get_constraints
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+def register_pcb_tools(mcp: FastMCP) -> None:
+    """Register the pcb domain router."""
+
+    @mcp.tool()
+    def pcb(
+        operation: str,
+        *,
+        # ── Lifecycle / board ─────────────────────────────────────────────
+        pcb_path: Optional[str] = None,
+        x_mm: Optional[float] = None,
+        y_mm: Optional[float] = None,
+        width_mm: Optional[float] = None,
+        height_mm: Optional[float] = None,
+        min_track_width_mm: float = 0.2,
+        min_clearance_mm: float = 0.2,
+        min_via_diameter_mm: float = 0.6,
+        min_via_drill_mm: float = 0.3,
+        min_hole_to_hole_mm: float = 0.25,
+        min_through_hole_diameter_mm: float = 0.3,
+        min_copper_edge_clearance_mm: float = 0.5,
+        fix_silkscreen: bool = True,
+        fill_zones_flag: bool = True,
+        # ── Footprints ────────────────────────────────────────────────────
+        library: Optional[str] = None,
+        footprint_name: Optional[str] = None,
+        reference: Optional[str] = None,
+        value: Optional[str] = None,
+        rotation_deg: Optional[float] = None,
+        layer: str = "F.Cu",
+        check_keepouts: bool = True,
+        # ── Nets ──────────────────────────────────────────────────────────
+        net_name: str = "",
+        old_name: Optional[str] = None,
+        new_name: Optional[str] = None,
+        class_name: Optional[str] = None,
+        nets: Optional[List[str]] = None,
+        track_width_mm: float = 0.25,
+        clearance_mm: float = 0.2,
+        via_diameter_mm: float = 0.6,
+        via_drill_mm: float = 0.3,
+        pad_number: Optional[str] = None,
+        assignments: Optional[List[Dict[str, str]]] = None,
+        # ── Routing ───────────────────────────────────────────────────────
+        start_x_mm: Optional[float] = None,
+        start_y_mm: Optional[float] = None,
+        end_x_mm: Optional[float] = None,
+        end_y_mm: Optional[float] = None,
+        trace_width_mm: float = 0.25,
+        drill_mm: float = 0.3,
+        size_mm: float = 0.6,
+        via_type: str = "through",
+        clear_tracks: bool = True,
+        clear_vias: bool = True,
+        clear_zones_flag: bool = False,
+        new_width_mm: Optional[float] = None,
+        net_filter: str = "",
+        layer_filter: str = "",
+        # ── Zones ─────────────────────────────────────────────────────────
+        corners: Optional[List[List[float]]] = None,
+        zone_clearance_mm: float = 0.3,
+        min_width_mm: float = 0.2,
+        connect_pads: str = "thermal",
+        priority: int = 0,
+        # ── Silkscreen / text ─────────────────────────────────────────────
+        text: Optional[str] = None,
+        text_size_mm: float = 1.0,
+        thickness_mm: float = 0.15,
+        silk_field: str = "reference",
+        visible: Optional[bool] = None,
+        rel_x_mm: Optional[float] = None,
+        rel_y_mm: Optional[float] = None,
+        silk_size_mm: Optional[float] = None,
+        silk_thickness_mm: Optional[float] = None,
+        angle_deg: Optional[float] = None,
+        silk_layer: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """PCB domain router — board lifecycle, footprints, nets, routing, zones, silkscreen.
+
+        Operations:
+
+        LIFECYCLE
+          create(pcb_path)
+              -> {status, file}   Create a new empty .kicad_pcb file.
+
+          load(pcb_path)
+              -> {status, file, footprint_count, track_count, footprints}
+                 Load a PCB file and return a summary.
+
+          finalize(pcb_path, fix_silkscreen=True, fill_zones_flag=True)
+              -> {status, silkscreen, zones}
+                 Fix silkscreen overlaps and fill copper zones in one step.
+
+        BOARD
+          set_outline(pcb_path, x_mm, y_mm, width_mm, height_mm)
+              -> {status, previous_edge_cuts_removed, outline}
+                 Set a rectangular board outline on Edge.Cuts (replaces existing).
+
+          set_design_rules(pcb_path, min_track_width_mm=0.2, min_clearance_mm=0.2,
+                           min_via_diameter_mm=0.6, min_via_drill_mm=0.3,
+                           min_hole_to_hole_mm=0.25, min_through_hole_diameter_mm=0.3,
+                           min_copper_edge_clearance_mm=0.5)
+              -> {status, design_rules, project_rules_updated}
+                 Set PCB design rules in the PCB file and .kicad_pro.
+
+          get_constraints(pcb_path)
+              -> {status, board_outline, keepout_zones, design_rules,
+                  existing_footprints_count, total_keepout_area_mm2}
+                 Board outline + keepouts + design rules. Shared with audit.constraints.
+
+        FOOTPRINTS
+          place_footprint(pcb_path, library, footprint_name, reference, value,
+                          x_mm, y_mm, rotation_deg=0, layer="F.Cu",
+                          check_keepouts=True)
+              -> {status, placed, bounding_box, placement_warnings?}
+
+          move_footprint(pcb_path, reference, x_mm, y_mm, rotation_deg=None)
+              -> {status, reference, x_mm, y_mm, rotation}
+
+          list_footprints(pcb_path)
+              -> {status, footprint_count, footprints}
+
+          get_pad_positions(pcb_path, reference)
+              -> {status, reference, pad_count, pads}
+
+          get_footprint_dimensions(library, footprint_name, rotation_deg=0)
+              -> {status, body_bbox, courtyard?, pad_span, keepout_zones?}
+                 Query footprint dimensions WITHOUT placing it on a PCB.
+
+        NETS
+          add_net(pcb_path, net_name)
+              -> {status, net, net_code}
+
+          rename_net(pcb_path, old_name, new_name)
+              -> {status, old_name, new_name, net_code, replacements}
+
+          list_nets(pcb_path)
+              -> {status, net_count, nets}
+
+          set_net_class(pcb_path, class_name, nets, track_width_mm=0.25,
+                        clearance_mm=0.2, via_diameter_mm=0.6, via_drill_mm=0.3)
+              -> {status, class_name, action, nets_assigned}
+
+          assign_pad_net(pcb_path, reference, pad_number, net_name)
+              -> {status, reference, pad, net}
+
+          bulk_assign_pad_nets(pcb_path, assignments)
+              -> {status, assigned, error_count, nets_created, errors}
+
+        ROUTING
+          add_trace(pcb_path, start_x_mm, start_y_mm, end_x_mm, end_y_mm,
+                    trace_width_mm=0.25, layer="F.Cu", net_name="")
+              -> {status, trace}
+
+          add_via(pcb_path, x_mm, y_mm, drill_mm=0.3, size_mm=0.6,
+                  net_name="", via_type="through")
+              -> {status, via}
+
+          clear_routing(pcb_path, clear_tracks=True, clear_vias=True,
+                        clear_zones_flag=False)
+              -> {status, tracks_removed, vias_removed, zones_removed}
+
+          edit_trace_width(pcb_path, new_width_mm, net_filter="", layer_filter="")
+              -> {status, updated, skipped}
+
+        ZONES
+          add_zone(pcb_path, net_name, layer="F.Cu", corners=[], clearance_mm=0.3,
+                   min_width_mm=0.2, connect_pads="thermal", priority=0)
+              -> {status, zone}   corners=[] auto-derives from board outline.
+
+          fill_zones(pcb_path)
+              -> {status, fill_success, zones_filled, zones}
+
+        SILKSCREEN + TEXT
+          add_text(pcb_path, text, x_mm, y_mm, layer="F.SilkS",
+                   text_size_mm=1.0, thickness_mm=0.15, rotation_deg=0)
+              -> {status, text, x_mm, y_mm, layer}
+
+          list_silkscreen(pcb_path)
+              -> {status, item_count, items}
+
+          update_silkscreen(pcb_path, reference, silk_field="reference",
+                            visible=None, x_mm=None, y_mm=None, rel_x_mm=None,
+                            rel_y_mm=None, silk_size_mm=None, silk_thickness_mm=None,
+                            angle_deg=None, silk_layer=None)
+              -> {status, reference, field, text, visible, ...}
+
+          auto_fix_silkscreen(pcb_path)
+              -> {status, already_ok, moved, hidden, fixes}
+
+          check_silkscreen_overlaps(pcb_path)
+              -> {status, silk_items_checked, pads_checked, overlap_count, overlaps,
+                  text_overlap_count, text_overlaps}
+                 Shared impl with audit.check_silkscreen_overlaps.
+        """
+        # ── Lifecycle ──────────────────────────────────────────────────────
+
+        if operation == "create":
+            if pcb_path is None:
+                return {"error": "operation='create' requires 'pcb_path'"}
+            return _op_create(pcb_path)
+
+        if operation == "load":
+            if pcb_path is None:
+                return {"error": "operation='load' requires 'pcb_path'"}
+            return _op_load(pcb_path)
+
+        if operation == "finalize":
+            if pcb_path is None:
+                return {"error": "operation='finalize' requires 'pcb_path'"}
+            return _op_finalize(pcb_path, fix_silkscreen=fix_silkscreen, fill_zones=fill_zones_flag)
+
+        # ── Board ──────────────────────────────────────────────────────────
+
+        if operation == "set_outline":
+            if pcb_path is None:
+                return {"error": "operation='set_outline' requires 'pcb_path'"}
+            if x_mm is None:
+                return {"error": "operation='set_outline' requires 'x_mm'"}
+            if y_mm is None:
+                return {"error": "operation='set_outline' requires 'y_mm'"}
+            if width_mm is None:
+                return {"error": "operation='set_outline' requires 'width_mm'"}
+            if height_mm is None:
+                return {"error": "operation='set_outline' requires 'height_mm'"}
+            return _op_set_outline(pcb_path, x_mm, y_mm, width_mm, height_mm)
+
+        if operation == "set_design_rules":
+            if pcb_path is None:
+                return {"error": "operation='set_design_rules' requires 'pcb_path'"}
+            return _op_set_design_rules(
+                pcb_path,
+                min_track_width_mm=min_track_width_mm,
+                min_clearance_mm=min_clearance_mm,
+                min_via_diameter_mm=min_via_diameter_mm,
+                min_via_drill_mm=min_via_drill_mm,
+                min_hole_to_hole_mm=min_hole_to_hole_mm,
+                min_through_hole_diameter_mm=min_through_hole_diameter_mm,
+                min_copper_edge_clearance_mm=min_copper_edge_clearance_mm,
+            )
+
+        if operation == "get_constraints":
+            if pcb_path is None:
+                return {"error": "operation='get_constraints' requires 'pcb_path'"}
+            return _op_get_constraints(pcb_path)
+
+        # ── Footprints ─────────────────────────────────────────────────────
+
+        if operation == "place_footprint":
+            if pcb_path is None:
+                return {"error": "operation='place_footprint' requires 'pcb_path'"}
+            if library is None:
+                return {"error": "operation='place_footprint' requires 'library'"}
+            if footprint_name is None:
+                return {"error": "operation='place_footprint' requires 'footprint_name'"}
+            if reference is None:
+                return {"error": "operation='place_footprint' requires 'reference'"}
+            if value is None:
+                return {"error": "operation='place_footprint' requires 'value'"}
+            if x_mm is None:
+                return {"error": "operation='place_footprint' requires 'x_mm'"}
+            if y_mm is None:
+                return {"error": "operation='place_footprint' requires 'y_mm'"}
+            return _op_place_footprint(
+                pcb_path, library, footprint_name, reference, value,
+                x_mm, y_mm, rotation_deg=rotation_deg or 0.0, layer=layer,
+                check_keepouts=check_keepouts,
+            )
+
+        if operation == "move_footprint":
+            if pcb_path is None:
+                return {"error": "operation='move_footprint' requires 'pcb_path'"}
+            if reference is None:
+                return {"error": "operation='move_footprint' requires 'reference'"}
+            if x_mm is None:
+                return {"error": "operation='move_footprint' requires 'x_mm'"}
+            if y_mm is None:
+                return {"error": "operation='move_footprint' requires 'y_mm'"}
+            return _op_move_footprint(
+                pcb_path, reference, x_mm, y_mm,
+                rotation_deg=rotation_deg,
+            )
+
+        if operation == "list_footprints":
+            if pcb_path is None:
+                return {"error": "operation='list_footprints' requires 'pcb_path'"}
+            return _op_list_footprints(pcb_path)
+
+        if operation == "get_pad_positions":
+            if pcb_path is None:
+                return {"error": "operation='get_pad_positions' requires 'pcb_path'"}
+            if reference is None:
+                return {"error": "operation='get_pad_positions' requires 'reference'"}
+            return _op_get_pad_positions(pcb_path, reference)
+
+        if operation == "get_footprint_dimensions":
+            if library is None:
+                return {"error": "operation='get_footprint_dimensions' requires 'library'"}
+            if footprint_name is None:
+                return {"error": "operation='get_footprint_dimensions' requires 'footprint_name'"}
+            return _op_get_footprint_dimensions(library, footprint_name, rotation_deg=rotation_deg or 0.0)
+
+        # ── Nets ───────────────────────────────────────────────────────────
+
+        if operation == "add_net":
+            if pcb_path is None:
+                return {"error": "operation='add_net' requires 'pcb_path'"}
+            if not net_name:
+                return {"error": "operation='add_net' requires 'net_name'"}
+            return _op_add_net(pcb_path, net_name)
+
+        if operation == "rename_net":
+            if pcb_path is None:
+                return {"error": "operation='rename_net' requires 'pcb_path'"}
+            if old_name is None:
+                return {"error": "operation='rename_net' requires 'old_name'"}
+            if new_name is None:
+                return {"error": "operation='rename_net' requires 'new_name'"}
+            return _op_rename_net(pcb_path, old_name, new_name)
+
+        if operation == "list_nets":
+            if pcb_path is None:
+                return {"error": "operation='list_nets' requires 'pcb_path'"}
+            return _op_list_nets(pcb_path)
+
+        if operation == "set_net_class":
+            if pcb_path is None:
+                return {"error": "operation='set_net_class' requires 'pcb_path'"}
+            if class_name is None:
+                return {"error": "operation='set_net_class' requires 'class_name'"}
+            if nets is None:
+                return {"error": "operation='set_net_class' requires 'nets'"}
+            return _op_set_net_class(
+                pcb_path, class_name, nets,
+                track_width_mm=track_width_mm,
+                clearance_mm=clearance_mm,
+                via_diameter_mm=via_diameter_mm,
+                via_drill_mm=via_drill_mm,
+            )
+
+        if operation == "assign_pad_net":
+            if pcb_path is None:
+                return {"error": "operation='assign_pad_net' requires 'pcb_path'"}
+            if reference is None:
+                return {"error": "operation='assign_pad_net' requires 'reference'"}
+            if pad_number is None:
+                return {"error": "operation='assign_pad_net' requires 'pad_number'"}
+            if not net_name:
+                return {"error": "operation='assign_pad_net' requires 'net_name'"}
+            return _op_assign_pad_net(pcb_path, reference, pad_number, net_name)
+
+        if operation == "bulk_assign_pad_nets":
+            if pcb_path is None:
+                return {"error": "operation='bulk_assign_pad_nets' requires 'pcb_path'"}
+            if not assignments:
+                return {"error": "operation='bulk_assign_pad_nets' requires 'assignments'"}
+            return _op_bulk_assign_pad_nets(pcb_path, assignments)
+
+        # ── Routing ────────────────────────────────────────────────────────
+
+        if operation == "add_trace":
+            if pcb_path is None:
+                return {"error": "operation='add_trace' requires 'pcb_path'"}
+            if start_x_mm is None:
+                return {"error": "operation='add_trace' requires 'start_x_mm'"}
+            if start_y_mm is None:
+                return {"error": "operation='add_trace' requires 'start_y_mm'"}
+            if end_x_mm is None:
+                return {"error": "operation='add_trace' requires 'end_x_mm'"}
+            if end_y_mm is None:
+                return {"error": "operation='add_trace' requires 'end_y_mm'"}
+            return _op_add_trace(
+                pcb_path, start_x_mm, start_y_mm, end_x_mm, end_y_mm,
+                width_mm=trace_width_mm, layer=layer, net_name=net_name,
+            )
+
+        if operation == "add_via":
+            if pcb_path is None:
+                return {"error": "operation='add_via' requires 'pcb_path'"}
+            if x_mm is None:
+                return {"error": "operation='add_via' requires 'x_mm'"}
+            if y_mm is None:
+                return {"error": "operation='add_via' requires 'y_mm'"}
+            return _op_add_via(
+                pcb_path, x_mm, y_mm,
+                drill_mm=drill_mm, size_mm=size_mm,
+                net_name=net_name, via_type=via_type,
+            )
+
+        if operation == "clear_routing":
+            if pcb_path is None:
+                return {"error": "operation='clear_routing' requires 'pcb_path'"}
+            return _op_clear_routing(
+                pcb_path,
+                clear_tracks=clear_tracks,
+                clear_vias=clear_vias,
+                clear_zones=clear_zones_flag,
+            )
+
+        if operation == "edit_trace_width":
+            if pcb_path is None:
+                return {"error": "operation='edit_trace_width' requires 'pcb_path'"}
+            if new_width_mm is None:
+                return {"error": "operation='edit_trace_width' requires 'new_width_mm'"}
+            return _op_edit_trace_width(
+                pcb_path, new_width_mm, net_name=net_filter, layer=layer_filter
+            )
+
+        # ── Zones ──────────────────────────────────────────────────────────
+
+        if operation == "add_zone":
+            if pcb_path is None:
+                return {"error": "operation='add_zone' requires 'pcb_path'"}
+            if not net_name:
+                return {"error": "operation='add_zone' requires 'net_name'"}
+            return _op_add_zone(
+                pcb_path, net_name,
+                layer=layer,
+                corners=corners if corners is not None else [],
+                clearance_mm=zone_clearance_mm,
+                min_width_mm=min_width_mm,
+                connect_pads=connect_pads,
+                priority=priority,
+            )
+
+        if operation == "fill_zones":
+            if pcb_path is None:
+                return {"error": "operation='fill_zones' requires 'pcb_path'"}
+            return _op_fill_zones(pcb_path)
+
+        # ── Silkscreen / text ──────────────────────────────────────────────
+
+        if operation == "add_text":
+            if pcb_path is None:
+                return {"error": "operation='add_text' requires 'pcb_path'"}
+            if text is None:
+                return {"error": "operation='add_text' requires 'text'"}
+            if x_mm is None:
+                return {"error": "operation='add_text' requires 'x_mm'"}
+            if y_mm is None:
+                return {"error": "operation='add_text' requires 'y_mm'"}
+            return _op_add_text(
+                pcb_path, text, x_mm, y_mm,
+                layer=layer, size_mm=text_size_mm,
+                thickness_mm=thickness_mm, rotation_deg=rotation_deg or 0.0,
+            )
+
+        if operation == "list_silkscreen":
+            if pcb_path is None:
+                return {"error": "operation='list_silkscreen' requires 'pcb_path'"}
+            return _op_list_silkscreen(pcb_path)
+
+        if operation == "update_silkscreen":
+            if pcb_path is None:
+                return {"error": "operation='update_silkscreen' requires 'pcb_path'"}
+            if reference is None:
+                return {"error": "operation='update_silkscreen' requires 'reference'"}
+            return _op_update_silkscreen(
+                pcb_path, reference,
+                field=silk_field,
+                visible=visible,
+                x_mm=x_mm, y_mm=y_mm,
+                rel_x_mm=rel_x_mm, rel_y_mm=rel_y_mm,
+                size_mm=silk_size_mm,
+                thickness_mm=silk_thickness_mm,
+                angle_deg=angle_deg,
+                layer=silk_layer,
+            )
+
+        if operation == "auto_fix_silkscreen":
+            if pcb_path is None:
+                return {"error": "operation='auto_fix_silkscreen' requires 'pcb_path'"}
+            return _op_auto_fix_silkscreen(pcb_path)
+
+        if operation == "check_silkscreen_overlaps":
+            if pcb_path is None:
+                return {"error": "operation='check_silkscreen_overlaps' requires 'pcb_path'"}
+            return _op_check_silkscreen_overlaps(pcb_path)
+
+        return {
+            "error": (
+                f"unknown operation {operation!r}; "
+                f"valid: create|load|finalize|"
+                f"set_outline|set_design_rules|get_constraints|"
+                f"place_footprint|move_footprint|list_footprints|"
+                f"get_pad_positions|get_footprint_dimensions|"
+                f"add_net|rename_net|list_nets|set_net_class|"
+                f"assign_pad_net|bulk_assign_pad_nets|"
+                f"add_trace|add_via|clear_routing|edit_trace_width|"
+                f"add_zone|fill_zones|"
+                f"add_text|list_silkscreen|update_silkscreen|"
+                f"auto_fix_silkscreen|check_silkscreen_overlaps"
+            )
+        }

--- a/src/kicad_mcp/tools/pcb_board.py
+++ b/src/kicad_mcp/tools/pcb_board.py
@@ -1,30 +1,23 @@
-"""PCB board management tools: load, create, outline, and design rules."""
+"""PCB board management ops: load, create, outline, and design rules.
+
+These are module-level _op_* helpers consumed by the pcb router (pcb.py).
+"""
 
 import logging
 import os
 from typing import Any, Dict, Optional
-
-from fastmcp import FastMCP
 
 from kicad_mcp.utils.pcbnew_bridge import run_pcbnew_script
 
 logger = logging.getLogger(__name__)
 
 
-def register_pcb_board_tools(mcp: FastMCP) -> None:
-    """Register PCB board management tools."""
+def _op_load(pcb_path: str) -> Dict[str, Any]:
+    """Load a .kicad_pcb file and return its summary."""
+    if not os.path.exists(pcb_path):
+        return {"error": f"File not found: {pcb_path}"}
 
-    @mcp.tool()
-    def load_pcb(pcb_path: str) -> Dict[str, Any]:
-        """Load a .kicad_pcb file and return its summary.
-
-        Args:
-            pcb_path: Absolute path to the .kicad_pcb file.
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"File not found: {pcb_path}"}
-
-        script = """
+    script = """
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -54,16 +47,12 @@ print(json.dumps({
     "footprints": fp_list,
 }))
 """
-        return run_pcbnew_script(script, params={"pcb_path": pcb_path})
+    return run_pcbnew_script(script, params={"pcb_path": pcb_path})
 
-    @mcp.tool()
-    def create_pcb(pcb_path: str) -> Dict[str, Any]:
-        """Create a new empty .kicad_pcb file.
 
-        Args:
-            pcb_path: Absolute path for the new PCB file.
-        """
-        script = """
+def _op_create(pcb_path: str) -> Dict[str, Any]:
+    """Create a new empty .kicad_pcb file."""
+    script = """
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -78,32 +67,21 @@ print(json.dumps({
     "file": pcb_path,
 }))
 """
-        return run_pcbnew_script(script, params={"pcb_path": pcb_path})
+    return run_pcbnew_script(script, params={"pcb_path": pcb_path})
 
-    @mcp.tool()
-    def add_board_outline(
-        pcb_path: str,
-        x_mm: float,
-        y_mm: float,
-        width_mm: float,
-        height_mm: float,
-    ) -> Dict[str, Any]:
-        """Add a rectangular board outline (Edge.Cuts) to the PCB.
 
-        Any existing Edge.Cuts segments are removed first, so this can be
-        used to resize the board without creating a new PCB file.
+def _op_set_outline(
+    pcb_path: str,
+    x_mm: float,
+    y_mm: float,
+    width_mm: float,
+    height_mm: float,
+) -> Dict[str, Any]:
+    """Add a rectangular board outline (Edge.Cuts) to the PCB."""
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
 
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-            x_mm: Top-left X position in mm.
-            y_mm: Top-left Y position in mm.
-            width_mm: Board width in mm.
-            height_mm: Board height in mm.
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
-
-        script = """
+    script = """
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -156,52 +134,30 @@ print(json.dumps({
     },
 }))
 """
-        return run_pcbnew_script(script, params={
-            "pcb_path": pcb_path,
-            "x_mm": x_mm,
-            "y_mm": y_mm,
-            "width_mm": width_mm,
-            "height_mm": height_mm,
-        })
+    return run_pcbnew_script(script, params={
+        "pcb_path": pcb_path,
+        "x_mm": x_mm,
+        "y_mm": y_mm,
+        "width_mm": width_mm,
+        "height_mm": height_mm,
+    })
 
-    @mcp.tool()
-    def set_design_rules(
-        pcb_path: str,
-        min_track_width_mm: float = 0.2,
-        min_clearance_mm: float = 0.2,
-        min_via_diameter_mm: float = 0.6,
-        min_via_drill_mm: float = 0.3,
-        min_hole_to_hole_mm: float = 0.25,
-        min_through_hole_diameter_mm: float = 0.3,
-        min_copper_edge_clearance_mm: float = 0.5,
-    ) -> Dict[str, Any]:
-        """Set PCB design rules (DRC constraints).
 
-        Sets rules in both the PCB file (pcbnew design settings) and the
-        project file (.kicad_pro DRC rules section).  The project file rules
-        control DRC checks that pcbnew's DesignSettings doesn't cover, such
-        as ``min_through_hole_diameter`` (needed for ESP32 thermal vias at
-        0.2mm) and ``min_copper_edge_clearance`` (needed for edge-mounted
-        connectors).
+def _op_set_design_rules(
+    pcb_path: str,
+    min_track_width_mm: float = 0.2,
+    min_clearance_mm: float = 0.2,
+    min_via_diameter_mm: float = 0.6,
+    min_via_drill_mm: float = 0.3,
+    min_hole_to_hole_mm: float = 0.25,
+    min_through_hole_diameter_mm: float = 0.3,
+    min_copper_edge_clearance_mm: float = 0.5,
+) -> Dict[str, Any]:
+    """Set PCB design rules (DRC constraints)."""
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
 
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-            min_track_width_mm: Minimum track width in mm (default 0.2).
-            min_clearance_mm: Minimum clearance between copper in mm (default 0.2).
-            min_via_diameter_mm: Minimum via pad diameter in mm (default 0.6).
-            min_via_drill_mm: Minimum via drill diameter in mm (default 0.3).
-            min_hole_to_hole_mm: Minimum hole-to-hole distance in mm (default 0.25).
-            min_through_hole_diameter_mm: Minimum through-hole drill diameter
-                in mm (default 0.3).  Set to 0.15 for boards with ESP32 modules
-                (their thermal vias use 0.2mm drills).
-            min_copper_edge_clearance_mm: Minimum clearance from copper to board
-                edge in mm (default 0.5).  Set to 0.0 for boards with edge-mounted
-                connectors (USB-C, Phoenix terminals).
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
-
-        script = """
+    script = """
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -232,70 +188,242 @@ print(json.dumps({
     },
 }))
 """
-        result = run_pcbnew_script(script, params={
-            "pcb_path": pcb_path,
-            "min_track_width_mm": min_track_width_mm,
-            "min_clearance_mm": min_clearance_mm,
-            "min_via_diameter_mm": min_via_diameter_mm,
-            "min_via_drill_mm": min_via_drill_mm,
-            "min_hole_to_hole_mm": min_hole_to_hole_mm,
-            "min_through_hole_diameter_mm": min_through_hole_diameter_mm,
-            "min_copper_edge_clearance_mm": min_copper_edge_clearance_mm,
-        })
+    result = run_pcbnew_script(script, params={
+        "pcb_path": pcb_path,
+        "min_track_width_mm": min_track_width_mm,
+        "min_clearance_mm": min_clearance_mm,
+        "min_via_diameter_mm": min_via_diameter_mm,
+        "min_via_drill_mm": min_via_drill_mm,
+        "min_hole_to_hole_mm": min_hole_to_hole_mm,
+        "min_through_hole_diameter_mm": min_through_hole_diameter_mm,
+        "min_copper_edge_clearance_mm": min_copper_edge_clearance_mm,
+    })
 
-        # Also update the .kicad_pro project file DRC rules.
-        # The two parameters min_through_hole_diameter_mm and
-        # min_copper_edge_clearance_mm are NOT applied via pcbnew's
-        # DesignSettings — they only live in .kicad_pro. If the project
-        # file is missing or the write fails, those two values are
-        # silently dropped on the floor; surface that to the caller
-        # rather than echoing them as if applied.
-        stem = os.path.splitext(pcb_path)[0]
-        pro_path = stem + ".kicad_pro"
-        pro_updated = False
-        pro_error: Optional[str] = None
+    # Also update the .kicad_pro project file DRC rules.
+    stem = os.path.splitext(pcb_path)[0]
+    pro_path = stem + ".kicad_pro"
+    pro_updated = False
+    pro_error: Optional[str] = None
 
-        if not os.path.exists(pro_path):
-            pro_error = (
-                f".kicad_pro project file not found at {pro_path}; "
-                "min_through_hole_diameter_mm and min_copper_edge_clearance_mm "
-                "were NOT applied (these live only in the project file)"
+    if not os.path.exists(pro_path):
+        pro_error = (
+            f".kicad_pro project file not found at {pro_path}; "
+            "min_through_hole_diameter_mm and min_copper_edge_clearance_mm "
+            "were NOT applied (these live only in the project file)"
+        )
+    else:
+        try:
+            import json as _json
+            with open(pro_path, "r") as f:
+                project = _json.load(f)
+            rules = (
+                project
+                .setdefault("board", {})
+                .setdefault("design_settings", {})
+                .setdefault("rules", {})
             )
-        else:
-            try:
-                import json as _json
-                with open(pro_path, "r") as f:
-                    project = _json.load(f)
-                # Navigate to board.design_settings.rules
-                rules = (
-                    project
-                    .setdefault("board", {})
-                    .setdefault("design_settings", {})
-                    .setdefault("rules", {})
-                )
-                rules["min_through_hole_diameter"] = min_through_hole_diameter_mm
-                rules["min_copper_edge_clearance"] = min_copper_edge_clearance_mm
-                rules["min_track_width"] = min_track_width_mm
-                rules["min_clearance"] = min_clearance_mm
-                rules["min_hole_to_hole"] = min_hole_to_hole_mm
-                rules["min_via_diameter"] = min_via_diameter_mm
-                with open(pro_path, "w") as f:
-                    _json.dump(project, f, indent=2)
-                    f.write("\n")
-                pro_updated = True
-            except (OSError, ValueError) as e:
-                # OSError = permission/disk/encoding; ValueError = malformed JSON.
-                # Anything else propagates.
-                pro_error = f"Failed to update .kicad_pro: {type(e).__name__}: {e}"
-                logger.warning(pro_error)
+            rules["min_through_hole_diameter"] = min_through_hole_diameter_mm
+            rules["min_copper_edge_clearance"] = min_copper_edge_clearance_mm
+            rules["min_track_width"] = min_track_width_mm
+            rules["min_clearance"] = min_clearance_mm
+            rules["min_hole_to_hole"] = min_hole_to_hole_mm
+            rules["min_via_diameter"] = min_via_diameter_mm
+            with open(pro_path, "w") as f:
+                _json.dump(project, f, indent=2)
+                f.write("\n")
+            pro_updated = True
+        except (OSError, ValueError) as e:
+            pro_error = f"Failed to update .kicad_pro: {type(e).__name__}: {e}"
+            logger.warning(pro_error)
 
-        if isinstance(result, dict) and "error" not in result:
-            result["project_rules_updated"] = pro_updated
-            if pro_updated:
-                result["project_file"] = pro_path
-            if pro_error is not None:
-                # Surface the partial-failure so the caller knows two of the
-                # seven params didn't apply.
-                result["project_rules_warning"] = pro_error
+    if isinstance(result, dict) and "error" not in result:
+        result["project_rules_updated"] = pro_updated
+        if pro_updated:
+            result["project_file"] = pro_path
+        if pro_error is not None:
+            result["project_rules_warning"] = pro_error
 
-        return result
+    return result
+
+
+def _op_finalize(
+    pcb_path: str,
+    fix_silkscreen: bool = True,
+    fill_zones: bool = True,
+) -> Dict[str, Any]:
+    """Fix silkscreen overlaps and fill copper zones in one operation."""
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
+
+    script = """
+import pcbnew, json, sys
+
+params = json.loads(open(sys.argv[1]).read())
+pcb_path = params["pcb_path"]
+
+board = pcbnew.LoadBoard(pcb_path)
+results = {}
+
+# ── Silkscreen fix ────────────────────────────────────────────────────────────
+if params["fix_silkscreen"]:
+    silk_layer_ids = [board.GetLayerID("F.SilkS"), board.GetLayerID("B.SilkS")]
+
+    all_pads = []
+    for fp in board.GetFootprints():
+        for pad in fp.Pads():
+            sz = pad.GetBoundingBox()
+            all_pads.append({
+                "reference": fp.GetReference(),
+                "x_min": sz.GetX(), "y_min": sz.GetY(),
+                "x_max": sz.GetRight(), "y_max": sz.GetBottom(),
+            })
+
+    # Collect all visible silk text objects for text-vs-text checking
+    all_silk = []
+    for fp in board.GetFootprints():
+        _ref = fp.GetReference()
+        for _ft, _fo in [("reference", fp.Reference()), ("value", fp.Value())]:
+            if not _fo.IsVisible() or _fo.GetLayer() not in silk_layer_ids:
+                continue
+            all_silk.append({"component": _ref, "obj": _fo, "layer": _fo.GetLayer()})
+    for drawing in board.GetDrawings():
+        if hasattr(drawing, 'GetText') and drawing.GetLayer() in silk_layer_ids:
+            _vis = drawing.IsVisible() if hasattr(drawing, 'IsVisible') else True
+            if _vis:
+                all_silk.append({"component": None, "obj": drawing, "layer": drawing.GetLayer()})
+
+    try:
+        board_bb = board.GetBoardEdgesBoundingBox()
+        board_valid = board_bb.GetWidth() > 0
+    except Exception:
+        board_valid = False
+
+    def _aabb_hit(a, bx_min, by_min, bx_max, by_max):
+        # Non-strict: touching edges count as overlap (matches KiCad DRC).
+        return (a.GetX() <= bx_max and a.GetRight() >= bx_min and
+                a.GetY() <= by_max and a.GetBottom() >= by_min)
+
+    def has_pad_overlap(text_bbox, own_ref):
+        for pad in all_pads:
+            if pad["reference"] == own_ref:
+                continue
+            if _aabb_hit(text_bbox, pad["x_min"], pad["y_min"], pad["x_max"], pad["y_max"]):
+                return True
+        return False
+
+    def has_text_overlap(text_bbox, own_ref, own_layer, own_obj):
+        for si in all_silk:
+            if si["obj"] is own_obj:
+                continue
+            if si["component"] is not None and si["component"] == own_ref:
+                continue
+            if si["layer"] != own_layer:
+                continue
+            if not si["obj"].IsVisible() if hasattr(si["obj"], 'IsVisible') else False:
+                continue
+            ob = si["obj"].GetBoundingBox()
+            if _aabb_hit(text_bbox, ob.GetX(), ob.GetY(), ob.GetRight(), ob.GetBottom()):
+                return True
+        return False
+
+    def has_any_overlap(text_bbox, own_ref, own_layer, own_obj):
+        return has_pad_overlap(text_bbox, own_ref) or has_text_overlap(text_bbox, own_ref, own_layer, own_obj)
+
+    def in_board(text_bbox):
+        if not board_valid:
+            return True
+        return (board_bb.GetX() <= text_bbox.GetX() and
+                text_bbox.GetRight() <= board_bb.GetRight() and
+                board_bb.GetY() <= text_bbox.GetY() and
+                text_bbox.GetBottom() <= board_bb.GetBottom())
+
+    MARGIN = pcbnew.FromMM(0.3)
+    silk_fixed = []
+    silk_hidden = []
+    silk_ok = 0
+
+    for fp in board.GetFootprints():
+        ref = fp.GetReference()
+        for field_type, field_obj in [("reference", fp.Reference()), ("value", fp.Value())]:
+            if not field_obj.IsVisible():
+                continue
+            if field_obj.GetLayer() not in silk_layer_ids:
+                continue
+            text_bbox = field_obj.GetBoundingBox()
+            own_layer = field_obj.GetLayer()
+            _has_overlap = has_any_overlap(text_bbox, ref, own_layer, field_obj)
+            _clips_edge = not in_board(text_bbox)
+            if not _has_overlap and not _clips_edge:
+                silk_ok += 1
+                continue
+
+            fp_bb = fp.GetBoundingBox()
+            cx  = fp_bb.GetCenter().x
+            cy  = fp_bb.GetCenter().y
+            fw2 = fp_bb.GetWidth()  // 2
+            fh2 = fp_bb.GetHeight() // 2
+            tw2 = text_bbox.GetWidth()  // 2
+            th2 = text_bbox.GetHeight() // 2
+
+            candidates = [
+                (cx,           cy - fh2 - th2 - MARGIN),
+                (cx,           cy + fh2 + th2 + MARGIN),
+                (cx - fw2 - tw2 - MARGIN, cy),
+                (cx + fw2 + tw2 + MARGIN, cy),
+                (cx - fw2 - tw2 - MARGIN, cy - fh2 - th2 - MARGIN),
+                (cx + fw2 + tw2 + MARGIN, cy - fh2 - th2 - MARGIN),
+                (cx - fw2 - tw2 - MARGIN, cy + fh2 + th2 + MARGIN),
+                (cx + fw2 + tw2 + MARGIN, cy + fh2 + th2 + MARGIN),
+            ]
+
+            orig_pos = field_obj.GetPosition()
+            resolved = False
+            for px, py in candidates:
+                field_obj.SetPosition(pcbnew.VECTOR2I(int(px), int(py)))
+                new_bbox = field_obj.GetBoundingBox()
+                if not has_any_overlap(new_bbox, ref, own_layer, field_obj) and in_board(new_bbox):
+                    resolved = True
+                    pos = field_obj.GetPosition()
+                    silk_fixed.append({"component": ref, "field": field_type,
+                                        "action": "moved",
+                                        "x_mm": round(pcbnew.ToMM(pos.x), 2),
+                                        "y_mm": round(pcbnew.ToMM(pos.y), 2)})
+                    break
+            if not resolved:
+                field_obj.SetPosition(orig_pos)
+                field_obj.SetVisible(False)
+                silk_hidden.append({"component": ref, "field": field_type, "action": "hidden"})
+
+    results["silkscreen"] = {
+        "already_ok": silk_ok,
+        "moved": len(silk_fixed),
+        "hidden": len(silk_hidden),
+        "fixes": silk_fixed + silk_hidden,
+    }
+
+# ── Zone fill ─────────────────────────────────────────────────────────────────
+if params["fill_zones"]:
+    copper_zones = [z for z in board.Zones() if not z.GetIsRuleArea()]
+    if copper_zones:
+        for z in copper_zones:
+            z.UnFill()
+        filler = pcbnew.ZONE_FILLER(board)
+        fill_ok = filler.Fill(board.Zones())
+        zone_info = []
+        for z in copper_zones:
+            ls = z.GetLayerSet()
+            lname = "F.Cu" if ls.Contains(pcbnew.F_Cu) else "B.Cu" if ls.Contains(pcbnew.B_Cu) else "other"
+            zone_info.append({"net": z.GetNetname(), "layer": lname, "filled": z.IsFilled()})
+        results["zones"] = {"fill_success": fill_ok, "zones_filled": len(copper_zones), "zones": zone_info}
+    else:
+        results["zones"] = {"fill_success": True, "zones_filled": 0, "message": "No copper zones"}
+
+board.Save(pcb_path)
+results["status"] = "ok"
+print(json.dumps(results))
+"""
+    return run_pcbnew_script(script, params={
+        "pcb_path": pcb_path,
+        "fix_silkscreen": fix_silkscreen,
+        "fill_zones": fill_zones,
+    }, timeout=120.0)

--- a/src/kicad_mcp/tools/pcb_footprints.py
+++ b/src/kicad_mcp/tools/pcb_footprints.py
@@ -1,61 +1,39 @@
-"""PCB footprint tools: place, move, list, search, and get pad positions."""
+"""PCB footprint ops: place, move, list, pad positions, dimensions.
+
+These are module-level _op_* helpers consumed by the pcb router (pcb.py).
+"""
 
 import logging
 import os
-from typing import Any, Dict, List, Optional
-
-from fastmcp import FastMCP
+from typing import Any, Dict, Optional
 
 from kicad_mcp.utils.pcbnew_bridge import run_pcbnew_script
 from kicad_mcp.utils.keepout_helpers import KEEPOUT_HELPER, LIB_SEARCH_HELPER
 
 logger = logging.getLogger(__name__)
 
+_KEEPOUT_HELPER = KEEPOUT_HELPER
 
-def register_pcb_footprint_tools(mcp: FastMCP) -> None:
-    """Register PCB footprint tools."""
 
-    _KEEPOUT_HELPER = KEEPOUT_HELPER
+def _op_place_footprint(
+    pcb_path: str,
+    library: str,
+    footprint_name: str,
+    reference: str,
+    value: str,
+    x_mm: float,
+    y_mm: float,
+    rotation_deg: float = 0.0,
+    layer: str = "F.Cu",
+    check_keepouts: bool = True,
+) -> Dict[str, Any]:
+    """Place a footprint on the PCB from a KiCad library."""
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
 
-    @mcp.tool()
-    def place_footprint(
-        pcb_path: str,
-        library: str,
-        footprint_name: str,
-        reference: str,
-        value: str,
-        x_mm: float,
-        y_mm: float,
-        rotation_deg: float = 0.0,
-        layer: str = "F.Cu",
-        check_keepouts: bool = True,
-    ) -> Dict[str, Any]:
-        """Place a footprint on the PCB from a KiCad library.
-
-        By default, checks the proposed position against keepout zones and
-        board boundaries before placing. If violations are found, the
-        footprint is still placed but warnings are included in the result.
-
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-            library: Footprint library name (e.g., "Resistor_THT").
-            footprint_name: Footprint name within the library.
-            reference: Component reference (e.g., "R1").
-            value: Component value (e.g., "330").
-            x_mm: X position in millimeters.
-            y_mm: Y position in millimeters.
-            rotation_deg: Rotation angle in degrees (default 0).
-            layer: PCB layer, "F.Cu" or "B.Cu" (default "F.Cu").
-            check_keepouts: Check placement against keepout zones and board
-                boundaries (default True). Warnings are included in the result
-                but do not prevent placement.
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
-
-        keepout_code = ""
-        if check_keepouts:
-            keepout_code = """
+    keepout_code = ""
+    if check_keepouts:
+        keepout_code = """
 """ + _KEEPOUT_HELPER + """
 
 # Check placement against keepout zones and board boundary
@@ -101,7 +79,7 @@ elif not rect_inside(fp_rect, outline):
     )
 """
 
-        script = """
+    script = """
 import pcbnew, json, os, glob, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -152,13 +130,6 @@ bbox_info = {
     "height_mm": round(pcbnew.ToMM(bbox.GetHeight()), 2),
 }
 
-# Try to get courtyard specifically (tighter than body bbox).
-# Earlier code called `fp.GetBoundingBox(False, True)` and labelled it
-# "only courtyard", but the second argument is `aIncludeText` (or
-# similar across KiCad versions), NOT a courtyard filter — the result
-# is the body bbox, not a courtyard bbox. Iterate GraphicalItems and
-# filter by CrtYd layer (same approach as the keepout_helpers
-# COURTYARD_BBOX_HELPER).
 cy_x_min = float("inf"); cy_y_min = float("inf")
 cy_x_max = float("-inf"); cy_y_max = float("-inf")
 cy_found = False
@@ -197,39 +168,31 @@ if placement_warnings:
     result["placement_warnings"] = placement_warnings
 print(json.dumps(result))
 """
-        return run_pcbnew_script(script, params={
-            "pcb_path": pcb_path,
-            "library": library,
-            "footprint_name": footprint_name,
-            "reference": reference,
-            "value": value,
-            "x_mm": x_mm,
-            "y_mm": y_mm,
-            "rotation_deg": rotation_deg,
-            "layer": layer,
-        })
+    return run_pcbnew_script(script, params={
+        "pcb_path": pcb_path,
+        "library": library,
+        "footprint_name": footprint_name,
+        "reference": reference,
+        "value": value,
+        "x_mm": x_mm,
+        "y_mm": y_mm,
+        "rotation_deg": rotation_deg,
+        "layer": layer,
+    })
 
-    @mcp.tool()
-    def move_footprint(
-        pcb_path: str,
-        reference: str,
-        x_mm: float,
-        y_mm: float,
-        rotation_deg: Optional[float] = None,
-    ) -> Dict[str, Any]:
-        """Move a footprint to a new position on the PCB.
 
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-            reference: Component reference (e.g., "R1").
-            x_mm: New X position in millimeters.
-            y_mm: New Y position in millimeters.
-            rotation_deg: New rotation in degrees (None to keep current).
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
+def _op_move_footprint(
+    pcb_path: str,
+    reference: str,
+    x_mm: float,
+    y_mm: float,
+    rotation_deg: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Move a footprint to a new position on the PCB."""
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
 
-        script = """
+    script = """
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -292,25 +255,21 @@ if placement_warnings:
     result["placement_warnings"] = placement_warnings
 print(json.dumps(result))
 """
-        return run_pcbnew_script(script, params={
-            "pcb_path": pcb_path,
-            "reference": reference,
-            "x_mm": x_mm,
-            "y_mm": y_mm,
-            "rotation_deg": rotation_deg,
-        })
+    return run_pcbnew_script(script, params={
+        "pcb_path": pcb_path,
+        "reference": reference,
+        "x_mm": x_mm,
+        "y_mm": y_mm,
+        "rotation_deg": rotation_deg,
+    })
 
-    @mcp.tool()
-    def list_pcb_footprints(pcb_path: str) -> Dict[str, Any]:
-        """List all footprints currently placed on the PCB.
 
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
+def _op_list_footprints(pcb_path: str) -> Dict[str, Any]:
+    """List all footprints currently placed on the PCB."""
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
 
-        script = """
+    script = """
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -326,8 +285,6 @@ PAD_SHAPE = {
     pcbnew.PAD_SHAPE_ROUNDRECT: "roundrect",
     pcbnew.PAD_SHAPE_CHAMFERED_RECT: "chamfered_rect",
 }
-# Newer KiCad versions add shapes (CUSTOM polygon, etc.) — track them
-# so callers can detect when the script encountered an unmapped shape.
 unknown_pad_shapes = set()
 
 fp_list = []
@@ -338,10 +295,6 @@ for fp in board.GetFootprints():
         pad_pos = pad.GetPosition()
         size = pad.GetSize()
         drill = pad.GetDrillSize()
-        # Collect copper layer names this pad covers. Iterate the layer
-        # set directly rather than the F_Cu..B_Cu integer range, which
-        # would also produce names for any non-copper layer that happens
-        # to fall in that integer range on future KiCad versions.
         lset = pad.GetLayerSet()
         copper_layers = [
             board.GetLayerName(lid)
@@ -362,7 +315,6 @@ for fp in board.GetFootprints():
             "size_y_mm": round(pcbnew.ToMM(size.y), 3),
             "copper_layers": copper_layers,
         }
-        # Drill info only for through-hole pads
         if drill.x > 0:
             pad_info["drill_x_mm"] = round(pcbnew.ToMM(drill.x), 3)
             pad_info["drill_y_mm"] = round(pcbnew.ToMM(drill.y), 3)
@@ -385,28 +337,18 @@ _out = {
     "footprints": fp_list,
 }
 if unknown_pad_shapes:
-    # Newer KiCad shapes (CUSTOM polygon etc.) showed up — record so a
-    # downstream maintainer can add them to PAD_SHAPE explicitly.
     _out["unknown_pad_shape_ids"] = sorted(unknown_pad_shapes)
 print(json.dumps(_out))
 """
-        return run_pcbnew_script(script, params={"pcb_path": pcb_path})
+    return run_pcbnew_script(script, params={"pcb_path": pcb_path})
 
-    @mcp.tool()
-    def get_pad_positions(
-        pcb_path: str,
-        reference: str,
-    ) -> Dict[str, Any]:
-        """Get all pad positions for a footprint.
 
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-            reference: Component reference (e.g., "R1").
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
+def _op_get_pad_positions(pcb_path: str, reference: str) -> Dict[str, Any]:
+    """Get all pad positions for a footprint."""
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
 
-        script = """
+    script = """
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -438,34 +380,19 @@ print(json.dumps({
     "pads": pads,
 }))
 """
-        return run_pcbnew_script(script, params={
-            "pcb_path": pcb_path,
-            "reference": reference,
-        })
+    return run_pcbnew_script(script, params={
+        "pcb_path": pcb_path,
+        "reference": reference,
+    })
 
-    @mcp.tool()
-    def get_footprint_dimensions(
-        library: str,
-        footprint_name: str,
-        rotation_deg: float = 0.0,
-    ) -> Dict[str, Any]:
-        """Query a footprint's bounding box, pad span, and embedded keepout zones.
 
-        Loads the footprint from the KiCad library WITHOUT placing it on a PCB.
-        Use this BEFORE placing components to plan layout with actual dimensions
-        rather than guessing.  Returns body bounding box, courtyard, pad span
-        (extent of actual copper pads), and any embedded keepout zones (like
-        the ESP32 antenna keepout).
-
-        All dimensions are relative to the footprint origin (0,0) with the
-        specified rotation applied.
-
-        Args:
-            library: Footprint library name (e.g., "RF_Module").
-            footprint_name: Footprint name (e.g., "ESP32-WROOM-32E").
-            rotation_deg: Rotation to apply before measuring (default 0).
-        """
-        script = """
+def _op_get_footprint_dimensions(
+    library: str,
+    footprint_name: str,
+    rotation_deg: float = 0.0,
+) -> Dict[str, Any]:
+    """Query a footprint's bounding box, pad span, and embedded keepout zones."""
+    script = """
 import pcbnew, json, os, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -505,7 +432,6 @@ cx_min = float("inf"); cy_min = float("inf")
 cx_max = float("-inf"); cy_max = float("-inf")
 found_cy = False
 for item in fp.GraphicalItems():
-    # Check both front and back courtyard via layer ID directly.
     ly = item.GetLayer()
     if ly in (pcbnew.F_CrtYd, pcbnew.B_CrtYd):
         found_cy = True
@@ -583,8 +509,8 @@ if keepouts:
     result["keepout_count"] = len(keepouts)
 print(json.dumps(result))
 """
-        return run_pcbnew_script(script, params={
-            "library": library,
-            "footprint_name": footprint_name,
-            "rotation_deg": rotation_deg,
-        })
+    return run_pcbnew_script(script, params={
+        "library": library,
+        "footprint_name": footprint_name,
+        "rotation_deg": rotation_deg,
+    })

--- a/src/kicad_mcp/tools/pcb_keepout.py
+++ b/src/kicad_mcp/tools/pcb_keepout.py
@@ -19,6 +19,10 @@ from kicad_mcp.utils.keepout_helpers import (
 
 logger = logging.getLogger(__name__)
 
+# Shared impl: check_silkscreen_overlaps lives in pcb_silkscreen so the pcb
+# router can use the same function without duplicating it.
+from kicad_mcp.tools.pcb_silkscreen import _op_check_silkscreen_overlaps  # noqa: E402
+
 # ---------------------------------------------------------------------------
 # Module-level helper string constants (embedded in pcbnew subprocess scripts)
 # ---------------------------------------------------------------------------
@@ -1222,6 +1226,11 @@ def register_pcb_keepout_tools(mcp: FastMCP) -> None:
                   effective_placement_area_mm2?}
                  Board outline + keepouts + design rules in one call. Use before
                  placement decisions to understand available area.
+
+          check_silkscreen_overlaps(pcb_path)
+              -> {status, silk_items_checked, pads_checked, overlap_count, overlaps,
+                  text_overlap_count, text_overlaps}
+                 Shared implementation with pcb.check_silkscreen_overlaps.
         """
         if detail not in ("summary", "full"):
             return {"error": f"detail must be 'summary' or 'full', got {detail!r}"}
@@ -1291,10 +1300,16 @@ def register_pcb_keepout_tools(mcp: FastMCP) -> None:
                 return {"error": "operation='constraints' requires 'pcb_path'"}
             return _op_constraints(pcb_path)
 
+        if operation == "check_silkscreen_overlaps":
+            if pcb_path is None:
+                return {"error": "operation='check_silkscreen_overlaps' requires 'pcb_path'"}
+            return _op_check_silkscreen_overlaps(pcb_path)
+
         return {
             "error": (
                 f"unknown operation {operation!r}; "
                 f"valid: all|placement|footprint_overlaps|pad_clearances|"
-                f"validate_one|auto_fix_placement|keepouts|pre_route_check|constraints"
+                f"validate_one|auto_fix_placement|keepouts|pre_route_check|"
+                f"constraints|check_silkscreen_overlaps"
             )
         }

--- a/src/kicad_mcp/tools/pcb_nets.py
+++ b/src/kicad_mcp/tools/pcb_nets.py
@@ -1,124 +1,83 @@
-"""PCB net tools: add, assign, bulk assign, list, net classes, and sync from schematic."""
+"""PCB net ops: add, assign, bulk assign, list, net classes, and sync from schematic.
+
+These are module-level _op_* helpers consumed by the pcb router (pcb.py).
+"""
 
 import json as _json
 import logging
 import os
 from typing import Any, Dict, List, Optional
 
-from fastmcp import FastMCP
-
 from kicad_mcp.utils.pcbnew_bridge import run_pcbnew_script
 
 logger = logging.getLogger(__name__)
 
 
-def register_pcb_net_tools(mcp: FastMCP) -> None:
-    """Register PCB net tools."""
+def _op_add_net(pcb_path: str, net_name: str) -> Dict[str, Any]:
+    """Add a named net to the PCB (direct file editing)."""
+    import re as _re
 
-    @mcp.tool()
-    def add_net(
-        pcb_path: str,
-        net_name: str,
-    ) -> Dict[str, Any]:
-        """Add a named net to the PCB.
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
+    if not net_name:
+        return {"error": "net_name must not be empty"}
+    if '"' in net_name or "\\" in net_name or "\n" in net_name or "\r" in net_name:
+        return {"error": f"net_name contains characters that require S-expression escaping: {net_name!r}"}
 
-        Uses direct file editing because pcbnew's Save() prunes nets
-        that have no pads, tracks, or zones referencing them.
+    with open(pcb_path, "r") as f:
+        content = f.read()
 
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-            net_name: Name for the net (e.g., "+3V3", "GND", "SDA").
-        """
-        import re as _re
-
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
-        # D: input validation — refuse net names with characters that would
-        # require S-expression escaping. We don't currently know whether
-        # KiCad permits any of these in net names; rejecting up-front means
-        # we never write a name our regex reader can't round-trip.
-        if not net_name:
-            return {"error": "net_name must not be empty"}
-        if '"' in net_name or "\\" in net_name or "\n" in net_name or "\r" in net_name:
-            return {"error": f"net_name contains characters that require S-expression escaping: {net_name!r}"}
-
-        with open(pcb_path, "r") as f:
-            content = f.read()
-
-        # Check if net already exists. Single search with capture group —
-        # the previous code did two searches (existence + extraction) with
-        # a fallback `-1` sentinel that was returned to the caller as a
-        # valid net_code, hiding any inconsistency between the two regexes.
-        escaped_name = _re.escape(net_name)
-        match = _re.search(rf'\(net\s+(\d+)\s+"{escaped_name}"\)', content)
-        if match:
-            return {
-                "status": "ok",
-                "net": net_name,
-                "net_code": int(match.group(1)),
-                "note": "Net already exists",
-            }
-
-        # Find the highest existing net code
-        net_codes = [int(m.group(1)) for m in _re.finditer(r'\(net\s+(\d+)\s+"', content)]
-        next_code = max(net_codes) + 1 if net_codes else 1
-
-        # Insert the new net definition after the last existing net line
-        # Net definitions appear as: (net 0 "")  (net 1 "VCC")  etc.
-        last_net_match = None
-        # Allow \" escape sequences inside the net name. Bare `[^"]*` would
-        # match through an unescaped `"` mid-name and produce a malformed
-        # extraction; this S-expression-string-aware form handles any net
-        # name our writer might encounter (defense in depth — add_net's
-        # input validation refuses to WRITE such names, but third-party
-        # PCB files may already contain them).
-        for m in _re.finditer(r'\(net\s+\d+\s+"(?:[^"\\]|\\.)*"\)', content):
-            last_net_match = m
-
-        if last_net_match:
-            insert_pos = last_net_match.end()
-        else:
-            # KiCad 10 omits the default (net 0 "") line in fresh PCBs.
-            # Fall back to inserting before the first footprint (or before the
-            # file's closing paren if there are no footprints yet).
-            fp_match = _re.search(r'\n\t\(footprint\b', content)
-            if fp_match:
-                insert_pos = fp_match.start()
-            else:
-                insert_pos = content.rfind('\n)')
-                if insert_pos == -1:
-                    return {"error": "Could not find insertion point in PCB file"}
-        new_net_line = f'\n\t(net {next_code} "{net_name}")'
-        content = content[:insert_pos] + new_net_line + content[insert_pos:]
-
-        with open(pcb_path, "w") as f:
-            f.write(content)
-
+    escaped_name = _re.escape(net_name)
+    match = _re.search(rf'\(net\s+(\d+)\s+"{escaped_name}"\)', content)
+    if match:
         return {
             "status": "ok",
             "net": net_name,
-            "net_code": next_code,
+            "net_code": int(match.group(1)),
+            "note": "Net already exists",
         }
 
-    @mcp.tool()
-    def assign_pad_net(
-        pcb_path: str,
-        reference: str,
-        pad_number: str,
-        net_name: str,
-    ) -> Dict[str, Any]:
-        """Assign a net to a specific pad on a footprint.
+    net_codes = [int(m.group(1)) for m in _re.finditer(r'\(net\s+(\d+)\s+"', content)]
+    next_code = max(net_codes) + 1 if net_codes else 1
 
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-            reference: Component reference (e.g., "R1").
-            pad_number: Pad number (e.g., "1", "2").
-            net_name: Net name to assign.
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
+    last_net_match = None
+    for m in _re.finditer(r'\(net\s+\d+\s+"(?:[^"\\]|\\.)*"\)', content):
+        last_net_match = m
 
-        script = """
+    if last_net_match:
+        insert_pos = last_net_match.end()
+    else:
+        fp_match = _re.search(r'\n\t\(footprint\b', content)
+        if fp_match:
+            insert_pos = fp_match.start()
+        else:
+            insert_pos = content.rfind('\n)')
+            if insert_pos == -1:
+                return {"error": "Could not find insertion point in PCB file"}
+    new_net_line = f'\n\t(net {next_code} "{net_name}")'
+    content = content[:insert_pos] + new_net_line + content[insert_pos:]
+
+    with open(pcb_path, "w") as f:
+        f.write(content)
+
+    return {
+        "status": "ok",
+        "net": net_name,
+        "net_code": next_code,
+    }
+
+
+def _op_assign_pad_net(
+    pcb_path: str,
+    reference: str,
+    pad_number: str,
+    net_name: str,
+) -> Dict[str, Any]:
+    """Assign a net to a specific pad on a footprint."""
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
+
+    script = """
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -159,33 +118,26 @@ print(json.dumps({
     "sub_pads": pad_count,
 }))
 """
-        return run_pcbnew_script(script, params={
-            "pcb_path": pcb_path,
-            "reference": reference,
-            "pad_number": pad_number,
-            "net_name": net_name,
-        })
+    return run_pcbnew_script(script, params={
+        "pcb_path": pcb_path,
+        "reference": reference,
+        "pad_number": pad_number,
+        "net_name": net_name,
+    })
 
-    @mcp.tool()
-    def bulk_assign_pad_nets(
-        pcb_path: str,
-        assignments: Optional[List[Dict[str, str]]] = None,
-    ) -> Dict[str, Any]:
-        """Assign nets to multiple pads in a single operation.
 
-        Each assignment is a dict with "reference", "pad", and "net" keys.
+def _op_bulk_assign_pad_nets(
+    pcb_path: str,
+    assignments: Optional[List[Dict[str, str]]] = None,
+) -> Dict[str, Any]:
+    """Assign nets to multiple pads in a single operation."""
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
 
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-            assignments: List of {"reference": "R1", "pad": "1", "net": "GND"} dicts.
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
+    if not assignments:
+        return {"error": "No assignments provided"}
 
-        if not assignments:
-            return {"error": "No assignments provided"}
-
-        script = """
+    script = """
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -210,7 +162,6 @@ for a in assignments:
 
     net = board.FindNet(net_name)
     if net is None or net.GetNetCode() == 0:
-        # Auto-create missing nets — they persist because pads reference them
         net_info = pcbnew.NETINFO_ITEM(board, net_name)
         board.Add(net_info)
         net = board.FindNet(net_name)
@@ -231,9 +182,6 @@ for a in assignments:
 
 board.Save(pcb_path)
 
-# Status reflects whether ALL assignments succeeded. A caller that only
-# checks status==ok would otherwise miss partial failures buried in the
-# errors list.
 if not errors:
     out_status = "ok"
 elif results:
@@ -250,84 +198,59 @@ print(json.dumps({
     "results": results,
 }))
 """
-        return run_pcbnew_script(script, params={
-            "pcb_path": pcb_path,
-            "assignments": assignments,
-        })
+    return run_pcbnew_script(script, params={
+        "pcb_path": pcb_path,
+        "assignments": assignments,
+    })
 
-    @mcp.tool()
-    def rename_net(
-        pcb_path: str,
-        old_name: str,
-        new_name: str,
-    ) -> Dict[str, Any]:
-        """Rename a net across the entire PCB.
 
-        Updates the net definition and all pad references that embed the net
-        name.  Track and via references store only the net code and need no
-        change.  Uses direct file editing so the rename survives pcbnew's
-        Save() pruning rules.
+def _op_rename_net(pcb_path: str, old_name: str, new_name: str) -> Dict[str, Any]:
+    """Rename a net across the entire PCB."""
+    import re as _re
 
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-            old_name: Current net name.
-            new_name: Replacement net name.
-        """
-        import re as _re
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
+    for name, label in [(old_name, "old_name"), (new_name, "new_name")]:
+        if not name:
+            return {"error": f"{label} must not be empty"}
+        if '"' in name or "\\" in name or "\n" in name or "\r" in name:
+            return {"error": f"{label} contains characters that require S-expression escaping: {name!r}"}
 
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
-        # D: input validation — same rule as add_net (refuse names with
-        # characters that would require S-expression escaping).
-        for name, label in [(old_name, "old_name"), (new_name, "new_name")]:
-            if not name:
-                return {"error": f"{label} must not be empty"}
-            if '"' in name or "\\" in name or "\n" in name or "\r" in name:
-                return {"error": f"{label} contains characters that require S-expression escaping: {name!r}"}
+    with open(pcb_path, "r") as f:
+        content = f.read()
 
-        with open(pcb_path, "r") as f:
-            content = f.read()
+    match = _re.search(r'\(net\s+(\d+)\s+"' + _re.escape(old_name) + r'"\)', content)
+    if not match:
+        return {"error": f"Net '{old_name}' not found in {pcb_path}"}
 
-        # Verify old net exists and get its code
-        match = _re.search(r'\(net\s+(\d+)\s+"' + _re.escape(old_name) + r'"\)', content)
-        if not match:
-            return {"error": f"Net '{old_name}' not found in {pcb_path}"}
+    if old_name == new_name:
+        return {"status": "ok", "old_name": old_name, "new_name": new_name, "replacements": 0}
 
-        if old_name == new_name:
-            return {"status": "ok", "old_name": old_name, "new_name": new_name, "replacements": 0}
+    if _re.search(r'\(net\s+\d+\s+"' + _re.escape(new_name) + r'"\)', content):
+        return {"error": f"Net '{new_name}' already exists — merge not supported"}
 
-        # Check new name doesn't already exist
-        if _re.search(r'\(net\s+\d+\s+"' + _re.escape(new_name) + r'"\)', content):
-            return {"error": f"Net '{new_name}' already exists — merge not supported"}
+    net_code = match.group(1)
+    pattern = r'\(net\s+' + net_code + r'\s+"' + _re.escape(old_name) + r'"\)'
+    new_content, count = _re.subn(pattern, f'(net {net_code} "{new_name}")', content)
 
-        net_code = match.group(1)
-        # Replace all occurrences of (net N "old_name") — covers both the
-        # top-level definition and pad-level references.
-        pattern = r'\(net\s+' + net_code + r'\s+"' + _re.escape(old_name) + r'"\)'
-        new_content, count = _re.subn(pattern, f'(net {net_code} "{new_name}")', content)
+    with open(pcb_path, "w") as f:
+        f.write(new_content)
 
-        with open(pcb_path, "w") as f:
-            f.write(new_content)
+    return {
+        "status": "ok",
+        "old_name": old_name,
+        "new_name": new_name,
+        "net_code": int(net_code),
+        "replacements": count,
+    }
 
-        return {
-            "status": "ok",
-            "old_name": old_name,
-            "new_name": new_name,
-            "net_code": int(net_code),
-            "replacements": count,
-        }
 
-    @mcp.tool()
-    def list_pcb_nets(pcb_path: str) -> Dict[str, Any]:
-        """List all nets in the PCB.
+def _op_list_nets(pcb_path: str) -> Dict[str, Any]:
+    """List all nets in the PCB."""
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
 
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
-
-        script = """
+    script = """
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -349,385 +272,88 @@ print(json.dumps({
     "nets": nets,
 }))
 """
-        return run_pcbnew_script(script, params={"pcb_path": pcb_path})
+    return run_pcbnew_script(script, params={"pcb_path": pcb_path})
 
-    @mcp.tool()
-    def update_pcb_from_schematic(
-        project_path: str,
-    ) -> Dict[str, Any]:
-        """Update PCB nets and pad assignments from the schematic (KiCad F8 equivalent).
 
-        Exports the netlist from the schematic using kicad-cli, then creates
-        all nets in the PCB and assigns them to the correct pads. This replaces
-        the manual process of defining nets and assigning pads one by one.
+def _op_set_net_class(
+    pcb_path: str,
+    class_name: str,
+    nets: List[str],
+    track_width_mm: float = 0.25,
+    clearance_mm: float = 0.2,
+    via_diameter_mm: float = 0.6,
+    via_drill_mm: float = 0.3,
+) -> Dict[str, Any]:
+    """Create or update a net class and assign nets to it."""
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
 
-        Requires that:
-        1. The schematic (.kicad_sch) exists in the project directory
-        2. The PCB (.kicad_pcb) exists in the project directory
-        3. Footprints in the PCB have matching references to the schematic
+    stem = os.path.splitext(pcb_path)[0]
+    pro_path = stem + ".kicad_pro"
+    if not os.path.exists(pro_path):
+        return {"error": f"Project file not found: {pro_path}"}
 
-        Args:
-            project_path: Path to the KiCad project file (.kicad_pro).
-        """
-        if not os.path.exists(project_path):
-            return {"error": f"Project file not found: {project_path}"}
+    with open(pro_path, "r") as f:
+        project = _json.load(f)
 
-        project_dir = os.path.dirname(project_path)
-        project_name = os.path.splitext(os.path.basename(project_path))[0]
-
-        # Find schematic and PCB files
-        sch_path = os.path.join(project_dir, project_name + ".kicad_sch")
-        pcb_path = os.path.join(project_dir, project_name + ".kicad_pcb")
-
-        if not os.path.exists(sch_path):
-            return {"error": f"Schematic file not found: {sch_path}"}
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
-
-        # Extract netlist from schematic via kicad-cli
-        from kicad_mcp.utils.netlist_parser import extract_netlist_via_cli
-
-        netlist_data = extract_netlist_via_cli(sch_path)
-        if netlist_data is None:
-            return {"error": "kicad-cli not available for netlist export"}
-
-        # Convert from extract_netlist_via_cli format to net_definitions + pad_assignments
-        nets = netlist_data.get("nets", {})
-        net_definitions = list(nets.keys())
-        pad_assignments = []
-        for net_name, pins in nets.items():
-            for pin_info in pins:
-                pad_assignments.append({
-                    "reference": pin_info["component"],
-                    "pad": pin_info["pin"],
-                    "net": net_name,
-                    "pinfunction": pin_info.get("pinfunction", ""),
-                })
-
-        if not net_definitions:
-            return {"error": "No nets found in schematic netlist"}
-
-        # Sanity-check: detect obvious power/ground cross-wiring.
-        # Use is_power_net (the canonical classifier) — substring tests on
-        # raw net names (`"VCC" in net`) would false-positive on names
-        # like `"AVEC"` or `"GND_5V"`.
-        from kicad_mcp.utils.netlist_parser import is_power_net
-        power_ground_warnings = []
-        _GND_FUNCS = {"GND", "VSS", "GNDA", "AGND", "DGND"}
-        _PWR_FUNCS = {"VDD", "VCC", "VIN", "3V3", "5V", "VBUS"}
-        for a in pad_assignments:
-            func = (a.get("pinfunction") or "").upper()
-            net = a["net"]
-            net_is_power = is_power_net(net) and not any(
-                net.upper().startswith(g) for g in ("GND", "VSS")
-            )
-            net_is_ground = any(net.upper().startswith(g) for g in ("GND", "VSS"))
-            if func in _GND_FUNCS and net_is_power:
-                power_ground_warnings.append(
-                    f"{a['reference']} pin {a['pad']} ({func}) → power net {a['net']}"
-                )
-            elif func in _PWR_FUNCS and net_is_ground:
-                power_ground_warnings.append(
-                    f"{a['reference']} pin {a['pad']} ({func}) → ground net {a['net']}"
-                )
-
-        # Detect suspiciously large nets (likely schematic wiring errors)
-        LARGE_NET_THRESHOLD = 30
-        for net_name, pins in nets.items():
-            if len(pins) > LARGE_NET_THRESHOLD:
-                # Collect distinct pin functions on this net
-                funcs = set()
-                for p in pins:
-                    f = (p.get("pinfunction") or "").upper()
-                    if f:
-                        funcs.add(f)
-                # If a net has both power and ground pin functions, it's shorted
-                has_gnd = any(f in ("GND", "VSS", "GNDA") for f in funcs)
-                has_pwr = any(
-                    f in ("VDD", "VCC", "VIN", "3V3", "5V", "VBUS") for f in funcs
-                )
-                severity = "ERROR: power/ground short" if (has_gnd and has_pwr) else "WARNING"
-                power_ground_warnings.append(
-                    f"{severity}: net '{net_name}' has {len(pins)} nodes "
-                    f"(functions: {', '.join(sorted(funcs)) or 'none'}). "
-                    f"Check schematic for unintended connections."
-                )
-
-        # Detect missing expected power/ground nets.
-        # Recognise GND under any conventional name (GND, AGND, DGND, VSS, etc.)
-        # — checking only for the literal "GND" net name would false-alarm on
-        # designs that use AGND/DGND as their only ground.
-        all_funcs = set()
-        for a in pad_assignments:
-            f = (a.get("pinfunction") or "").upper()
-            if f:
-                all_funcs.add(f)
-        net_names_upper = {n.upper() for n in net_definitions}
-        if any(f in _GND_FUNCS for f in all_funcs):
-            has_ground_net = any(
-                n.startswith(("GND", "VSS")) for n in net_names_upper
-            )
-            if not has_ground_net:
-                power_ground_warnings.append(
-                    "WARNING: design has GND-function pins but no GND/VSS net. "
-                    "GND may be absorbed into another net due to schematic wiring error."
-                )
-
-        # Step 3: Inject nets into PCB file via direct editing
-        # (pcbnew's Save() prunes unused nets, so we must inject them
-        # into the file first, then use pcbnew for pad assignments)
-        import re as _re
-
-        with open(pcb_path, "r") as f:
-            pcb_content = f.read()
-
-        # Find existing nets
-        existing_nets = {}
-        for m in _re.finditer(r'\(net\s+(\d+)\s+"((?:[^"\\]|\\.)*)"\)', pcb_content):
-            existing_nets[m.group(2)] = int(m.group(1))
-
-        # Determine next available net code
-        max_code = max(existing_nets.values()) if existing_nets else 0
-
-        nets_created = []
-        nets_existing = []
-        skipped_unconnected = []
-
-        for net_name in net_definitions:
-            if net_name in existing_nets:
-                nets_existing.append(net_name)
-            else:
-                max_code += 1
-                existing_nets[net_name] = max_code
-                nets_created.append(net_name)
-
-        # Insert new net definitions into the file
-        if nets_created:
-            # Find the last (net ...) line to insert after
-            last_net_match = None
-            for m in _re.finditer(r'\(net\s+\d+\s+"(?:[^"\\]|\\.)*"\)', pcb_content):
-                last_net_match = m
-
-            if last_net_match:
-                insert_pos = last_net_match.end()
-            else:
-                # KiCad 10 omits the default (net 0 "") line in fresh PCBs.
-                fp_match = _re.search(r'\n\t\(footprint\b', pcb_content)
-                if fp_match:
-                    insert_pos = fp_match.start()
-                else:
-                    insert_pos = pcb_content.rfind('\n)')
-
-            new_lines = ""
-            for net_name in nets_created:
-                code = existing_nets[net_name]
-                new_lines += f'\n\t(net {code} "{net_name}")'
-            pcb_content = (
-                pcb_content[:insert_pos] + new_lines + pcb_content[insert_pos:]
-            )
-
-            with open(pcb_path, "w") as f:
-                f.write(pcb_content)
-
-        # Step 4: Assign nets to pads via pcbnew
-        script = """
-import pcbnew, json, sys
-
-params = json.loads(open(sys.argv[1]).read())
-pcb_path = params["pcb_path"]
-
-board = pcbnew.LoadBoard(pcb_path)
-
-assignments = params["assignments"]
-assigned = []
-assign_errors = []
-
-for a in assignments:
-    ref = a["reference"]
-    pad_num = a["pad"]
-    net_name = a["net"]
-
-    fp = board.FindFootprintByReference(ref)
-    if fp is None:
-        assign_errors.append(f"Footprint {ref} not found in PCB")
-        continue
-
-    net = board.FindNet(net_name)
-    if net is None or net.GetNetCode() == 0:
-        assign_errors.append(f"Net {net_name} not found")
-        continue
-
-    pad_count = 0
-    pinfunc = a.get("pinfunction", "")
-    old_net = ""
-    for pad in fp.Pads():
-        if pad.GetNumber() == pad_num:
-            if pad_count == 0:
-                old_net = pad.GetNetname()
-            pad.SetNet(net)
-            pad_count += 1
-    if pad_count > 0:
-        assigned.append({
-            "reference": ref,
-            "pad": pad_num,
-            "net": net_name,
-            "pinfunction": pinfunc,
-            "old_net": old_net,
-            "sub_pads": pad_count,
-        })
-    else:
-        assign_errors.append(f"Pad {pad_num} not found on {ref}")
-
-board.Save(pcb_path)
-
-# Verify nets
-final_nets = []
-for code, net in board.GetNetsByNetcode().items():
-    if code > 0:
-        final_nets.append(net.GetNetname())
-
-# Build a mapping summary for quick human verification
-# Format: "NET_NAME: REF:pad(function), REF:pad(function), ..."
-net_map = {}
-for a in assigned:
-    net = a["net"]
-    entry = f"{a['reference']}:{a['pad']}"
-    if a.get("pinfunction"):
-        entry += f"({a['pinfunction']})"
-    net_map.setdefault(net, []).append(entry)
-mapping_summary = {net: ", ".join(entries) for net, entries in sorted(net_map.items())}
-
-print(json.dumps({
-    "status": "ok",
-    "total_nets_in_pcb": len(final_nets),
-    "pads_assigned": len(assigned),
-    "pad_assignments": assigned,
-    "assignment_errors": assign_errors,
-    "mapping_summary": mapping_summary,
-}))
-"""
-        pcbnew_result = run_pcbnew_script(script, params={
-            "pcb_path": pcb_path,
-            "assignments": pad_assignments,
-        }, timeout=60.0)
-
-        # Merge file-editing results with pcbnew results
-        pcbnew_result["schematic"] = sch_path
-        pcbnew_result["pcb"] = pcb_path
-        pcbnew_result["nets_created"] = nets_created
-        pcbnew_result["nets_existing"] = nets_existing
-        pcbnew_result["unconnected_nets_skipped"] = skipped_unconnected
-        if power_ground_warnings:
-            pcbnew_result["power_ground_warnings"] = power_ground_warnings
-
-        return pcbnew_result
-
-    @mcp.tool()
-    def set_net_class(
-        pcb_path: str,
-        class_name: str,
-        nets: List[str],
-        track_width_mm: float = 0.25,
-        clearance_mm: float = 0.2,
-        via_diameter_mm: float = 0.6,
-        via_drill_mm: float = 0.3,
-    ) -> Dict[str, Any]:
-        """Create or update a net class and assign nets to it.
-
-        Net classes define per-net routing rules (trace width, clearance, via
-        size).  FreeRouter reads these from the Specctra DSN export and routes
-        each net at the correct width.  Call this BEFORE autoroute_pcb so
-        FreeRouter sees the classes.
-
-        Common usage: create a "Power" class with wider traces for GND/VCC,
-        and leave signal nets on the Default class.
-
-        Net class definitions live in the KiCad project file (.kicad_pro),
-        which must exist alongside the PCB file.
-
-        Args:
-            pcb_path: Path to the .kicad_pcb file.  The .kicad_pro file is
-                derived from this path (same directory, same stem).
-            class_name: Name for the net class (e.g., "Power", "HighSpeed").
-            nets: List of net names to assign to this class.
-            track_width_mm: Trace width in mm (default 0.25).
-            clearance_mm: Clearance to other nets in mm (default 0.2).
-            via_diameter_mm: Via pad diameter in mm (default 0.6).
-            via_drill_mm: Via drill diameter in mm (default 0.3).
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
-
-        # Derive project file path
-        stem = os.path.splitext(pcb_path)[0]
-        pro_path = stem + ".kicad_pro"
-        if not os.path.exists(pro_path):
-            return {"error": f"Project file not found: {pro_path}"}
-
-        with open(pro_path, "r") as f:
-            project = _json.load(f)
-
-        # Ensure net_settings structure exists
-        if "net_settings" not in project:
-            project["net_settings"] = {
-                "classes": [_default_net_class()],
-                "meta": {"version": 4},
-                "net_colors": None,
-                "netclass_assignments": None,
-                "netclass_patterns": [],
-            }
-
-        ns = project["net_settings"]
-        classes = ns.get("classes", [])
-
-        # Find or create the class
-        existing = None
-        for cls in classes:
-            if cls.get("name") == class_name:
-                existing = cls
-                break
-
-        if existing:
-            existing["track_width"] = track_width_mm
-            existing["clearance"] = clearance_mm
-            existing["via_diameter"] = via_diameter_mm
-            existing["via_drill"] = via_drill_mm
-            action = "updated"
-        else:
-            new_class = _default_net_class()
-            new_class["name"] = class_name
-            new_class["track_width"] = track_width_mm
-            new_class["clearance"] = clearance_mm
-            new_class["via_diameter"] = via_diameter_mm
-            new_class["via_drill"] = via_drill_mm
-            classes.append(new_class)
-            ns["classes"] = classes
-            action = "created"
-
-        # Assign nets to this class
-        assignments = ns.get("netclass_assignments") or {}
-        assigned_count = 0
-        for net_name in nets:
-            assignments[net_name] = class_name
-            assigned_count += 1
-        ns["netclass_assignments"] = assignments
-
-        with open(pro_path, "w") as f:
-            _json.dump(project, f, indent=2)
-            f.write("\n")
-
-        return {
-            "status": "ok",
-            "class_name": class_name,
-            "action": action,
-            "track_width_mm": track_width_mm,
-            "clearance_mm": clearance_mm,
-            "via_diameter_mm": via_diameter_mm,
-            "via_drill_mm": via_drill_mm,
-            "nets_assigned": assigned_count,
-            "nets": nets,
-            "project_file": pro_path,
+    if "net_settings" not in project:
+        project["net_settings"] = {
+            "classes": [_default_net_class()],
+            "meta": {"version": 4},
+            "net_colors": None,
+            "netclass_assignments": None,
+            "netclass_patterns": [],
         }
+
+    ns = project["net_settings"]
+    classes = ns.get("classes", [])
+
+    existing = None
+    for cls in classes:
+        if cls.get("name") == class_name:
+            existing = cls
+            break
+
+    if existing:
+        existing["track_width"] = track_width_mm
+        existing["clearance"] = clearance_mm
+        existing["via_diameter"] = via_diameter_mm
+        existing["via_drill"] = via_drill_mm
+        action = "updated"
+    else:
+        new_class = _default_net_class()
+        new_class["name"] = class_name
+        new_class["track_width"] = track_width_mm
+        new_class["clearance"] = clearance_mm
+        new_class["via_diameter"] = via_diameter_mm
+        new_class["via_drill"] = via_drill_mm
+        classes.append(new_class)
+        ns["classes"] = classes
+        action = "created"
+
+    assignments = ns.get("netclass_assignments") or {}
+    assigned_count = 0
+    for net_name in nets:
+        assignments[net_name] = class_name
+        assigned_count += 1
+    ns["netclass_assignments"] = assignments
+
+    with open(pro_path, "w") as f:
+        _json.dump(project, f, indent=2)
+        f.write("\n")
+
+    return {
+        "status": "ok",
+        "class_name": class_name,
+        "action": action,
+        "track_width_mm": track_width_mm,
+        "clearance_mm": clearance_mm,
+        "via_diameter_mm": via_diameter_mm,
+        "via_drill_mm": via_drill_mm,
+        "nets_assigned": assigned_count,
+        "nets": nets,
+        "project_file": pro_path,
+    }
 
 
 def _default_net_class() -> Dict[str, Any]:

--- a/src/kicad_mcp/tools/pcb_routing.py
+++ b/src/kicad_mcp/tools/pcb_routing.py
@@ -1,48 +1,34 @@
-"""PCB routing tools: traces, vias, and routing management."""
+"""PCB routing ops: traces, vias, and routing management.
+
+These are module-level _op_* helpers consumed by the pcb router (pcb.py).
+"""
 
 import logging
 import os
 from typing import Any, Dict
-
-from fastmcp import FastMCP
 
 from kicad_mcp.utils.pcbnew_bridge import run_pcbnew_script
 
 logger = logging.getLogger(__name__)
 
 
-def register_pcb_routing_tools(mcp: FastMCP) -> None:
-    """Register PCB routing tools."""
+def _op_add_trace(
+    pcb_path: str,
+    start_x_mm: float,
+    start_y_mm: float,
+    end_x_mm: float,
+    end_y_mm: float,
+    width_mm: float = 0.25,
+    layer: str = "F.Cu",
+    net_name: str = "",
+) -> Dict[str, Any]:
+    """Add a copper trace between two points on the PCB."""
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
+    if width_mm <= 0:
+        return {"error": f"width_mm must be positive (got {width_mm})"}
 
-    @mcp.tool()
-    def add_trace(
-        pcb_path: str,
-        start_x_mm: float,
-        start_y_mm: float,
-        end_x_mm: float,
-        end_y_mm: float,
-        width_mm: float = 0.25,
-        layer: str = "F.Cu",
-        net_name: str = "",
-    ) -> Dict[str, Any]:
-        """Add a copper trace between two points on the PCB.
-
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-            start_x_mm: Start X position in mm.
-            start_y_mm: Start Y position in mm.
-            end_x_mm: End X position in mm.
-            end_y_mm: End Y position in mm.
-            width_mm: Trace width in mm (default 0.25).
-            layer: Copper layer name (default "F.Cu").
-            net_name: Net name to assign (empty for unassigned).
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
-        if width_mm <= 0:
-            return {"error": f"width_mm must be positive (got {width_mm})"}
-
-        script = """
+    script = """
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -56,10 +42,6 @@ track.SetEnd(pcbnew.VECTOR2I(pcbnew.FromMM(params["end_x_mm"]), pcbnew.FromMM(pa
 track.SetWidth(pcbnew.FromMM(params["width_mm"]))
 track.SetLayer(board.GetLayerID(params["layer"]))
 
-# Net assignment: explicit error if the requested net doesn't exist.
-# Silently dropping the assignment would write an unconnected trace and
-# return status=ok, leaving the caller to discover the problem only when
-# DRC flags an unconnected item.
 net_name = params["net_name"]
 if net_name:
     net = board.FindNet(net_name)
@@ -82,51 +64,41 @@ print(json.dumps({
     },
 }))
 """
-        return run_pcbnew_script(script, params={
-            "pcb_path": pcb_path,
-            "start_x_mm": start_x_mm,
-            "start_y_mm": start_y_mm,
-            "end_x_mm": end_x_mm,
-            "end_y_mm": end_y_mm,
-            "width_mm": width_mm,
-            "layer": layer,
-            "net_name": net_name,
-        })
+    return run_pcbnew_script(script, params={
+        "pcb_path": pcb_path,
+        "start_x_mm": start_x_mm,
+        "start_y_mm": start_y_mm,
+        "end_x_mm": end_x_mm,
+        "end_y_mm": end_y_mm,
+        "width_mm": width_mm,
+        "layer": layer,
+        "net_name": net_name,
+    })
 
-    @mcp.tool()
-    def add_via(
-        pcb_path: str,
-        x_mm: float,
-        y_mm: float,
-        drill_mm: float = 0.3,
-        size_mm: float = 0.6,
-        net_name: str = "",
-        via_type: str = "through",
-    ) -> Dict[str, Any]:
-        """Add a via to the PCB.
 
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-            x_mm: X position in millimeters.
-            y_mm: Y position in millimeters.
-            drill_mm: Drill diameter in mm (default 0.3).
-            size_mm: Via pad diameter in mm (default 0.6).
-            net_name: Net name to assign (empty for unassigned).
-            via_type: Via type - "through", "blind_buried", or "micro" (default "through").
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
-        if drill_mm <= 0:
-            return {"error": f"drill_mm must be positive (got {drill_mm})"}
-        if size_mm <= 0:
-            return {"error": f"size_mm must be positive (got {size_mm})"}
-        if drill_mm >= size_mm:
-            return {"error": f"drill_mm ({drill_mm}) must be less than size_mm ({size_mm}) — a drill ≥ pad means no annular ring"}
-        valid_via_types = ("through", "blind_buried", "micro")
-        if via_type not in valid_via_types:
-            return {"error": f"via_type must be one of {valid_via_types}; got {via_type!r}"}
+def _op_add_via(
+    pcb_path: str,
+    x_mm: float,
+    y_mm: float,
+    drill_mm: float = 0.3,
+    size_mm: float = 0.6,
+    net_name: str = "",
+    via_type: str = "through",
+) -> Dict[str, Any]:
+    """Add a via to the PCB."""
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
+    if drill_mm <= 0:
+        return {"error": f"drill_mm must be positive (got {drill_mm})"}
+    if size_mm <= 0:
+        return {"error": f"size_mm must be positive (got {size_mm})"}
+    if drill_mm >= size_mm:
+        return {"error": f"drill_mm ({drill_mm}) must be less than size_mm ({size_mm}) — a drill >= pad means no annular ring"}
+    valid_via_types = ("through", "blind_buried", "micro")
+    if via_type not in valid_via_types:
+        return {"error": f"via_type must be one of {valid_via_types}; got {via_type!r}"}
 
-        script = """
+    script = """
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -139,8 +111,6 @@ via.SetPosition(pcbnew.VECTOR2I(pcbnew.FromMM(params["x_mm"]), pcbnew.FromMM(par
 via.SetDrill(pcbnew.FromMM(params["drill_mm"]))
 via.SetWidth(pcbnew.FromMM(params["size_mm"]))
 
-# Via type already validated at the Python tool layer; this dispatch is
-# total over the validated set.
 via_type = params["via_type"]
 _VIATYPE_MAP = {
     "through":      pcbnew.VIATYPE_THROUGH,
@@ -149,7 +119,6 @@ _VIATYPE_MAP = {
 }
 via.SetViaType(_VIATYPE_MAP[via_type])
 
-# Net assignment: explicit error if the requested net doesn't exist.
 net_name = params["net_name"]
 if net_name:
     net = board.FindNet(net_name)
@@ -173,46 +142,34 @@ print(json.dumps({
     },
 }))
 """
-        return run_pcbnew_script(script, params={
-            "pcb_path": pcb_path,
-            "x_mm": x_mm,
-            "y_mm": y_mm,
-            "drill_mm": drill_mm,
-            "size_mm": size_mm,
-            "via_type": via_type,
-            "net_name": net_name,
-        })
+    return run_pcbnew_script(script, params={
+        "pcb_path": pcb_path,
+        "x_mm": x_mm,
+        "y_mm": y_mm,
+        "drill_mm": drill_mm,
+        "size_mm": size_mm,
+        "via_type": via_type,
+        "net_name": net_name,
+    })
 
-    @mcp.tool()
-    def edit_trace_width(
-        pcb_path: str,
-        new_width_mm: float,
-        net_name: str = "",
-        layer: str = "",
-    ) -> Dict[str, Any]:
-        """Change the width of existing traces.
 
-        Filters by net name and/or layer; if neither is supplied, updates
-        every track on the board.  Vias are never modified.
+def _op_edit_trace_width(
+    pcb_path: str,
+    new_width_mm: float,
+    net_name: str = "",
+    layer: str = "",
+) -> Dict[str, Any]:
+    """Change the width of existing traces."""
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
+    if new_width_mm <= 0:
+        return {"error": f"new_width_mm must be positive (got {new_width_mm})"}
+    if net_name and net_name != net_name.strip():
+        return {"error": f"net_name has surrounding whitespace; use empty string for 'all nets', not {net_name!r}"}
+    if layer and layer != layer.strip():
+        return {"error": f"layer has surrounding whitespace; use empty string for 'all layers', not {layer!r}"}
 
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-            new_width_mm: New trace width in mm.
-            net_name: Limit to traces on this net. Empty string = all nets.
-            layer: Limit to traces on this layer (e.g. "F.Cu"). Empty = all layers.
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
-        if new_width_mm <= 0:
-            return {"error": f"new_width_mm must be positive (got {new_width_mm})"}
-        # Whitespace-padded filter strings are almost certainly a typo;
-        # an empty string is the documented "all" sentinel.
-        if net_name and net_name != net_name.strip():
-            return {"error": f"net_name has surrounding whitespace; use empty string for 'all nets', not {net_name!r}"}
-        if layer and layer != layer.strip():
-            return {"error": f"layer has surrounding whitespace; use empty string for 'all layers', not {layer!r}"}
-
-        script = """
+    script = """
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -250,35 +207,25 @@ print(json.dumps({
     "layer_filter": layer_filter or "(all)",
 }))
 """
-        return run_pcbnew_script(script, params={
-            "pcb_path": pcb_path,
-            "new_width_mm": new_width_mm,
-            "net_name": net_name,
-            "layer": layer,
-        })
+    return run_pcbnew_script(script, params={
+        "pcb_path": pcb_path,
+        "new_width_mm": new_width_mm,
+        "net_name": net_name,
+        "layer": layer,
+    })
 
-    @mcp.tool()
-    def clear_routing(
-        pcb_path: str,
-        clear_tracks: bool = True,
-        clear_vias: bool = True,
-        clear_zones: bool = False,
-    ) -> Dict[str, Any]:
-        """Remove tracks, vias, and/or copper zones from the PCB.
 
-        Useful before re-autorouting after component placement changes.
-        By default removes tracks and vias but preserves zones.
+def _op_clear_routing(
+    pcb_path: str,
+    clear_tracks: bool = True,
+    clear_vias: bool = True,
+    clear_zones: bool = False,
+) -> Dict[str, Any]:
+    """Remove tracks, vias, and/or copper zones from the PCB."""
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
 
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-            clear_tracks: Remove all tracks (default True).
-            clear_vias: Remove all vias (default True).
-            clear_zones: Remove all copper zones (default False).
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
-
-        script = """
+    script = """
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -305,13 +252,10 @@ if params["clear_tracks"] or params["clear_vias"]:
         board.Remove(item)
 
 if params["clear_zones"]:
-    # Collect zone references from Zones() iterator (not GetArea index)
-    # and remove them. Using list() materialises the iterator before
-    # we start mutating the board.
     zone_list = list(board.Zones())
     for zone in zone_list:
         if zone.GetIsRuleArea():
-            continue  # Preserve keepout/rule areas, only remove copper zones
+            continue
         board.Remove(zone)
         zones_removed += 1
 
@@ -324,9 +268,9 @@ print(json.dumps({
     "zones_removed": zones_removed,
 }))
 """
-        return run_pcbnew_script(script, params={
-            "pcb_path": pcb_path,
-            "clear_tracks": clear_tracks,
-            "clear_vias": clear_vias,
-            "clear_zones": clear_zones,
-        })
+    return run_pcbnew_script(script, params={
+        "pcb_path": pcb_path,
+        "clear_tracks": clear_tracks,
+        "clear_vias": clear_vias,
+        "clear_zones": clear_zones,
+    })

--- a/src/kicad_mcp/tools/pcb_silkscreen.py
+++ b/src/kicad_mcp/tools/pcb_silkscreen.py
@@ -1,46 +1,34 @@
-"""PCB silkscreen tools: add text, list items, update items, check overlaps."""
+"""PCB silkscreen ops: add text, list items, update items, check overlaps, auto-fix.
+
+These are module-level _op_* helpers consumed by the pcb router (pcb.py).
+_op_check_silkscreen_overlaps is also imported by the audit router (pcb_keepout.py)
+to serve audit.check_silkscreen_overlaps — single source of truth, two surfaces.
+"""
 
 import logging
 import os
 from typing import Any, Dict, Optional
-
-from fastmcp import FastMCP
 
 from kicad_mcp.utils.pcbnew_bridge import run_pcbnew_script
 
 logger = logging.getLogger(__name__)
 
 
-def register_pcb_silkscreen_tools(mcp: FastMCP) -> None:
-    """Register PCB silkscreen tools."""
+def _op_add_text(
+    pcb_path: str,
+    text: str,
+    x_mm: float,
+    y_mm: float,
+    layer: str = "F.SilkS",
+    size_mm: float = 1.0,
+    thickness_mm: float = 0.15,
+    rotation_deg: float = 0.0,
+) -> Dict[str, Any]:
+    """Add text to the PCB."""
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
 
-    @mcp.tool()
-    def add_text_to_pcb(
-        pcb_path: str,
-        text: str,
-        x_mm: float,
-        y_mm: float,
-        layer: str = "F.SilkS",
-        size_mm: float = 1.0,
-        thickness_mm: float = 0.15,
-        rotation_deg: float = 0.0,
-    ) -> Dict[str, Any]:
-        """Add text to the PCB.
-
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-            text: Text content.
-            x_mm: X position in millimeters.
-            y_mm: Y position in millimeters.
-            layer: PCB layer (default "F.SilkS").
-            size_mm: Text height in mm (default 1.0).
-            thickness_mm: Text line thickness in mm (default 0.15).
-            rotation_deg: Text rotation in degrees (default 0).
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
-
-        script = """
+    script = """
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -68,31 +56,24 @@ print(json.dumps({
     "layer": params["layer"],
 }))
 """
-        return run_pcbnew_script(script, params={
-            "pcb_path": pcb_path,
-            "text": text,
-            "x_mm": x_mm,
-            "y_mm": y_mm,
-            "layer": layer,
-            "size_mm": size_mm,
-            "thickness_mm": thickness_mm,
-            "rotation_deg": rotation_deg,
-        })
+    return run_pcbnew_script(script, params={
+        "pcb_path": pcb_path,
+        "text": text,
+        "x_mm": x_mm,
+        "y_mm": y_mm,
+        "layer": layer,
+        "size_mm": size_mm,
+        "thickness_mm": thickness_mm,
+        "rotation_deg": rotation_deg,
+    })
 
-    @mcp.tool()
-    def list_silkscreen_items(pcb_path: str) -> Dict[str, Any]:
-        """List all silkscreen text items on the PCB.
 
-        Returns reference designators, values, and standalone text with their
-        positions, sizes, visibility, and layers.
+def _op_list_silkscreen(pcb_path: str) -> Dict[str, Any]:
+    """List all silkscreen text items on the PCB."""
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
 
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
-
-        script = """
+    script = """
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -102,7 +83,6 @@ board = pcbnew.LoadBoard(pcb_path)
 
 items = []
 
-# Footprint text (references and values)
 for fp in board.GetFootprints():
     ref = fp.GetReference()
     for field_type, field_obj in [("reference", fp.Reference()), ("value", fp.Value())]:
@@ -124,7 +104,6 @@ for fp in board.GetFootprints():
             "angle_deg": field_obj.GetTextAngle().AsDegrees(),
         })
 
-# Standalone text items on silkscreen layers
 silk_layers = [board.GetLayerID("F.SilkS"), board.GetLayerID("B.SilkS")]
 for drawing in board.GetDrawings():
     if hasattr(drawing, 'GetText') and drawing.GetLayer() in silk_layers:
@@ -151,53 +130,35 @@ print(json.dumps({
     "items": items,
 }))
 """
-        return run_pcbnew_script(script, params={"pcb_path": pcb_path})
+    return run_pcbnew_script(script, params={"pcb_path": pcb_path})
 
-    @mcp.tool()
-    def update_silkscreen_item(
-        pcb_path: str,
-        reference: str,
-        field: str = "reference",
-        visible: Optional[bool] = None,
-        x_mm: Optional[float] = None,
-        y_mm: Optional[float] = None,
-        rel_x_mm: Optional[float] = None,
-        rel_y_mm: Optional[float] = None,
-        size_mm: Optional[float] = None,
-        thickness_mm: Optional[float] = None,
-        angle_deg: Optional[float] = None,
-        layer: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        """Update a silkscreen text item's properties.
 
-        Modify visibility, position, size, rotation, or layer of a footprint's
-        reference designator or value text.
+def _op_update_silkscreen(
+    pcb_path: str,
+    reference: str,
+    field: str = "reference",
+    visible: Optional[bool] = None,
+    x_mm: Optional[float] = None,
+    y_mm: Optional[float] = None,
+    rel_x_mm: Optional[float] = None,
+    rel_y_mm: Optional[float] = None,
+    size_mm: Optional[float] = None,
+    thickness_mm: Optional[float] = None,
+    angle_deg: Optional[float] = None,
+    layer: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Update a silkscreen text item's properties."""
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
 
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-            reference: Component reference (e.g., "R1").
-            field: Which field to update - "reference" or "value" (default "reference").
-            visible: Set visibility (True/False). None to keep current.
-            x_mm: New absolute X position in mm. None to keep current.
-            y_mm: New absolute Y position in mm. None to keep current.
-            rel_x_mm: New X position relative to footprint center in mm. None to keep current.
-            rel_y_mm: New Y position relative to footprint center in mm. None to keep current.
-            size_mm: New text height in mm. None to keep current.
-            thickness_mm: New text stroke thickness in mm. None to keep current.
-            angle_deg: New text rotation in degrees. None to keep current.
-            layer: New layer name (e.g., "F.SilkS", "B.SilkS"). None to keep current.
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
+    if field not in ("reference", "value"):
+        return {"error": f"field must be 'reference' or 'value', got {field!r}"}
 
-        if field not in ("reference", "value"):
-            return {"error": f"field must be 'reference' or 'value', got {field!r}"}
+    if all(v is None for v in (visible, x_mm, y_mm, rel_x_mm, rel_y_mm,
+                                size_mm, thickness_mm, angle_deg, layer)):
+        return {"error": "No modifications specified"}
 
-        if all(v is None for v in (visible, x_mm, y_mm, rel_x_mm, rel_y_mm,
-                                    size_mm, thickness_mm, angle_deg, layer)):
-            return {"error": "No modifications specified"}
-
-        script = """
+    script = """
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -213,7 +174,6 @@ if fp is None:
 
 text = fp.Reference() if params["field"] == "reference" else fp.Value()
 
-# Apply modifications from params
 if params["visible"] is not None:
     text.SetVisible(params["visible"])
 if params["x_mm"] is not None and params["y_mm"] is not None:
@@ -256,159 +216,34 @@ print(json.dumps({
     "angle_deg": text.GetTextAngle().AsDegrees(),
 }))
 """
-        return run_pcbnew_script(script, params={
-            "pcb_path": pcb_path,
-            "reference": reference,
-            "field": field,
-            "visible": visible,
-            "x_mm": x_mm,
-            "y_mm": y_mm,
-            "rel_x_mm": rel_x_mm,
-            "rel_y_mm": rel_y_mm,
-            "size_mm": size_mm,
-            "thickness_mm": thickness_mm,
-            "angle_deg": angle_deg,
-            "layer": layer,
-        })
+    return run_pcbnew_script(script, params={
+        "pcb_path": pcb_path,
+        "reference": reference,
+        "field": field,
+        "visible": visible,
+        "x_mm": x_mm,
+        "y_mm": y_mm,
+        "rel_x_mm": rel_x_mm,
+        "rel_y_mm": rel_y_mm,
+        "size_mm": size_mm,
+        "thickness_mm": thickness_mm,
+        "angle_deg": angle_deg,
+        "layer": layer,
+    })
 
-    @mcp.tool()
-    def edit_text(
-        pcb_path: str,
-        text: str,
-        new_text: Optional[str] = None,
-        x_mm: Optional[float] = None,
-        y_mm: Optional[float] = None,
-        layer: Optional[str] = None,
-        size_mm: Optional[float] = None,
-        thickness_mm: Optional[float] = None,
-        rotation_deg: Optional[float] = None,
-        near_x_mm: Optional[float] = None,
-        near_y_mm: Optional[float] = None,
-    ) -> Dict[str, Any]:
-        """Edit a standalone PCB text item in place.
 
-        Finds the text by its current content and applies updates without
-        requiring delete-and-recreate.  If multiple items share the same
-        text, supply near_x_mm / near_y_mm to pick the closest one.
+def _op_check_silkscreen_overlaps(pcb_path: str) -> Dict[str, Any]:
+    """Find silkscreen text items that overlap copper pads or other silkscreen text.
 
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-            text: Current text content to match.
-            new_text: Replacement text content. None to keep current.
-            x_mm: New X position in mm. None to keep current.
-            y_mm: New Y position in mm. None to keep current.
-            layer: New layer name (e.g. "F.SilkS", "B.SilkS"). None to keep current.
-            size_mm: New text height in mm. None to keep current.
-            thickness_mm: New stroke thickness in mm. None to keep current.
-            rotation_deg: New rotation in degrees. None to keep current.
-            near_x_mm: Disambiguate by proximity — X of expected location.
-            near_y_mm: Disambiguate by proximity — Y of expected location.
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
+    This function is the single source of truth for silkscreen overlap checking.
+    It is used by both:
+      - pcb router (operation='check_silkscreen_overlaps')
+      - audit router (operation='check_silkscreen_overlaps') via import in pcb_keepout.py
+    """
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
 
-        if all(v is None for v in (new_text, x_mm, y_mm, layer, size_mm, thickness_mm, rotation_deg)):
-            return {"error": "No modifications specified"}
-
-        script = """
-import pcbnew, json, math, sys
-
-params = json.loads(open(sys.argv[1]).read())
-pcb_path = params["pcb_path"]
-
-board = pcbnew.LoadBoard(pcb_path)
-
-target_text = params["text"]
-near_x = params["near_x_mm"]
-near_y = params["near_y_mm"]
-
-candidates = []
-for drawing in board.GetDrawings():
-    if hasattr(drawing, 'GetText') and drawing.GetText() == target_text:
-        candidates.append(drawing)
-
-if not candidates:
-    print(json.dumps({"error": f"No standalone text matching {target_text!r} found"}))
-    raise SystemExit(0)
-
-if len(candidates) > 1:
-    if near_x is not None and near_y is not None:
-        ref_x = pcbnew.FromMM(near_x)
-        ref_y = pcbnew.FromMM(near_y)
-        candidates.sort(key=lambda d: math.hypot(d.GetPosition().x - ref_x, d.GetPosition().y - ref_y))
-    else:
-        positions = [f"({round(pcbnew.ToMM(d.GetPosition().x),2)}, {round(pcbnew.ToMM(d.GetPosition().y),2)})" for d in candidates]
-        print(json.dumps({"error": f"Multiple items match {target_text!r}: {positions}. Supply near_x_mm/near_y_mm to disambiguate."}))
-        raise SystemExit(0)
-
-item = candidates[0]
-
-# Apply modifications from params
-if params["new_text"] is not None:
-    item.SetText(params["new_text"])
-if params["x_mm"] is not None and params["y_mm"] is not None:
-    item.SetPosition(pcbnew.VECTOR2I(pcbnew.FromMM(params["x_mm"]), pcbnew.FromMM(params["y_mm"])))
-elif params["x_mm"] is not None:
-    pos = item.GetPosition()
-    item.SetPosition(pcbnew.VECTOR2I(pcbnew.FromMM(params["x_mm"]), pos.y))
-elif params["y_mm"] is not None:
-    pos = item.GetPosition()
-    item.SetPosition(pcbnew.VECTOR2I(pos.x, pcbnew.FromMM(params["y_mm"])))
-if params["layer"] is not None:
-    item.SetLayer(board.GetLayerID(params["layer"]))
-if params["size_mm"] is not None:
-    item.SetTextSize(pcbnew.VECTOR2I(pcbnew.FromMM(params["size_mm"]), pcbnew.FromMM(params["size_mm"])))
-if params["thickness_mm"] is not None:
-    item.SetTextThickness(pcbnew.FromMM(params["thickness_mm"]))
-if params["rotation_deg"] is not None:
-    item.SetTextAngle(pcbnew.EDA_ANGLE(params["rotation_deg"], pcbnew.DEGREES_T))
-
-board.Save(pcb_path)
-
-pos = item.GetPosition()
-size = item.GetTextSize()
-print(json.dumps({
-    "status": "ok",
-    "text": item.GetText(),
-    "x_mm": round(pcbnew.ToMM(pos.x), 3),
-    "y_mm": round(pcbnew.ToMM(pos.y), 3),
-    "layer": board.GetLayerName(item.GetLayer()),
-    "size_mm": round(pcbnew.ToMM(size.x), 3),
-    "thickness_mm": round(pcbnew.ToMM(item.GetTextThickness()), 3),
-    "rotation_deg": item.GetTextAngle().AsDegrees(),
-}))
-"""
-        return run_pcbnew_script(script, params={
-            "pcb_path": pcb_path,
-            "text": text,
-            "new_text": new_text,
-            "x_mm": x_mm,
-            "y_mm": y_mm,
-            "layer": layer,
-            "size_mm": size_mm,
-            "thickness_mm": thickness_mm,
-            "rotation_deg": rotation_deg,
-            "near_x_mm": near_x_mm,
-            "near_y_mm": near_y_mm,
-        })
-
-    @mcp.tool()
-    def check_silkscreen_overlaps(pcb_path: str) -> Dict[str, Any]:
-        """Find silkscreen text items that overlap copper pads or other silkscreen text.
-
-        Checks all visible silkscreen text (reference designators, values,
-        standalone text) against all pads on the board and against each other.
-        Reports overlaps between different components that could cause
-        manufacturing issues.  Skips text overlapping its own component's
-        pads (which is normal).
-
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
-
-        script = """
+    script = """
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -418,7 +253,6 @@ board = pcbnew.LoadBoard(pcb_path)
 
 silk_layer_ids = [board.GetLayerID("F.SilkS"), board.GetLayerID("B.SilkS")]
 
-# Collect all visible silkscreen text items with bounding boxes
 silk_items = []
 for fp in board.GetFootprints():
     ref = fp.GetReference()
@@ -439,7 +273,6 @@ for fp in board.GetFootprints():
             "bbox_y_max": bbox.GetBottom(),
         })
 
-# Also check standalone text
 for drawing in board.GetDrawings():
     if hasattr(drawing, 'GetText') and drawing.GetLayer() in silk_layer_ids:
         if hasattr(drawing, 'IsVisible') and not drawing.IsVisible():
@@ -456,7 +289,6 @@ for drawing in board.GetDrawings():
             "bbox_y_max": bbox.GetBottom(),
         })
 
-# Collect all pads
 pads = []
 for fp in board.GetFootprints():
     for pad in fp.Pads():
@@ -473,7 +305,6 @@ for fp in board.GetFootprints():
 def aabb_overlap(ax_min, ay_min, ax_max, ay_max, bx_min, by_min, bx_max, by_max):
     return ax_min < bx_max and ax_max > bx_min and ay_min < by_max and ay_max > by_min
 
-# Check text-over-pad overlaps (skip text overlapping own component)
 pad_overlaps = []
 for si in silk_items:
     for pad in pads:
@@ -490,7 +321,6 @@ for si in silk_items:
                 "pad_number": pad["pad_number"],
             })
 
-# Check text-over-text overlaps (different components, same layer)
 text_overlaps = []
 for i in range(len(silk_items)):
     a = silk_items[i]
@@ -518,28 +348,15 @@ print(json.dumps({
     "text_overlaps": text_overlaps,
 }))
 """
-        return run_pcbnew_script(script, params={"pcb_path": pcb_path})
+    return run_pcbnew_script(script, params={"pcb_path": pcb_path})
 
-    @mcp.tool()
-    def auto_fix_silkscreen(pcb_path: str) -> Dict[str, Any]:
-        """Automatically fix silkscreen text that overlaps copper pads or other text.
 
-        For each visible silkscreen text item (reference designator or value)
-        that overlaps pads from a different component or text from a different
-        component, tries up to 8 candidate positions arranged around the
-        footprint's bounding box (N, S, W, E, NW, NE, SW, SE).  The first
-        position that is free of pad and text overlaps and lies within the
-        board outline is used.  Text is hidden only when all 8 positions fail.
+def _op_auto_fix_silkscreen(pcb_path: str) -> Dict[str, Any]:
+    """Automatically fix silkscreen text that overlaps copper pads or other text."""
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
 
-        Does not modify standalone text items (only footprint reference/value).
-
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
-
-        script = """
+    script = """
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -549,7 +366,6 @@ board = pcbnew.LoadBoard(pcb_path)
 
 silk_layer_ids = [board.GetLayerID("F.SilkS"), board.GetLayerID("B.SilkS")]
 
-# Collect all pads with bounding boxes
 all_pads = []
 for fp in board.GetFootprints():
     for pad in fp.Pads():
@@ -560,9 +376,6 @@ for fp in board.GetFootprints():
             "x_max": sz.GetRight(), "y_max": sz.GetBottom(),
         })
 
-# Collect all visible silk text objects for text-vs-text checking.
-# We store the actual pcbnew field objects so we can re-read bboxes
-# after earlier items have been moved.
 all_silk = []
 for fp in board.GetFootprints():
     ref = fp.GetReference()
@@ -573,7 +386,6 @@ for fp in board.GetFootprints():
             continue
         all_silk.append({"component": ref, "field_type": ft, "obj": fo,
                           "layer": fo.GetLayer()})
-# Standalone text (not fixable, but used as obstacles)
 for drawing in board.GetDrawings():
     if hasattr(drawing, 'GetText') and drawing.GetLayer() in silk_layer_ids:
         vis = drawing.IsVisible() if hasattr(drawing, 'IsVisible') else True
@@ -581,7 +393,6 @@ for drawing in board.GetDrawings():
             all_silk.append({"component": None, "field_type": "standalone",
                               "obj": drawing, "layer": drawing.GetLayer()})
 
-# Board outline bbox for boundary clamping
 if hasattr(board, 'GetBoardEdgesBoundingBox'):
     board_bb = board.GetBoardEdgesBoundingBox()
     board_valid = board_bb.GetWidth() > 0
@@ -591,9 +402,7 @@ else:
 
 def aabb_hit(a, bx_min, by_min, bx_max, by_max):
     # Non-strict: touching edges count as overlap, matching KiCad DRC's
-    # silk_over_copper / silk_overlap semantics. A silkscreen text item
-    # whose edge is flush with a pad is a DRC violation, so flag it here
-    # rather than letting it slip through to fail at fab.
+    # silk_over_copper / silk_overlap semantics.
     return (a.GetX() <= bx_max and a.GetRight() >= bx_min and
             a.GetY() <= by_max and a.GetBottom() >= by_min)
 
@@ -655,12 +464,8 @@ for fp in board.GetFootprints():
             already_ok += 1
             continue
 
-        # Degenerate text bbox (zero width or height) usually means an
-        # empty value string or a library quirk — moving it is pointless
-        # because the candidate-overlap check against a zero-area bbox
-        # cannot tell us anything useful. Skip with a counter.
         if text_bbox.GetWidth() <= 0 or text_bbox.GetHeight() <= 0:
-            already_ok += 1  # counts as "no actionable fix"
+            already_ok += 1
             continue
 
         fp_bb = fp.GetBoundingBox()
@@ -719,198 +524,4 @@ print(json.dumps({
     "fixes": fixed + hidden,
 }))
 """
-        return run_pcbnew_script(script, params={"pcb_path": pcb_path})
-
-    @mcp.tool()
-    def finalize_pcb(
-        pcb_path: str,
-        fix_silkscreen: bool = True,
-        fill_zones: bool = True,
-    ) -> Dict[str, Any]:
-        """Fix silkscreen overlaps and fill copper zones in one operation.
-
-        A compound finalisation step to run before generating fabrication
-        outputs.  Equivalent to auto_fix_silkscreen + fill_zones in sequence
-        but with a single board load and save, so it is faster and avoids
-        intermediate file states.
-
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-            fix_silkscreen: Run silkscreen overlap auto-fix (default True).
-            fill_zones: Run copper zone fill (default True).
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
-
-        script = """
-import pcbnew, json, sys
-
-params = json.loads(open(sys.argv[1]).read())
-pcb_path = params["pcb_path"]
-
-board = pcbnew.LoadBoard(pcb_path)
-results = {}
-
-# ── Silkscreen fix ────────────────────────────────────────────────────────────
-if params["fix_silkscreen"]:
-    silk_layer_ids = [board.GetLayerID("F.SilkS"), board.GetLayerID("B.SilkS")]
-
-    all_pads = []
-    for fp in board.GetFootprints():
-        for pad in fp.Pads():
-            sz = pad.GetBoundingBox()
-            all_pads.append({
-                "reference": fp.GetReference(),
-                "x_min": sz.GetX(), "y_min": sz.GetY(),
-                "x_max": sz.GetRight(), "y_max": sz.GetBottom(),
-            })
-
-    # Collect all visible silk text objects for text-vs-text checking
-    all_silk = []
-    for fp in board.GetFootprints():
-        _ref = fp.GetReference()
-        for _ft, _fo in [("reference", fp.Reference()), ("value", fp.Value())]:
-            if not _fo.IsVisible() or _fo.GetLayer() not in silk_layer_ids:
-                continue
-            all_silk.append({"component": _ref, "obj": _fo, "layer": _fo.GetLayer()})
-    for drawing in board.GetDrawings():
-        if hasattr(drawing, 'GetText') and drawing.GetLayer() in silk_layer_ids:
-            _vis = drawing.IsVisible() if hasattr(drawing, 'IsVisible') else True
-            if _vis:
-                all_silk.append({"component": None, "obj": drawing, "layer": drawing.GetLayer()})
-
-    try:
-        board_bb = board.GetBoardEdgesBoundingBox()
-        board_valid = board_bb.GetWidth() > 0
-    except Exception:
-        board_valid = False
-
-    def _aabb_hit(a, bx_min, by_min, bx_max, by_max):
-        # Non-strict: touching edges count as overlap (matches KiCad DRC).
-        return (a.GetX() <= bx_max and a.GetRight() >= bx_min and
-                a.GetY() <= by_max and a.GetBottom() >= by_min)
-
-    def has_pad_overlap(text_bbox, own_ref):
-        for pad in all_pads:
-            if pad["reference"] == own_ref:
-                continue
-            if _aabb_hit(text_bbox, pad["x_min"], pad["y_min"], pad["x_max"], pad["y_max"]):
-                return True
-        return False
-
-    def has_text_overlap(text_bbox, own_ref, own_layer, own_obj):
-        for si in all_silk:
-            if si["obj"] is own_obj:
-                continue
-            if si["component"] is not None and si["component"] == own_ref:
-                continue
-            if si["layer"] != own_layer:
-                continue
-            if not si["obj"].IsVisible() if hasattr(si["obj"], 'IsVisible') else False:
-                continue
-            ob = si["obj"].GetBoundingBox()
-            if _aabb_hit(text_bbox, ob.GetX(), ob.GetY(), ob.GetRight(), ob.GetBottom()):
-                return True
-        return False
-
-    def has_any_overlap(text_bbox, own_ref, own_layer, own_obj):
-        return has_pad_overlap(text_bbox, own_ref) or has_text_overlap(text_bbox, own_ref, own_layer, own_obj)
-
-    def in_board(text_bbox):
-        if not board_valid:
-            return True
-        return (board_bb.GetX() <= text_bbox.GetX() and
-                text_bbox.GetRight() <= board_bb.GetRight() and
-                board_bb.GetY() <= text_bbox.GetY() and
-                text_bbox.GetBottom() <= board_bb.GetBottom())
-
-    MARGIN = pcbnew.FromMM(0.3)
-    silk_fixed = []
-    silk_hidden = []
-    silk_ok = 0
-
-    for fp in board.GetFootprints():
-        ref = fp.GetReference()
-        for field_type, field_obj in [("reference", fp.Reference()), ("value", fp.Value())]:
-            if not field_obj.IsVisible():
-                continue
-            if field_obj.GetLayer() not in silk_layer_ids:
-                continue
-            text_bbox = field_obj.GetBoundingBox()
-            own_layer = field_obj.GetLayer()
-            _has_overlap = has_any_overlap(text_bbox, ref, own_layer, field_obj)
-            _clips_edge = not in_board(text_bbox)
-            if not _has_overlap and not _clips_edge:
-                silk_ok += 1
-                continue
-
-            fp_bb = fp.GetBoundingBox()
-            cx  = fp_bb.GetCenter().x
-            cy  = fp_bb.GetCenter().y
-            fw2 = fp_bb.GetWidth()  // 2
-            fh2 = fp_bb.GetHeight() // 2
-            tw2 = text_bbox.GetWidth()  // 2
-            th2 = text_bbox.GetHeight() // 2
-
-            candidates = [
-                (cx,           cy - fh2 - th2 - MARGIN),
-                (cx,           cy + fh2 + th2 + MARGIN),
-                (cx - fw2 - tw2 - MARGIN, cy),
-                (cx + fw2 + tw2 + MARGIN, cy),
-                (cx - fw2 - tw2 - MARGIN, cy - fh2 - th2 - MARGIN),
-                (cx + fw2 + tw2 + MARGIN, cy - fh2 - th2 - MARGIN),
-                (cx - fw2 - tw2 - MARGIN, cy + fh2 + th2 + MARGIN),
-                (cx + fw2 + tw2 + MARGIN, cy + fh2 + th2 + MARGIN),
-            ]
-
-            orig_pos = field_obj.GetPosition()
-            resolved = False
-            for px, py in candidates:
-                field_obj.SetPosition(pcbnew.VECTOR2I(int(px), int(py)))
-                new_bbox = field_obj.GetBoundingBox()
-                if not has_any_overlap(new_bbox, ref, own_layer, field_obj) and in_board(new_bbox):
-                    resolved = True
-                    pos = field_obj.GetPosition()
-                    silk_fixed.append({"component": ref, "field": field_type,
-                                        "action": "moved",
-                                        "x_mm": round(pcbnew.ToMM(pos.x), 2),
-                                        "y_mm": round(pcbnew.ToMM(pos.y), 2)})
-                    break
-            if not resolved:
-                field_obj.SetPosition(orig_pos)
-                field_obj.SetVisible(False)
-                silk_hidden.append({"component": ref, "field": field_type, "action": "hidden"})
-
-    results["silkscreen"] = {
-        "already_ok": silk_ok,
-        "moved": len(silk_fixed),
-        "hidden": len(silk_hidden),
-        "fixes": silk_fixed + silk_hidden,
-    }
-
-# ── Zone fill ─────────────────────────────────────────────────────────────────
-if params["fill_zones"]:
-    copper_zones = [z for z in board.Zones() if not z.GetIsRuleArea()]
-    if copper_zones:
-        for z in copper_zones:
-            z.UnFill()
-        filler = pcbnew.ZONE_FILLER(board)
-        fill_ok = filler.Fill(board.Zones())
-        zone_info = []
-        for z in copper_zones:
-            ls = z.GetLayerSet()
-            lname = "F.Cu" if ls.Contains(pcbnew.F_Cu) else "B.Cu" if ls.Contains(pcbnew.B_Cu) else "other"
-            zone_info.append({"net": z.GetNetname(), "layer": lname, "filled": z.IsFilled()})
-        results["zones"] = {"fill_success": fill_ok, "zones_filled": len(copper_zones), "zones": zone_info}
-    else:
-        results["zones"] = {"fill_success": True, "zones_filled": 0, "message": "No copper zones"}
-
-board.Save(pcb_path)
-results["status"] = "ok"
-print(json.dumps(results))
-"""
-        return run_pcbnew_script(script, params={
-            "pcb_path": pcb_path,
-            "fix_silkscreen": fix_silkscreen,
-            "fill_zones": fill_zones,
-        }, timeout=120.0)
+    return run_pcbnew_script(script, params={"pcb_path": pcb_path})

--- a/src/kicad_mcp/tools/pcb_zones.py
+++ b/src/kicad_mcp/tools/pcb_zones.py
@@ -1,50 +1,32 @@
-"""PCB copper zone tools: add zones and fill zones."""
+"""PCB copper zone ops: add zones and fill zones.
+
+These are module-level _op_* helpers consumed by the pcb router (pcb.py).
+"""
 
 import logging
 import os
 from typing import Any, Dict, List
-
-from fastmcp import FastMCP
 
 from kicad_mcp.utils.pcbnew_bridge import run_pcbnew_script
 
 logger = logging.getLogger(__name__)
 
 
-def register_pcb_zone_tools(mcp: FastMCP) -> None:
-    """Register PCB copper zone tools."""
+def _op_add_zone(
+    pcb_path: str,
+    net_name: str,
+    layer: str = "F.Cu",
+    corners: List[List[float]] = [],
+    clearance_mm: float = 0.3,
+    min_width_mm: float = 0.2,
+    connect_pads: str = "thermal",
+    priority: int = 0,
+) -> Dict[str, Any]:
+    """Add a copper zone (pour/fill) to the PCB."""
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
 
-    @mcp.tool()
-    def add_copper_zone(
-        pcb_path: str,
-        net_name: str,
-        layer: str = "F.Cu",
-        corners: List[List[float]] = [],
-        clearance_mm: float = 0.3,
-        min_width_mm: float = 0.2,
-        connect_pads: str = "thermal",
-        priority: int = 0,
-    ) -> Dict[str, Any]:
-        """Add a copper zone (pour/fill) to the PCB.
-
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-            net_name: Net name for the zone (e.g., "GND").
-            layer: Copper layer (default "F.Cu").
-            corners: List of [x_mm, y_mm] corner points defining the zone outline.
-                If empty, automatically uses the board outline (Edge.Cuts)
-                as the zone boundary — the most common use case for ground pours.
-            clearance_mm: Clearance to other nets in mm (default 0.3).
-            min_width_mm: Minimum fill width in mm (default 0.2).
-            connect_pads: Pad connection type - "thermal", "solid", or "none" (default "thermal").
-                Note: "thermal" relief can cause starved-thermal DRC violations when
-                autorouted traces block spoke formation. Use "solid" to avoid this.
-            priority: Zone priority (higher fills first, default 0).
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
-
-        script = """
+    script = """
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -57,14 +39,9 @@ if net is None or net.GetNetCode() == 0:
     print(json.dumps({"error": f"Net {params['net_name']!r} not found"}))
     raise SystemExit(0)
 
-# Determine zone corners. Empty list = auto-derive from board outline.
-# A list with 1 or 2 entries is almost certainly a caller error (a polygon
-# needs >= 3 vertices); we reject it explicitly rather than silently
-# falling back to the auto-outline path.
 corners = params["corners"]
 auto_outline = False
 if len(corners) == 0:
-    # Auto-derive from board outline (Edge.Cuts bounding box)
     bb = board.GetBoardEdgesBoundingBox()
     if bb.GetWidth() > 0 and bb.GetHeight() > 0:
         x0 = round(pcbnew.ToMM(bb.GetX()), 2)
@@ -85,13 +62,9 @@ zone.SetNet(net)
 zone.SetLayer(board.GetLayerID(params["layer"]))
 zone.SetAssignedPriority(params["priority"])
 
-# Set clearance and minimum width
 zone.SetLocalClearance(pcbnew.FromMM(params["clearance_mm"]))
 zone.SetMinThickness(pcbnew.FromMM(params["min_width_mm"]))
 
-# Set pad connection type. Reject unknown values explicitly — silently
-# defaulting to thermal would hide caller typos that change the
-# electrical behavior of the zone.
 _PAD_CONNECT_MAP = {
     "solid": pcbnew.ZONE_CONNECTION_FULL,
     "none": pcbnew.ZONE_CONNECTION_NONE,
@@ -103,7 +76,6 @@ if connect not in _PAD_CONNECT_MAP:
     raise SystemExit(0)
 zone.SetPadConnection(_PAD_CONNECT_MAP[connect])
 
-# Build outline
 outline = zone.Outline()
 outline.NewOutline()
 for i, (cx, cy) in enumerate(corners):
@@ -111,8 +83,6 @@ for i, (cx, cy) in enumerate(corners):
 
 board.Add(zone)
 
-# Fill the zone (pass board.Zones() directly — matches fill_zones pattern;
-# the previous manual ZONES() copy was redundant.)
 filler = pcbnew.ZONE_FILLER(board)
 filler.Fill(board.Zones())
 
@@ -135,32 +105,24 @@ if auto_outline:
     result["note"] = "Zone corners auto-derived from board outline (Edge.Cuts)"
 print(json.dumps(result))
 """
-        return run_pcbnew_script(script, params={
-            "pcb_path": pcb_path,
-            "net_name": net_name,
-            "layer": layer,
-            "corners": corners,
-            "clearance_mm": clearance_mm,
-            "min_width_mm": min_width_mm,
-            "connect_pads": connect_pads,
-            "priority": priority,
-        }, timeout=60.0)
+    return run_pcbnew_script(script, params={
+        "pcb_path": pcb_path,
+        "net_name": net_name,
+        "layer": layer,
+        "corners": corners,
+        "clearance_mm": clearance_mm,
+        "min_width_mm": min_width_mm,
+        "connect_pads": connect_pads,
+        "priority": priority,
+    }, timeout=60.0)
 
-    @mcp.tool()
-    def fill_zones(pcb_path: str) -> Dict[str, Any]:
-        """Fill all copper zones on the PCB.
 
-        Runs the zone filler headlessly to compute copper fills for all
-        non-rule-area zones. This replaces the manual "press B in KiCad" step.
-        Zones must already exist on the board (use add_copper_zone first).
+def _op_fill_zones(pcb_path: str) -> Dict[str, Any]:
+    """Fill all copper zones on the PCB."""
+    if not os.path.exists(pcb_path):
+        return {"error": f"PCB file not found: {pcb_path}"}
 
-        Args:
-            pcb_path: Path to the .kicad_pcb file.
-        """
-        if not os.path.exists(pcb_path):
-            return {"error": f"PCB file not found: {pcb_path}"}
-
-        script = """
+    script = """
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -168,7 +130,6 @@ pcb_path = params["pcb_path"]
 
 board = pcbnew.LoadBoard(pcb_path)
 
-# Count copper zones (skip rule areas)
 copper_zones = []
 for z in board.Zones():
     if not z.GetIsRuleArea():
@@ -178,27 +139,17 @@ if not copper_zones:
     print(json.dumps({"status": "ok", "message": "No copper zones to fill", "zones_filled": 0}))
     raise SystemExit(0)
 
-# Unfill first to force recomputation
 for z in copper_zones:
     z.UnFill()
 
-# Fill all zones (never pass aCheck=True headlessly — it hangs)
 filler = pcbnew.ZONE_FILLER(board)
 zones = board.Zones()
 success = filler.Fill(zones)
 
-# Collect results
 zone_info = []
 for z in copper_zones:
-    # Use board.GetLayerName for the actual layer — the previous
-    # two-branch F.Cu/B.Cu/"unknown" classifier silently reported every
-    # inner-copper zone as "unknown".
     layer_id = z.GetLayer()
     layer_name = board.GetLayerName(layer_id)
-    # GetFilledArea returns IU² (nm²). ToMM(x) converts nm → mm (one
-    # power of 10^-6). For area we need 10^-12 — apply ToMM twice, or
-    # equivalently divide by 1e12. Previously this called ToMM once and
-    # reported filled_area_mm2 inflated by a factor of 10^6.
     area_iu_sq = z.GetFilledArea()
     area_mm_sq = pcbnew.ToMM(pcbnew.ToMM(area_iu_sq))
     zone_info.append({
@@ -217,4 +168,4 @@ print(json.dumps({
     "zones": zone_info,
 }))
 """
-        return run_pcbnew_script(script, params={"pcb_path": pcb_path}, timeout=60.0)
+    return run_pcbnew_script(script, params={"pcb_path": pcb_path}, timeout=60.0)

--- a/tests/test_net_class.py
+++ b/tests/test_net_class.py
@@ -10,25 +10,26 @@ import os
 import pytest
 from fastmcp import FastMCP
 
-from kicad_mcp.tools.pcb_nets import register_pcb_net_tools, _default_net_class
+from kicad_mcp.tools.pcb import register_pcb_tools
+from kicad_mcp.tools.pcb_nets import _default_net_class
 
 
 # -- Fixtures ----------------------------------------------------------------
 
 @pytest.fixture
-def net_server():
-    """Create a FastMCP server with only net tools registered."""
-    mcp = FastMCP("test-nets")
-    register_pcb_net_tools(mcp)
+def pcb_server():
+    """Create a FastMCP server with the pcb router registered."""
+    mcp = FastMCP("test-pcb")
+    register_pcb_tools(mcp)
     return mcp
 
 
-def _get_tool_fn(mcp_server, tool_name):
-    """Extract a tool function from the FastMCP 3.0 server by name."""
+def _get_pcb_fn(mcp_server):
+    """Extract the pcb router function from the FastMCP server."""
     import asyncio
-    tool = asyncio.run(mcp_server.get_tool(tool_name))
+    tool = asyncio.run(mcp_server.get_tool("pcb"))
     if tool is None:
-        raise ValueError(f"Tool {tool_name!r} not found")
+        raise ValueError("Tool 'pcb' not found")
     return tool.fn
 
 
@@ -54,26 +55,30 @@ def pcb_and_pro(tmp_path):
 
 class TestSetNetClass:
 
-    def test_pcb_not_found(self, net_server):
-        fn = _get_tool_fn(net_server, "set_net_class")
-        result = fn("/nonexistent/board.kicad_pcb", "Power", ["GND"])
+    def test_pcb_not_found(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("set_net_class",
+                    pcb_path="/nonexistent/board.kicad_pcb",
+                    class_name="Power", nets=["GND"])
         assert "error" in result
         assert "not found" in result["error"]
 
-    def test_pro_not_found(self, net_server, tmp_path):
+    def test_pro_not_found(self, pcb_server, tmp_path):
         """set_net_class requires .kicad_pro alongside PCB."""
         pcb = tmp_path / "test.kicad_pcb"
         pcb.write_text("(kicad_pcb)")
-        fn = _get_tool_fn(net_server, "set_net_class")
-        result = fn(str(pcb), "Power", ["GND"])
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("set_net_class",
+                    pcb_path=str(pcb), class_name="Power", nets=["GND"])
         assert "error" in result
         assert "Project file not found" in result["error"]
 
-    def test_create_new_class(self, net_server, pcb_and_pro):
+    def test_create_new_class(self, pcb_server, pcb_and_pro):
         pcb_path, pro_path = pcb_and_pro
-        fn = _get_tool_fn(net_server, "set_net_class")
+        fn = _get_pcb_fn(pcb_server)
         result = fn(
-            pcb_path, "Power", ["GND", "+5V", "+3V3"],
+            "set_net_class",
+            pcb_path=pcb_path, class_name="Power", nets=["GND", "+5V", "+3V3"],
             track_width_mm=0.5, clearance_mm=0.3,
         )
         assert result["status"] == "ok"
@@ -95,13 +100,15 @@ class TestSetNetClass:
         assert assignments["+5V"] == "Power"
         assert assignments["+3V3"] == "Power"
 
-    def test_update_existing_class(self, net_server, pcb_and_pro):
+    def test_update_existing_class(self, pcb_server, pcb_and_pro):
         pcb_path, pro_path = pcb_and_pro
-        fn = _get_tool_fn(net_server, "set_net_class")
+        fn = _get_pcb_fn(pcb_server)
         # Create
-        fn(pcb_path, "Power", ["GND"], track_width_mm=0.4)
+        fn("set_net_class", pcb_path=pcb_path, class_name="Power",
+           nets=["GND"], track_width_mm=0.4)
         # Update
-        result = fn(pcb_path, "Power", ["+5V"], track_width_mm=0.6)
+        result = fn("set_net_class", pcb_path=pcb_path, class_name="Power",
+                    nets=["+5V"], track_width_mm=0.6)
         assert result["action"] == "updated"
         assert result["track_width_mm"] == 0.6
 
@@ -116,11 +123,13 @@ class TestSetNetClass:
         assert assignments["GND"] == "Power"
         assert assignments["+5V"] == "Power"
 
-    def test_multiple_classes(self, net_server, pcb_and_pro):
+    def test_multiple_classes(self, pcb_server, pcb_and_pro):
         pcb_path, pro_path = pcb_and_pro
-        fn = _get_tool_fn(net_server, "set_net_class")
-        fn(pcb_path, "Power", ["GND", "+5V"], track_width_mm=0.5)
-        fn(pcb_path, "HighSpeed", ["SDA", "SCL"], track_width_mm=0.15, clearance_mm=0.15)
+        fn = _get_pcb_fn(pcb_server)
+        fn("set_net_class", pcb_path=pcb_path, class_name="Power",
+           nets=["GND", "+5V"], track_width_mm=0.5)
+        fn("set_net_class", pcb_path=pcb_path, class_name="HighSpeed",
+           nets=["SDA", "SCL"], track_width_mm=0.15, clearance_mm=0.15)
 
         with open(pro_path) as f:
             pro = json.load(f)
@@ -129,22 +138,25 @@ class TestSetNetClass:
         names = {c["name"] for c in classes}
         assert names == {"Default", "Power", "HighSpeed"}
 
-    def test_default_via_params(self, net_server, pcb_and_pro):
+    def test_default_via_params(self, pcb_server, pcb_and_pro):
         pcb_path, pro_path = pcb_and_pro
-        fn = _get_tool_fn(net_server, "set_net_class")
-        result = fn(pcb_path, "Signal", ["SIG1"])
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("set_net_class", pcb_path=pcb_path, class_name="Signal",
+                    nets=["SIG1"])
         assert result["via_diameter_mm"] == 0.6
         assert result["via_drill_mm"] == 0.3
 
-    def test_missing_net_settings_in_pro(self, net_server, tmp_path):
+    def test_missing_net_settings_in_pro(self, pcb_server, tmp_path):
         """If the .kicad_pro has no net_settings, tool creates it."""
         pcb = tmp_path / "test.kicad_pcb"
         pcb.write_text("(kicad_pcb)")
         pro = tmp_path / "test.kicad_pro"
         pro.write_text(json.dumps({"board": {}}))
 
-        fn = _get_tool_fn(net_server, "set_net_class")
-        result = fn(str(pcb), "Power", ["GND"], track_width_mm=0.5)
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("set_net_class",
+                    pcb_path=str(pcb), class_name="Power", nets=["GND"],
+                    track_width_mm=0.5)
         assert result["status"] == "ok"
 
         with open(str(pro)) as f:

--- a/tests/test_new_tools.py
+++ b/tests/test_new_tools.py
@@ -13,8 +13,7 @@ import pytest
 from fastmcp import FastMCP
 
 from kicad_mcp.server import create_server
-from kicad_mcp.tools.pcb_board import register_pcb_board_tools
-from kicad_mcp.tools.pcb_footprints import register_pcb_footprint_tools
+from kicad_mcp.tools.pcb import register_pcb_tools
 from kicad_mcp.tools.pcb_keepout import register_pcb_keepout_tools
 from kicad_mcp.tools.export import register_export_tools
 
@@ -121,17 +120,23 @@ class TestCheckPinCollisions:
 class TestGetFootprintDimensions:
 
     @pytest.fixture
-    def fp_server(self):
-        mcp = FastMCP("test-fp")
-        register_pcb_footprint_tools(mcp)
+    def pcb_server(self):
+        mcp = FastMCP("test-pcb")
+        register_pcb_tools(mcp)
         return mcp
 
-    def test_tool_registered(self, fp_server):
-        fn = _get_tool_fn(fp_server, "get_footprint_dimensions")
+    def _get_pcb_fn(self, mcp_server):
+        tool = asyncio.run(mcp_server.get_tool("pcb"))
+        if tool is None:
+            raise ValueError("Tool 'pcb' not found")
+        return tool.fn
+
+    def test_tool_registered(self, pcb_server):
+        fn = self._get_pcb_fn(pcb_server)
         assert fn is not None
 
     @patch("kicad_mcp.tools.pcb_footprints.run_pcbnew_script")
-    def test_script_loads_footprint(self, mock_run, fp_server):
+    def test_script_loads_footprint(self, mock_run, pcb_server):
         mock_run.return_value = {
             "status": "ok",
             "library": "Resistor_SMD",
@@ -149,15 +154,16 @@ class TestGetFootprintDimensions:
                 "width_mm": 1.6, "height_mm": 0.8,
             },
         }
-        fn = _get_tool_fn(fp_server, "get_footprint_dimensions")
-        result = fn(library="Resistor_SMD", footprint_name="R_0603_1608Metric")
+        fn = self._get_pcb_fn(pcb_server)
+        result = fn("get_footprint_dimensions",
+                    library="Resistor_SMD", footprint_name="R_0603_1608Metric")
         assert result["status"] == "ok"
         assert result["pad_count"] == 2
         assert "body_bbox" in result
         assert "pad_span" in result
 
     @patch("kicad_mcp.tools.pcb_footprints.run_pcbnew_script")
-    def test_script_handles_keepout_zones(self, mock_run, fp_server):
+    def test_script_handles_keepout_zones(self, mock_run, pcb_server):
         """ESP32-WROOM-32E should report embedded keepout zones."""
         mock_run.return_value = {
             "status": "ok",
@@ -191,18 +197,21 @@ class TestGetFootprintDimensions:
             ],
             "keepout_count": 1,
         }
-        fn = _get_tool_fn(fp_server, "get_footprint_dimensions")
-        result = fn(library="RF_Module", footprint_name="ESP32-WROOM-32E")
+        fn = self._get_pcb_fn(pcb_server)
+        result = fn("get_footprint_dimensions",
+                    library="RF_Module", footprint_name="ESP32-WROOM-32E")
         assert "keepout_zones" in result
         assert result["keepout_count"] == 1
         kz = result["keepout_zones"][0]
         assert kz["constraints"]["no_footprints"] is True
 
     @patch("kicad_mcp.tools.pcb_footprints.run_pcbnew_script")
-    def test_rotation_passed_to_script(self, mock_run, fp_server):
+    def test_rotation_passed_to_script(self, mock_run, pcb_server):
         mock_run.return_value = {"status": "ok", "rotation_deg": 90}
-        fn = _get_tool_fn(fp_server, "get_footprint_dimensions")
-        fn(library="Resistor_SMD", footprint_name="R_0603_1608Metric", rotation_deg=90)
+        fn = self._get_pcb_fn(pcb_server)
+        fn("get_footprint_dimensions",
+           library="Resistor_SMD", footprint_name="R_0603_1608Metric",
+           rotation_deg=90)
         params = mock_run.call_args[1]["params"]
         assert params["rotation_deg"] == 90
 
@@ -308,13 +317,19 @@ class TestPreRouteCheck:
 class TestSetDesignRulesProjectFile:
 
     @pytest.fixture
-    def board_server(self):
-        mcp = FastMCP("test-board")
-        register_pcb_board_tools(mcp)
+    def pcb_server(self):
+        mcp = FastMCP("test-pcb")
+        register_pcb_tools(mcp)
         return mcp
 
+    def _get_pcb_fn(self, mcp_server):
+        tool = asyncio.run(mcp_server.get_tool("pcb"))
+        if tool is None:
+            raise ValueError("Tool 'pcb' not found")
+        return tool.fn
+
     @patch("kicad_mcp.tools.pcb_board.run_pcbnew_script")
-    def test_updates_kicad_pro(self, mock_run, board_server, pcb_with_pro):
+    def test_updates_kicad_pro(self, mock_run, pcb_server, pcb_with_pro):
         pcb_path, pro_path = pcb_with_pro
         mock_run.return_value = {
             "status": "ok",
@@ -328,9 +343,9 @@ class TestSetDesignRulesProjectFile:
                 "min_copper_edge_clearance_mm": 0.0,
             },
         }
-        fn = _get_tool_fn(board_server, "set_design_rules")
+        fn = self._get_pcb_fn(pcb_server)
         result = fn(
-            pcb_path,
+            "set_design_rules", pcb_path=pcb_path,
             min_through_hole_diameter_mm=0.15,
             min_copper_edge_clearance_mm=0.0,
         )
@@ -344,28 +359,28 @@ class TestSetDesignRulesProjectFile:
         assert rules["min_copper_edge_clearance"] == 0.0
 
     @patch("kicad_mcp.tools.pcb_board.run_pcbnew_script")
-    def test_no_pro_file_still_works(self, mock_run, board_server, pcb_file):
+    def test_no_pro_file_still_works(self, mock_run, pcb_server, pcb_file):
         """When no .kicad_pro exists, PCB rules are still set."""
         mock_run.return_value = {
             "status": "ok",
             "design_rules": {},
         }
-        fn = _get_tool_fn(board_server, "set_design_rules")
-        result = fn(pcb_file)
+        fn = self._get_pcb_fn(pcb_server)
+        result = fn("set_design_rules", pcb_path=pcb_file)
         assert result["project_rules_updated"] is False
 
     @patch("kicad_mcp.tools.pcb_board.run_pcbnew_script")
-    def test_default_values(self, mock_run, board_server, pcb_file):
+    def test_default_values(self, mock_run, pcb_server, pcb_file):
         """Default min_through_hole_diameter should be 0.3mm."""
         mock_run.return_value = {"status": "ok", "design_rules": {}}
-        fn = _get_tool_fn(board_server, "set_design_rules")
-        fn(pcb_file)
+        fn = self._get_pcb_fn(pcb_server)
+        fn("set_design_rules", pcb_path=pcb_file)
         params = mock_run.call_args[1]["params"]
         # Params should contain the default via drill value
         assert params["min_via_drill_mm"] == 0.3
 
     @patch("kicad_mcp.tools.pcb_board.run_pcbnew_script")
-    def test_creates_rules_section_if_missing(self, mock_run, board_server, tmp_path):
+    def test_creates_rules_section_if_missing(self, mock_run, pcb_server, tmp_path):
         """If .kicad_pro exists but has no rules section, create it."""
         pcb = tmp_path / "test.kicad_pcb"
         pcb.write_text("(kicad_pcb)")
@@ -373,8 +388,9 @@ class TestSetDesignRulesProjectFile:
         pro.write_text("{}")  # Empty project file
 
         mock_run.return_value = {"status": "ok", "design_rules": {}}
-        fn = _get_tool_fn(board_server, "set_design_rules")
-        result = fn(str(pcb), min_through_hole_diameter_mm=0.15)
+        fn = self._get_pcb_fn(pcb_server)
+        result = fn("set_design_rules", pcb_path=str(pcb),
+                    min_through_hole_diameter_mm=0.15)
         assert result["project_rules_updated"] is True
 
         with open(str(pro)) as f:

--- a/tests/test_pcb_board.py
+++ b/tests/test_pcb_board.py
@@ -13,16 +13,16 @@ from unittest.mock import patch
 import pytest
 from fastmcp import FastMCP
 
-from kicad_mcp.tools.pcb_board import register_pcb_board_tools
+from kicad_mcp.tools.pcb import register_pcb_tools
 
 
 # -- Fixtures ----------------------------------------------------------------
 
 @pytest.fixture
-def board_server():
-    """Create a FastMCP server with only board tools registered."""
-    mcp = FastMCP("test-board")
-    register_pcb_board_tools(mcp)
+def pcb_server():
+    """Create a FastMCP server with the pcb router registered."""
+    mcp = FastMCP("test-pcb")
+    register_pcb_tools(mcp)
     return mcp
 
 
@@ -43,25 +43,25 @@ def pcb_with_project(tmp_path):
     return {"pcb_path": str(pcb), "pro_path": str(pro)}
 
 
-def _get_tool_fn(mcp_server, tool_name):
-    tool = asyncio.run(mcp_server.get_tool(tool_name))
+def _get_pcb_fn(mcp_server):
+    tool = asyncio.run(mcp_server.get_tool("pcb"))
     if tool is None:
-        raise ValueError(f"Tool {tool_name!r} not found")
+        raise ValueError("Tool 'pcb' not found")
     return tool.fn
 
 
-# -- load_pcb tests ----------------------------------------------------------
+# -- load tests --------------------------------------------------------------
 
 class TestLoadPcb:
 
-    def test_file_not_found(self, board_server):
-        fn = _get_tool_fn(board_server, "load_pcb")
-        result = fn("/nonexistent/board.kicad_pcb")
+    def test_file_not_found(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("load", pcb_path="/nonexistent/board.kicad_pcb")
         assert "error" in result
         assert "not found" in result["error"].lower()
 
     @patch("kicad_mcp.tools.pcb_board.run_pcbnew_script")
-    def test_returns_board_summary(self, mock_run, board_server, pcb_file):
+    def test_returns_board_summary(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {
             "status": "ok",
             "file": pcb_file,
@@ -72,57 +72,58 @@ class TestLoadPcb:
                  "x_mm": 100.0, "y_mm": 80.0, "layer": "F.Cu"},
             ],
         }
-        fn = _get_tool_fn(board_server, "load_pcb")
-        result = fn(pcb_file)
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("load", pcb_path=pcb_file)
         assert result["status"] == "ok"
         assert result["footprint_count"] == 3
         assert result["track_count"] == 12
         mock_run.assert_called_once()
 
     @patch("kicad_mcp.tools.pcb_board.run_pcbnew_script")
-    def test_passes_path_via_params(self, mock_run, board_server, pcb_file):
+    def test_passes_path_via_params(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {"status": "ok", "file": pcb_file,
                                   "footprint_count": 0, "track_count": 0,
                                   "footprints": []}
-        fn = _get_tool_fn(board_server, "load_pcb")
-        fn(pcb_file)
+        fn = _get_pcb_fn(pcb_server)
+        fn("load", pcb_path=pcb_file)
         params = mock_run.call_args[1]["params"]
         assert params["pcb_path"] == pcb_file
 
 
-# -- create_pcb tests --------------------------------------------------------
+# -- create tests ------------------------------------------------------------
 
 class TestCreatePcb:
 
     @patch("kicad_mcp.tools.pcb_board.run_pcbnew_script")
-    def test_create_returns_ok(self, mock_run, board_server, tmp_path):
+    def test_create_returns_ok(self, mock_run, pcb_server, tmp_path):
         pcb_path = str(tmp_path / "new.kicad_pcb")
         mock_run.return_value = {"status": "ok", "file": pcb_path}
-        fn = _get_tool_fn(board_server, "create_pcb")
-        result = fn(pcb_path)
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("create", pcb_path=pcb_path)
         assert result["status"] == "ok"
 
     @patch("kicad_mcp.tools.pcb_board.run_pcbnew_script")
-    def test_passes_path_via_params(self, mock_run, board_server, tmp_path):
+    def test_passes_path_via_params(self, mock_run, pcb_server, tmp_path):
         pcb_path = str(tmp_path / "new.kicad_pcb")
         mock_run.return_value = {"status": "ok", "file": pcb_path}
-        fn = _get_tool_fn(board_server, "create_pcb")
-        fn(pcb_path)
+        fn = _get_pcb_fn(pcb_server)
+        fn("create", pcb_path=pcb_path)
         params = mock_run.call_args[1]["params"]
         assert params["pcb_path"] == pcb_path
 
 
-# -- add_board_outline tests -------------------------------------------------
+# -- set_outline tests -------------------------------------------------------
 
-class TestAddBoardOutline:
+class TestSetOutline:
 
-    def test_file_not_found(self, board_server):
-        fn = _get_tool_fn(board_server, "add_board_outline")
-        result = fn("/nonexistent/board.kicad_pcb", 0, 0, 50, 30)
+    def test_file_not_found(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("set_outline", pcb_path="/nonexistent/board.kicad_pcb",
+                    x_mm=0, y_mm=0, width_mm=50, height_mm=30)
         assert "error" in result
 
     @patch("kicad_mcp.tools.pcb_board.run_pcbnew_script")
-    def test_returns_outline_info(self, mock_run, board_server, pcb_file):
+    def test_returns_outline_info(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {
             "status": "ok",
             "previous_edge_cuts_removed": 0,
@@ -131,19 +132,21 @@ class TestAddBoardOutline:
                 "width_mm": 50.0, "height_mm": 30.0,
             },
         }
-        fn = _get_tool_fn(board_server, "add_board_outline")
-        result = fn(pcb_file, 100.0, 80.0, 50.0, 30.0)
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("set_outline", pcb_path=pcb_file,
+                    x_mm=100.0, y_mm=80.0, width_mm=50.0, height_mm=30.0)
         assert result["status"] == "ok"
         assert result["outline"]["width_mm"] == 50.0
         assert result["outline"]["height_mm"] == 30.0
 
     @patch("kicad_mcp.tools.pcb_board.run_pcbnew_script")
-    def test_passes_all_params(self, mock_run, board_server, pcb_file):
+    def test_passes_all_params(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {"status": "ok", "previous_edge_cuts_removed": 4,
                                   "outline": {"x_mm": 10, "y_mm": 20,
                                               "width_mm": 60, "height_mm": 40}}
-        fn = _get_tool_fn(board_server, "add_board_outline")
-        fn(pcb_file, 10, 20, 60, 40)
+        fn = _get_pcb_fn(pcb_server)
+        fn("set_outline", pcb_path=pcb_file,
+           x_mm=10, y_mm=20, width_mm=60, height_mm=40)
         params = mock_run.call_args[1]["params"]
         assert params["x_mm"] == 10
         assert params["y_mm"] == 20
@@ -151,14 +154,15 @@ class TestAddBoardOutline:
         assert params["height_mm"] == 40
 
     @patch("kicad_mcp.tools.pcb_board.run_pcbnew_script")
-    def test_removes_existing_outline(self, mock_run, board_server, pcb_file):
+    def test_removes_existing_outline(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {
             "status": "ok",
             "previous_edge_cuts_removed": 4,
             "outline": {"x_mm": 0, "y_mm": 0, "width_mm": 50, "height_mm": 30},
         }
-        fn = _get_tool_fn(board_server, "add_board_outline")
-        result = fn(pcb_file, 0, 0, 50, 30)
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("set_outline", pcb_path=pcb_file,
+                    x_mm=0, y_mm=0, width_mm=50, height_mm=30)
         assert result["previous_edge_cuts_removed"] == 4
 
 
@@ -166,13 +170,13 @@ class TestAddBoardOutline:
 
 class TestSetDesignRules:
 
-    def test_file_not_found(self, board_server):
-        fn = _get_tool_fn(board_server, "set_design_rules")
-        result = fn("/nonexistent/board.kicad_pcb")
+    def test_file_not_found(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("set_design_rules", pcb_path="/nonexistent/board.kicad_pcb")
         assert "error" in result
 
     @patch("kicad_mcp.tools.pcb_board.run_pcbnew_script")
-    def test_returns_design_rules(self, mock_run, board_server, pcb_with_project):
+    def test_returns_design_rules(self, mock_run, pcb_server, pcb_with_project):
         pcb_path = pcb_with_project["pcb_path"]
         mock_run.return_value = {
             "status": "ok",
@@ -186,13 +190,13 @@ class TestSetDesignRules:
                 "min_copper_edge_clearance_mm": 0.5,
             },
         }
-        fn = _get_tool_fn(board_server, "set_design_rules")
-        result = fn(pcb_path, min_track_width_mm=0.25)
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("set_design_rules", pcb_path=pcb_path, min_track_width_mm=0.25)
         assert result["status"] == "ok"
         assert result["design_rules"]["min_track_width_mm"] == 0.25
 
     @patch("kicad_mcp.tools.pcb_board.run_pcbnew_script")
-    def test_updates_project_file(self, mock_run, board_server, pcb_with_project):
+    def test_updates_project_file(self, mock_run, pcb_server, pcb_with_project):
         pcb_path = pcb_with_project["pcb_path"]
         pro_path = pcb_with_project["pro_path"]
         mock_run.return_value = {
@@ -207,9 +211,9 @@ class TestSetDesignRules:
                 "min_copper_edge_clearance_mm": 0.0,
             },
         }
-        fn = _get_tool_fn(board_server, "set_design_rules")
+        fn = _get_pcb_fn(pcb_server)
         result = fn(
-            pcb_path,
+            "set_design_rules", pcb_path=pcb_path,
             min_track_width_mm=0.3,
             min_clearance_mm=0.25,
             min_through_hole_diameter_mm=0.2,
@@ -226,7 +230,7 @@ class TestSetDesignRules:
         assert rules["min_track_width"] == 0.3
 
     @patch("kicad_mcp.tools.pcb_board.run_pcbnew_script")
-    def test_no_project_file(self, mock_run, board_server, pcb_file):
+    def test_no_project_file(self, mock_run, pcb_server, pcb_file):
         """set_design_rules works even without a .kicad_pro file."""
         mock_run.return_value = {
             "status": "ok",
@@ -240,7 +244,19 @@ class TestSetDesignRules:
                 "min_copper_edge_clearance_mm": 0.5,
             },
         }
-        fn = _get_tool_fn(board_server, "set_design_rules")
-        result = fn(pcb_file)
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("set_design_rules", pcb_path=pcb_file)
         assert result["status"] == "ok"
         assert result["project_rules_updated"] is False
+
+
+# -- unknown operation -------------------------------------------------------
+
+class TestUnknownOperation:
+
+    def test_unknown_op_returns_error(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("bogus_op", pcb_path="/some/board.kicad_pcb")
+        assert "error" in result
+        assert "unknown operation" in result["error"]
+        assert "bogus_op" in result["error"]

--- a/tests/test_pcb_footprints.py
+++ b/tests/test_pcb_footprints.py
@@ -11,16 +11,16 @@ from unittest.mock import patch, MagicMock
 import pytest
 from fastmcp import FastMCP
 
-from kicad_mcp.tools.pcb_footprints import register_pcb_footprint_tools
+from kicad_mcp.tools.pcb import register_pcb_tools
 from kicad_mcp.tools.library import register_library_tools
 
 
 # -- Fixtures ----------------------------------------------------------------
 
 @pytest.fixture
-def fp_server():
-    mcp = FastMCP("test-footprints")
-    register_pcb_footprint_tools(mcp)
+def pcb_server():
+    mcp = FastMCP("test-pcb")
+    register_pcb_tools(mcp)
     return mcp
 
 
@@ -38,6 +38,13 @@ def pcb_file(tmp_path):
     return str(pcb)
 
 
+def _get_pcb_fn(mcp_server):
+    tool = asyncio.run(mcp_server.get_tool("pcb"))
+    if tool is None:
+        raise ValueError("Tool 'pcb' not found")
+    return tool.fn
+
+
 def _get_tool_fn(mcp_server, tool_name):
     tool = asyncio.run(mcp_server.get_tool(tool_name))
     if tool is None:
@@ -49,14 +56,16 @@ def _get_tool_fn(mcp_server, tool_name):
 
 class TestPlaceFootprint:
 
-    def test_file_not_found(self, fp_server):
-        fn = _get_tool_fn(fp_server, "place_footprint")
-        result = fn("/nonexistent/board.kicad_pcb", "Resistor_SMD", "R_0805",
-                    "R1", "10k", 100, 80)
+    def test_file_not_found(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("place_footprint",
+                    pcb_path="/nonexistent/board.kicad_pcb",
+                    library="Resistor_SMD", footprint_name="R_0805",
+                    reference="R1", value="10k", x_mm=100, y_mm=80)
         assert "error" in result
 
     @patch("kicad_mcp.tools.pcb_footprints.run_pcbnew_script")
-    def test_returns_placement_info(self, mock_run, fp_server, pcb_file):
+    def test_returns_placement_info(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {
             "status": "ok",
             "placed": {
@@ -73,17 +82,24 @@ class TestPlaceFootprint:
                 "width_mm": 3.0, "height_mm": 1.0,
             },
         }
-        fn = _get_tool_fn(fp_server, "place_footprint")
-        result = fn(pcb_file, "Resistor_SMD", "R_0805", "R1", "10k", 100, 80)
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("place_footprint",
+                    pcb_path=pcb_file,
+                    library="Resistor_SMD", footprint_name="R_0805",
+                    reference="R1", value="10k", x_mm=100, y_mm=80)
         assert result["status"] == "ok"
         assert result["placed"]["reference"] == "R1"
         assert "bounding_box" in result
 
     @patch("kicad_mcp.tools.pcb_footprints.run_pcbnew_script")
-    def test_passes_all_params(self, mock_run, fp_server, pcb_file):
+    def test_passes_all_params(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {"status": "ok", "placed": {}, "bounding_box": {}}
-        fn = _get_tool_fn(fp_server, "place_footprint")
-        fn(pcb_file, "LED_SMD", "LED_0805", "D1", "RED", 50, 60,
+        fn = _get_pcb_fn(pcb_server)
+        fn("place_footprint",
+           pcb_path=pcb_file,
+           library="LED_SMD", footprint_name="LED_0805",
+           reference="D1", value="RED",
+           x_mm=50, y_mm=60,
            rotation_deg=90, layer="B.Cu")
         params = mock_run.call_args[1]["params"]
         assert params["library"] == "LED_SMD"
@@ -96,7 +112,7 @@ class TestPlaceFootprint:
         assert params["layer"] == "B.Cu"
 
     @patch("kicad_mcp.tools.pcb_footprints.run_pcbnew_script")
-    def test_placement_warnings(self, mock_run, fp_server, pcb_file):
+    def test_placement_warnings(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {
             "status": "ok",
             "placed": {"reference": "U1", "footprint": "RF:ESP32",
@@ -104,24 +120,33 @@ class TestPlaceFootprint:
             "bounding_box": {},
             "placement_warnings": ["Overlaps keepout from U1 (blocks tracks, vias)"],
         }
-        fn = _get_tool_fn(fp_server, "place_footprint")
-        result = fn(pcb_file, "RF_Module", "ESP32", "U1", "ESP32", 130, 76)
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("place_footprint",
+                    pcb_path=pcb_file,
+                    library="RF_Module", footprint_name="ESP32",
+                    reference="U1", value="ESP32",
+                    x_mm=130, y_mm=76)
         assert "placement_warnings" in result
         assert len(result["placement_warnings"]) == 1
 
     @patch("kicad_mcp.tools.pcb_footprints.run_pcbnew_script")
-    def test_keepout_check_included_by_default(self, mock_run, fp_server, pcb_file):
+    def test_keepout_check_included_by_default(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {"status": "ok", "placed": {}, "bounding_box": {}}
-        fn = _get_tool_fn(fp_server, "place_footprint")
-        fn(pcb_file, "R", "R_0805", "R1", "1k", 100, 80)
+        fn = _get_pcb_fn(pcb_server)
+        fn("place_footprint",
+           pcb_path=pcb_file, library="R", footprint_name="R_0805",
+           reference="R1", value="1k", x_mm=100, y_mm=80)
         script = mock_run.call_args[0][0]
         assert "extract_keepouts" in script
 
     @patch("kicad_mcp.tools.pcb_footprints.run_pcbnew_script")
-    def test_keepout_check_disabled(self, mock_run, fp_server, pcb_file):
+    def test_keepout_check_disabled(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {"status": "ok", "placed": {}, "bounding_box": {}}
-        fn = _get_tool_fn(fp_server, "place_footprint")
-        fn(pcb_file, "R", "R_0805", "R1", "1k", 100, 80, check_keepouts=False)
+        fn = _get_pcb_fn(pcb_server)
+        fn("place_footprint",
+           pcb_path=pcb_file, library="R", footprint_name="R_0805",
+           reference="R1", value="1k", x_mm=100, y_mm=80,
+           check_keepouts=False)
         script = mock_run.call_args[0][0]
         assert "extract_keepouts" not in script
 
@@ -130,13 +155,15 @@ class TestPlaceFootprint:
 
 class TestMoveFootprint:
 
-    def test_file_not_found(self, fp_server):
-        fn = _get_tool_fn(fp_server, "move_footprint")
-        result = fn("/nonexistent/board.kicad_pcb", "R1", 100, 80)
+    def test_file_not_found(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("move_footprint",
+                    pcb_path="/nonexistent/board.kicad_pcb",
+                    reference="R1", x_mm=100, y_mm=80)
         assert "error" in result
 
     @patch("kicad_mcp.tools.pcb_footprints.run_pcbnew_script")
-    def test_moves_footprint(self, mock_run, fp_server, pcb_file):
+    def test_moves_footprint(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {
             "status": "ok",
             "reference": "R1",
@@ -144,41 +171,45 @@ class TestMoveFootprint:
             "y_mm": 90.0,
             "rotation": 0,
         }
-        fn = _get_tool_fn(fp_server, "move_footprint")
-        result = fn(pcb_file, "R1", 120, 90)
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("move_footprint",
+                    pcb_path=pcb_file, reference="R1", x_mm=120, y_mm=90)
         assert result["status"] == "ok"
         assert result["x_mm"] == 120.0
 
     @patch("kicad_mcp.tools.pcb_footprints.run_pcbnew_script")
-    def test_move_with_rotation(self, mock_run, fp_server, pcb_file):
+    def test_move_with_rotation(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {"status": "ok", "reference": "R1",
                                   "x_mm": 100, "y_mm": 80, "rotation": 45}
-        fn = _get_tool_fn(fp_server, "move_footprint")
-        fn(pcb_file, "R1", 100, 80, rotation_deg=45)
+        fn = _get_pcb_fn(pcb_server)
+        fn("move_footprint",
+           pcb_path=pcb_file, reference="R1", x_mm=100, y_mm=80,
+           rotation_deg=45)
         params = mock_run.call_args[1]["params"]
         assert params["rotation_deg"] == 45
 
     @patch("kicad_mcp.tools.pcb_footprints.run_pcbnew_script")
-    def test_move_without_rotation(self, mock_run, fp_server, pcb_file):
+    def test_move_without_rotation(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {"status": "ok", "reference": "R1",
                                   "x_mm": 100, "y_mm": 80, "rotation": 0}
-        fn = _get_tool_fn(fp_server, "move_footprint")
-        fn(pcb_file, "R1", 100, 80)
+        fn = _get_pcb_fn(pcb_server)
+        fn("move_footprint",
+           pcb_path=pcb_file, reference="R1", x_mm=100, y_mm=80)
         params = mock_run.call_args[1]["params"]
         assert params["rotation_deg"] is None
 
 
-# -- list_pcb_footprints tests -----------------------------------------------
+# -- list_footprints tests ---------------------------------------------------
 
-class TestListPcbFootprints:
+class TestListFootprints:
 
-    def test_file_not_found(self, fp_server):
-        fn = _get_tool_fn(fp_server, "list_pcb_footprints")
-        result = fn("/nonexistent/board.kicad_pcb")
+    def test_file_not_found(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("list_footprints", pcb_path="/nonexistent/board.kicad_pcb")
         assert "error" in result
 
     @patch("kicad_mcp.tools.pcb_footprints.run_pcbnew_script")
-    def test_lists_footprints(self, mock_run, fp_server, pcb_file):
+    def test_lists_footprints(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {
             "status": "ok",
             "footprint_count": 2,
@@ -191,8 +222,8 @@ class TestListPcbFootprints:
                  "pads": []},
             ],
         }
-        fn = _get_tool_fn(fp_server, "list_pcb_footprints")
-        result = fn(pcb_file)
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("list_footprints", pcb_path=pcb_file)
         assert result["footprint_count"] == 2
         assert result["footprints"][0]["reference"] == "R1"
 
@@ -201,13 +232,14 @@ class TestListPcbFootprints:
 
 class TestGetPadPositions:
 
-    def test_file_not_found(self, fp_server):
-        fn = _get_tool_fn(fp_server, "get_pad_positions")
-        result = fn("/nonexistent/board.kicad_pcb", "R1")
+    def test_file_not_found(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("get_pad_positions",
+                    pcb_path="/nonexistent/board.kicad_pcb", reference="R1")
         assert "error" in result
 
     @patch("kicad_mcp.tools.pcb_footprints.run_pcbnew_script")
-    def test_returns_pads(self, mock_run, fp_server, pcb_file):
+    def test_returns_pads(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {
             "status": "ok",
             "reference": "U1",
@@ -219,8 +251,8 @@ class TestGetPadPositions:
                 {"number": "4", "x_mm": 102.54, "y_mm": 80, "net": "SCL", "shape": "Oval"},
             ],
         }
-        fn = _get_tool_fn(fp_server, "get_pad_positions")
-        result = fn(pcb_file, "U1")
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("get_pad_positions", pcb_path=pcb_file, reference="U1")
         assert result["pad_count"] == 4
         assert result["pads"][0]["net"] == "VCC"
 
@@ -230,7 +262,7 @@ class TestGetPadPositions:
 class TestGetFootprintDimensions:
 
     @patch("kicad_mcp.tools.pcb_footprints.run_pcbnew_script")
-    def test_returns_dimensions(self, mock_run, fp_server):
+    def test_returns_dimensions(self, mock_run, pcb_server):
         mock_run.return_value = {
             "status": "ok",
             "library": "Resistor_SMD",
@@ -247,25 +279,27 @@ class TestGetFootprintDimensions:
                          "x_max_mm": 1.7, "y_max_mm": 0.85,
                          "width_mm": 3.4, "height_mm": 1.7},
         }
-        fn = _get_tool_fn(fp_server, "get_footprint_dimensions")
-        result = fn("Resistor_SMD", "R_0805_2012Metric")
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("get_footprint_dimensions",
+                    library="Resistor_SMD", footprint_name="R_0805_2012Metric")
         assert result["status"] == "ok"
         assert result["pad_count"] == 2
         assert "body_bbox" in result
         assert "courtyard" in result
 
     @patch("kicad_mcp.tools.pcb_footprints.run_pcbnew_script")
-    def test_with_rotation(self, mock_run, fp_server):
+    def test_with_rotation(self, mock_run, pcb_server):
         mock_run.return_value = {"status": "ok", "library": "R", "footprint": "R_0805",
                                   "rotation_deg": 90, "pad_count": 2,
                                   "body_bbox": {}, "pad_span": {}}
-        fn = _get_tool_fn(fp_server, "get_footprint_dimensions")
-        fn("R", "R_0805", rotation_deg=90)
+        fn = _get_pcb_fn(pcb_server)
+        fn("get_footprint_dimensions",
+           library="R", footprint_name="R_0805", rotation_deg=90)
         params = mock_run.call_args[1]["params"]
         assert params["rotation_deg"] == 90
 
     @patch("kicad_mcp.tools.pcb_footprints.run_pcbnew_script")
-    def test_with_keepout_zones(self, mock_run, fp_server):
+    def test_with_keepout_zones(self, mock_run, pcb_server):
         mock_run.return_value = {
             "status": "ok",
             "library": "RF_Module",
@@ -284,8 +318,9 @@ class TestGetFootprintDimensions:
             ],
             "keepout_count": 1,
         }
-        fn = _get_tool_fn(fp_server, "get_footprint_dimensions")
-        result = fn("RF_Module", "ESP32-WROOM-32E")
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("get_footprint_dimensions",
+                    library="RF_Module", footprint_name="ESP32-WROOM-32E")
         assert result["keepout_count"] == 1
 
 

--- a/tests/test_pcb_nets_tools.py
+++ b/tests/test_pcb_nets_tools.py
@@ -12,15 +12,15 @@ from unittest.mock import patch
 import pytest
 from fastmcp import FastMCP
 
-from kicad_mcp.tools.pcb_nets import register_pcb_net_tools
+from kicad_mcp.tools.pcb import register_pcb_tools
 
 
 # -- Fixtures ----------------------------------------------------------------
 
 @pytest.fixture
-def net_server():
-    mcp = FastMCP("test-nets")
-    register_pcb_net_tools(mcp)
+def pcb_server():
+    mcp = FastMCP("test-pcb")
+    register_pcb_tools(mcp)
     return mcp
 
 
@@ -53,10 +53,10 @@ def pcb_with_project(tmp_path):
     return {"pcb_path": str(pcb), "pro_path": str(pro)}
 
 
-def _get_tool_fn(mcp_server, tool_name):
-    tool = asyncio.run(mcp_server.get_tool(tool_name))
+def _get_pcb_fn(mcp_server):
+    tool = asyncio.run(mcp_server.get_tool("pcb"))
     if tool is None:
-        raise ValueError(f"Tool {tool_name!r} not found")
+        raise ValueError("Tool 'pcb' not found")
     return tool.fn
 
 
@@ -64,14 +64,15 @@ def _get_tool_fn(mcp_server, tool_name):
 
 class TestAddNet:
 
-    def test_file_not_found(self, net_server):
-        fn = _get_tool_fn(net_server, "add_net")
-        result = fn("/nonexistent/board.kicad_pcb", "SDA")
+    def test_file_not_found(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("add_net",
+                    pcb_path="/nonexistent/board.kicad_pcb", net_name="SDA")
         assert "error" in result
 
-    def test_adds_new_net(self, net_server, pcb_file):
-        fn = _get_tool_fn(net_server, "add_net")
-        result = fn(pcb_file, "SDA")
+    def test_adds_new_net(self, pcb_server, pcb_file):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("add_net", pcb_path=pcb_file, net_name="SDA")
         assert result["status"] == "ok"
         assert result["net"] == "SDA"
         assert result["net_code"] == 3  # next after 2
@@ -81,17 +82,17 @@ class TestAddNet:
             content = f.read()
         assert '(net 3 "SDA")' in content
 
-    def test_existing_net_returns_ok(self, net_server, pcb_file):
-        fn = _get_tool_fn(net_server, "add_net")
-        result = fn(pcb_file, "GND")
+    def test_existing_net_returns_ok(self, pcb_server, pcb_file):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("add_net", pcb_path=pcb_file, net_name="GND")
         assert result["status"] == "ok"
         assert result["note"] == "Net already exists"
         assert result["net_code"] == 1
 
-    def test_adds_multiple_nets_sequentially(self, net_server, pcb_file):
-        fn = _get_tool_fn(net_server, "add_net")
-        r1 = fn(pcb_file, "SDA")
-        r2 = fn(pcb_file, "SCL")
+    def test_adds_multiple_nets_sequentially(self, pcb_server, pcb_file):
+        fn = _get_pcb_fn(pcb_server)
+        r1 = fn("add_net", pcb_path=pcb_file, net_name="SDA")
+        r2 = fn("add_net", pcb_path=pcb_file, net_name="SCL")
         assert r1["net_code"] == 3
         assert r2["net_code"] == 4
 
@@ -100,14 +101,16 @@ class TestAddNet:
 
 class TestRenameNet:
 
-    def test_file_not_found(self, net_server):
-        fn = _get_tool_fn(net_server, "rename_net")
-        result = fn("/nonexistent/board.kicad_pcb", "GND", "AGND")
+    def test_file_not_found(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("rename_net",
+                    pcb_path="/nonexistent/board.kicad_pcb",
+                    old_name="GND", new_name="AGND")
         assert "error" in result
 
-    def test_renames_net(self, net_server, pcb_file):
-        fn = _get_tool_fn(net_server, "rename_net")
-        result = fn(pcb_file, "GND", "AGND")
+    def test_renames_net(self, pcb_server, pcb_file):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("rename_net", pcb_path=pcb_file, old_name="GND", new_name="AGND")
         assert result["status"] == "ok"
         assert result["old_name"] == "GND"
         assert result["new_name"] == "AGND"
@@ -118,21 +121,21 @@ class TestRenameNet:
         assert '"AGND"' in content
         assert '(net 1 "GND")' not in content
 
-    def test_rename_nonexistent_net(self, net_server, pcb_file):
-        fn = _get_tool_fn(net_server, "rename_net")
-        result = fn(pcb_file, "NOSUCHNET", "NEWNAME")
+    def test_rename_nonexistent_net(self, pcb_server, pcb_file):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("rename_net", pcb_path=pcb_file, old_name="NOSUCHNET", new_name="NEWNAME")
         assert "error" in result
         assert "not found" in result["error"].lower()
 
-    def test_rename_to_existing_name(self, net_server, pcb_file):
-        fn = _get_tool_fn(net_server, "rename_net")
-        result = fn(pcb_file, "GND", "VCC")
+    def test_rename_to_existing_name(self, pcb_server, pcb_file):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("rename_net", pcb_path=pcb_file, old_name="GND", new_name="VCC")
         assert "error" in result
         assert "already exists" in result["error"]
 
-    def test_same_name_noop(self, net_server, pcb_file):
-        fn = _get_tool_fn(net_server, "rename_net")
-        result = fn(pcb_file, "GND", "GND")
+    def test_same_name_noop(self, pcb_server, pcb_file):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("rename_net", pcb_path=pcb_file, old_name="GND", new_name="GND")
         assert result["status"] == "ok"
         assert result["replacements"] == 0
 
@@ -141,13 +144,15 @@ class TestRenameNet:
 
 class TestAssignPadNet:
 
-    def test_file_not_found(self, net_server):
-        fn = _get_tool_fn(net_server, "assign_pad_net")
-        result = fn("/nonexistent/board.kicad_pcb", "R1", "1", "GND")
+    def test_file_not_found(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("assign_pad_net",
+                    pcb_path="/nonexistent/board.kicad_pcb",
+                    reference="R1", pad_number="1", net_name="GND")
         assert "error" in result
 
     @patch("kicad_mcp.tools.pcb_nets.run_pcbnew_script")
-    def test_assigns_pad(self, mock_run, net_server, pcb_file):
+    def test_assigns_pad(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {
             "status": "ok",
             "reference": "R1",
@@ -155,17 +160,19 @@ class TestAssignPadNet:
             "net": "GND",
             "sub_pads": 1,
         }
-        fn = _get_tool_fn(net_server, "assign_pad_net")
-        result = fn(pcb_file, "R1", "1", "GND")
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("assign_pad_net",
+                    pcb_path=pcb_file, reference="R1", pad_number="1", net_name="GND")
         assert result["status"] == "ok"
         assert result["reference"] == "R1"
 
     @patch("kicad_mcp.tools.pcb_nets.run_pcbnew_script")
-    def test_passes_params(self, mock_run, net_server, pcb_file):
+    def test_passes_params(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {"status": "ok", "reference": "U1",
                                   "pad": "3", "net": "VCC", "sub_pads": 1}
-        fn = _get_tool_fn(net_server, "assign_pad_net")
-        fn(pcb_file, "U1", "3", "VCC")
+        fn = _get_pcb_fn(pcb_server)
+        fn("assign_pad_net",
+           pcb_path=pcb_file, reference="U1", pad_number="3", net_name="VCC")
         params = mock_run.call_args[1]["params"]
         assert params["reference"] == "U1"
         assert params["pad_number"] == "3"
@@ -176,20 +183,22 @@ class TestAssignPadNet:
 
 class TestBulkAssignPadNets:
 
-    def test_file_not_found(self, net_server):
-        fn = _get_tool_fn(net_server, "bulk_assign_pad_nets")
-        result = fn("/nonexistent/board.kicad_pcb",
-                    [{"reference": "R1", "pad": "1", "net": "GND"}])
+    def test_file_not_found(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("bulk_assign_pad_nets",
+                    pcb_path="/nonexistent/board.kicad_pcb",
+                    assignments=[{"reference": "R1", "pad": "1", "net": "GND"}])
         assert "error" in result
 
-    def test_empty_assignments(self, net_server, pcb_file):
-        fn = _get_tool_fn(net_server, "bulk_assign_pad_nets")
-        result = fn(pcb_file, [])
+    def test_empty_assignments(self, pcb_server, pcb_file):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("bulk_assign_pad_nets",
+                    pcb_path=pcb_file, assignments=[])
         assert "error" in result
-        assert "No assignments" in result["error"]
+        assert "assignments" in result["error"]
 
     @patch("kicad_mcp.tools.pcb_nets.run_pcbnew_script")
-    def test_bulk_assign(self, mock_run, net_server, pcb_file):
+    def test_bulk_assign(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {
             "status": "ok",
             "assigned": 3,
@@ -201,28 +210,28 @@ class TestBulkAssignPadNets:
                 {"reference": "C1", "pad": "1", "net": "VCC", "sub_pads": 1},
             ],
         }
-        fn = _get_tool_fn(net_server, "bulk_assign_pad_nets")
+        fn = _get_pcb_fn(pcb_server)
         assignments = [
             {"reference": "R1", "pad": "1", "net": "GND"},
             {"reference": "R1", "pad": "2", "net": "VCC"},
             {"reference": "C1", "pad": "1", "net": "VCC"},
         ]
-        result = fn(pcb_file, assignments)
+        result = fn("bulk_assign_pad_nets", pcb_path=pcb_file, assignments=assignments)
         assert result["assigned"] == 3
         assert len(result["errors"]) == 0
 
 
-# -- list_pcb_nets tests -----------------------------------------------------
+# -- list_nets tests ---------------------------------------------------------
 
-class TestListPcbNets:
+class TestListNets:
 
-    def test_file_not_found(self, net_server):
-        fn = _get_tool_fn(net_server, "list_pcb_nets")
-        result = fn("/nonexistent/board.kicad_pcb")
+    def test_file_not_found(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("list_nets", pcb_path="/nonexistent/board.kicad_pcb")
         assert "error" in result
 
     @patch("kicad_mcp.tools.pcb_nets.run_pcbnew_script")
-    def test_lists_nets(self, mock_run, net_server, pcb_file):
+    def test_lists_nets(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {
             "status": "ok",
             "net_count": 3,
@@ -232,8 +241,8 @@ class TestListPcbNets:
                 {"code": 3, "name": "SDA"},
             ],
         }
-        fn = _get_tool_fn(net_server, "list_pcb_nets")
-        result = fn(pcb_file)
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("list_nets", pcb_path=pcb_file)
         assert result["net_count"] == 3
         assert result["nets"][0]["name"] == "GND"
 
@@ -242,22 +251,26 @@ class TestListPcbNets:
 
 class TestSetNetClass:
 
-    def test_pcb_not_found(self, net_server):
-        fn = _get_tool_fn(net_server, "set_net_class")
-        result = fn("/nonexistent/board.kicad_pcb", "Power", ["GND"])
+    def test_pcb_not_found(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("set_net_class",
+                    pcb_path="/nonexistent/board.kicad_pcb",
+                    class_name="Power", nets=["GND"])
         assert "error" in result
 
-    def test_project_not_found(self, net_server, pcb_file):
-        fn = _get_tool_fn(net_server, "set_net_class")
-        result = fn(pcb_file, "Power", ["GND"])
+    def test_project_not_found(self, pcb_server, pcb_file):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("set_net_class",
+                    pcb_path=pcb_file, class_name="Power", nets=["GND"])
         assert "error" in result
         assert "Project file not found" in result["error"]
 
-    def test_creates_net_class(self, net_server, pcb_with_project):
+    def test_creates_net_class(self, pcb_server, pcb_with_project):
         pcb_path = pcb_with_project["pcb_path"]
         pro_path = pcb_with_project["pro_path"]
-        fn = _get_tool_fn(net_server, "set_net_class")
-        result = fn(pcb_path, "Power", ["GND", "VCC"],
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("set_net_class",
+                    pcb_path=pcb_path, class_name="Power", nets=["GND", "VCC"],
                     track_width_mm=0.5, clearance_mm=0.3)
         assert result["status"] == "ok"
         assert result["action"] == "created"
@@ -269,12 +282,14 @@ class TestSetNetClass:
         assert assignments["GND"] == "Power"
         assert assignments["VCC"] == "Power"
 
-    def test_updates_existing_class(self, net_server, pcb_with_project):
+    def test_updates_existing_class(self, pcb_server, pcb_with_project):
         pcb_path = pcb_with_project["pcb_path"]
-        fn = _get_tool_fn(net_server, "set_net_class")
+        fn = _get_pcb_fn(pcb_server)
         # Create
-        fn(pcb_path, "Power", ["GND"], track_width_mm=0.5)
+        fn("set_net_class", pcb_path=pcb_path, class_name="Power",
+           nets=["GND"], track_width_mm=0.5)
         # Update
-        result = fn(pcb_path, "Power", ["GND"], track_width_mm=0.8)
+        result = fn("set_net_class", pcb_path=pcb_path, class_name="Power",
+                    nets=["GND"], track_width_mm=0.8)
         assert result["action"] == "updated"
         assert result["track_width_mm"] == 0.8

--- a/tests/test_pcb_routing.py
+++ b/tests/test_pcb_routing.py
@@ -11,15 +11,15 @@ from unittest.mock import patch
 import pytest
 from fastmcp import FastMCP
 
-from kicad_mcp.tools.pcb_routing import register_pcb_routing_tools
+from kicad_mcp.tools.pcb import register_pcb_tools
 
 
 # -- Fixtures ----------------------------------------------------------------
 
 @pytest.fixture
-def routing_server():
-    mcp = FastMCP("test-routing")
-    register_pcb_routing_tools(mcp)
+def pcb_server():
+    mcp = FastMCP("test-pcb")
+    register_pcb_tools(mcp)
     return mcp
 
 
@@ -30,10 +30,10 @@ def pcb_file(tmp_path):
     return str(pcb)
 
 
-def _get_tool_fn(mcp_server, tool_name):
-    tool = asyncio.run(mcp_server.get_tool(tool_name))
+def _get_pcb_fn(mcp_server):
+    tool = asyncio.run(mcp_server.get_tool("pcb"))
     if tool is None:
-        raise ValueError(f"Tool {tool_name!r} not found")
+        raise ValueError("Tool 'pcb' not found")
     return tool.fn
 
 
@@ -41,13 +41,15 @@ def _get_tool_fn(mcp_server, tool_name):
 
 class TestAddTrace:
 
-    def test_file_not_found(self, routing_server):
-        fn = _get_tool_fn(routing_server, "add_trace")
-        result = fn("/nonexistent/board.kicad_pcb", 0, 0, 10, 10)
+    def test_file_not_found(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("add_trace",
+                    pcb_path="/nonexistent/board.kicad_pcb",
+                    start_x_mm=0, start_y_mm=0, end_x_mm=10, end_y_mm=10)
         assert "error" in result
 
     @patch("kicad_mcp.tools.pcb_routing.run_pcbnew_script")
-    def test_returns_trace_info(self, mock_run, routing_server, pcb_file):
+    def test_returns_trace_info(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {
             "status": "ok",
             "trace": {
@@ -58,17 +60,24 @@ class TestAddTrace:
                 "net": "VCC",
             },
         }
-        fn = _get_tool_fn(routing_server, "add_trace")
-        result = fn(pcb_file, 100.0, 80.0, 110.0, 80.0, net_name="VCC")
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("add_trace",
+                    pcb_path=pcb_file,
+                    start_x_mm=100.0, start_y_mm=80.0,
+                    end_x_mm=110.0, end_y_mm=80.0,
+                    net_name="VCC")
         assert result["status"] == "ok"
         assert result["trace"]["start"] == [100.0, 80.0]
         assert result["trace"]["net"] == "VCC"
 
     @patch("kicad_mcp.tools.pcb_routing.run_pcbnew_script")
-    def test_passes_all_params(self, mock_run, routing_server, pcb_file):
+    def test_passes_all_params(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {"status": "ok", "trace": {}}
-        fn = _get_tool_fn(routing_server, "add_trace")
-        fn(pcb_file, 1, 2, 3, 4, width_mm=0.5, layer="B.Cu", net_name="GND")
+        fn = _get_pcb_fn(pcb_server)
+        fn("add_trace",
+           pcb_path=pcb_file,
+           start_x_mm=1, start_y_mm=2, end_x_mm=3, end_y_mm=4,
+           trace_width_mm=0.5, layer="B.Cu", net_name="GND")
         params = mock_run.call_args[1]["params"]
         assert params["start_x_mm"] == 1
         assert params["start_y_mm"] == 2
@@ -79,10 +88,12 @@ class TestAddTrace:
         assert params["net_name"] == "GND"
 
     @patch("kicad_mcp.tools.pcb_routing.run_pcbnew_script")
-    def test_default_width_and_layer(self, mock_run, routing_server, pcb_file):
+    def test_default_width_and_layer(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {"status": "ok", "trace": {}}
-        fn = _get_tool_fn(routing_server, "add_trace")
-        fn(pcb_file, 0, 0, 10, 10)
+        fn = _get_pcb_fn(pcb_server)
+        fn("add_trace",
+           pcb_path=pcb_file,
+           start_x_mm=0, start_y_mm=0, end_x_mm=10, end_y_mm=10)
         params = mock_run.call_args[1]["params"]
         assert params["width_mm"] == 0.25
         assert params["layer"] == "F.Cu"
@@ -93,13 +104,15 @@ class TestAddTrace:
 
 class TestAddVia:
 
-    def test_file_not_found(self, routing_server):
-        fn = _get_tool_fn(routing_server, "add_via")
-        result = fn("/nonexistent/board.kicad_pcb", 50, 50)
+    def test_file_not_found(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("add_via",
+                    pcb_path="/nonexistent/board.kicad_pcb",
+                    x_mm=50, y_mm=50)
         assert "error" in result
 
     @patch("kicad_mcp.tools.pcb_routing.run_pcbnew_script")
-    def test_returns_via_info(self, mock_run, routing_server, pcb_file):
+    def test_returns_via_info(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {
             "status": "ok",
             "via": {
@@ -108,17 +121,19 @@ class TestAddVia:
                 "type": "through", "net": "",
             },
         }
-        fn = _get_tool_fn(routing_server, "add_via")
-        result = fn(pcb_file, 50.0, 60.0)
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("add_via", pcb_path=pcb_file, x_mm=50.0, y_mm=60.0)
         assert result["status"] == "ok"
         assert result["via"]["x_mm"] == 50.0
         assert result["via"]["type"] == "through"
 
     @patch("kicad_mcp.tools.pcb_routing.run_pcbnew_script")
-    def test_custom_via_params(self, mock_run, routing_server, pcb_file):
+    def test_custom_via_params(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {"status": "ok", "via": {}}
-        fn = _get_tool_fn(routing_server, "add_via")
-        fn(pcb_file, 10, 20, drill_mm=0.4, size_mm=0.8,
+        fn = _get_pcb_fn(pcb_server)
+        fn("add_via",
+           pcb_path=pcb_file, x_mm=10, y_mm=20,
+           drill_mm=0.4, size_mm=0.8,
            net_name="GND", via_type="blind_buried")
         params = mock_run.call_args[1]["params"]
         assert params["drill_mm"] == 0.4
@@ -131,13 +146,14 @@ class TestAddVia:
 
 class TestEditTraceWidth:
 
-    def test_file_not_found(self, routing_server):
-        fn = _get_tool_fn(routing_server, "edit_trace_width")
-        result = fn("/nonexistent/board.kicad_pcb", 0.5)
+    def test_file_not_found(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("edit_trace_width",
+                    pcb_path="/nonexistent/board.kicad_pcb", new_width_mm=0.5)
         assert "error" in result
 
     @patch("kicad_mcp.tools.pcb_routing.run_pcbnew_script")
-    def test_update_all_traces(self, mock_run, routing_server, pcb_file):
+    def test_update_all_traces(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {
             "status": "ok",
             "updated": 15,
@@ -146,18 +162,20 @@ class TestEditTraceWidth:
             "net_filter": "(all)",
             "layer_filter": "(all)",
         }
-        fn = _get_tool_fn(routing_server, "edit_trace_width")
-        result = fn(pcb_file, 0.5)
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("edit_trace_width", pcb_path=pcb_file, new_width_mm=0.5)
         assert result["updated"] == 15
         assert result["skipped"] == 3
 
     @patch("kicad_mcp.tools.pcb_routing.run_pcbnew_script")
-    def test_filter_by_net_and_layer(self, mock_run, routing_server, pcb_file):
+    def test_filter_by_net_and_layer(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {"status": "ok", "updated": 5, "skipped": 10,
                                   "new_width_mm": 0.4, "net_filter": "VCC",
                                   "layer_filter": "F.Cu"}
-        fn = _get_tool_fn(routing_server, "edit_trace_width")
-        fn(pcb_file, 0.4, net_name="VCC", layer="F.Cu")
+        fn = _get_pcb_fn(pcb_server)
+        fn("edit_trace_width",
+           pcb_path=pcb_file, new_width_mm=0.4,
+           net_filter="VCC", layer_filter="F.Cu")
         params = mock_run.call_args[1]["params"]
         assert params["net_name"] == "VCC"
         assert params["layer"] == "F.Cu"
@@ -167,21 +185,21 @@ class TestEditTraceWidth:
 
 class TestClearRouting:
 
-    def test_file_not_found(self, routing_server):
-        fn = _get_tool_fn(routing_server, "clear_routing")
-        result = fn("/nonexistent/board.kicad_pcb")
+    def test_file_not_found(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("clear_routing", pcb_path="/nonexistent/board.kicad_pcb")
         assert "error" in result
 
     @patch("kicad_mcp.tools.pcb_routing.run_pcbnew_script")
-    def test_default_clears_tracks_and_vias(self, mock_run, routing_server, pcb_file):
+    def test_default_clears_tracks_and_vias(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {
             "status": "ok",
             "tracks_removed": 20,
             "vias_removed": 5,
             "zones_removed": 0,
         }
-        fn = _get_tool_fn(routing_server, "clear_routing")
-        result = fn(pcb_file)
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("clear_routing", pcb_path=pcb_file)
         assert result["tracks_removed"] == 20
         assert result["vias_removed"] == 5
         assert result["zones_removed"] == 0
@@ -191,11 +209,13 @@ class TestClearRouting:
         assert params["clear_zones"] is False
 
     @patch("kicad_mcp.tools.pcb_routing.run_pcbnew_script")
-    def test_clear_zones_too(self, mock_run, routing_server, pcb_file):
+    def test_clear_zones_too(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {"status": "ok", "tracks_removed": 0,
                                   "vias_removed": 0, "zones_removed": 2}
-        fn = _get_tool_fn(routing_server, "clear_routing")
-        fn(pcb_file, clear_tracks=False, clear_vias=False, clear_zones=True)
+        fn = _get_pcb_fn(pcb_server)
+        fn("clear_routing",
+           pcb_path=pcb_file, clear_tracks=False, clear_vias=False,
+           clear_zones_flag=True)
         params = mock_run.call_args[1]["params"]
         assert params["clear_tracks"] is False
         assert params["clear_vias"] is False

--- a/tests/test_pcb_silkscreen.py
+++ b/tests/test_pcb_silkscreen.py
@@ -1,6 +1,6 @@
 """
 Tests for PCB silkscreen tools: add text, list items, update items,
-check overlaps, auto-fix, finalize.
+check overlaps, auto-fix.
 
 Unit tests mock run_pcbnew_script.
 """
@@ -11,15 +11,15 @@ from unittest.mock import patch
 import pytest
 from fastmcp import FastMCP
 
-from kicad_mcp.tools.pcb_silkscreen import register_pcb_silkscreen_tools
+from kicad_mcp.tools.pcb import register_pcb_tools
 
 
 # -- Fixtures ----------------------------------------------------------------
 
 @pytest.fixture
-def silk_server():
-    mcp = FastMCP("test-silkscreen")
-    register_pcb_silkscreen_tools(mcp)
+def pcb_server():
+    mcp = FastMCP("test-pcb")
+    register_pcb_tools(mcp)
     return mcp
 
 
@@ -30,24 +30,26 @@ def pcb_file(tmp_path):
     return str(pcb)
 
 
-def _get_tool_fn(mcp_server, tool_name):
-    tool = asyncio.run(mcp_server.get_tool(tool_name))
+def _get_pcb_fn(mcp_server):
+    tool = asyncio.run(mcp_server.get_tool("pcb"))
     if tool is None:
-        raise ValueError(f"Tool {tool_name!r} not found")
+        raise ValueError("Tool 'pcb' not found")
     return tool.fn
 
 
-# -- add_text_to_pcb tests --------------------------------------------------
+# -- add_text tests ----------------------------------------------------------
 
-class TestAddTextToPcb:
+class TestAddText:
 
-    def test_file_not_found(self, silk_server):
-        fn = _get_tool_fn(silk_server, "add_text_to_pcb")
-        result = fn("/nonexistent/board.kicad_pcb", "Hello", 100, 80)
+    def test_file_not_found(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("add_text",
+                    pcb_path="/nonexistent/board.kicad_pcb",
+                    text="Hello", x_mm=100, y_mm=80)
         assert "error" in result
 
     @patch("kicad_mcp.tools.pcb_silkscreen.run_pcbnew_script")
-    def test_adds_text(self, mock_run, silk_server, pcb_file):
+    def test_adds_text(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {
             "status": "ok",
             "text": "Rev 1.0",
@@ -55,17 +57,20 @@ class TestAddTextToPcb:
             "y_mm": 115.0,
             "layer": "F.SilkS",
         }
-        fn = _get_tool_fn(silk_server, "add_text_to_pcb")
-        result = fn(pcb_file, "Rev 1.0", 110, 115)
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("add_text",
+                    pcb_path=pcb_file, text="Rev 1.0", x_mm=110, y_mm=115)
         assert result["status"] == "ok"
         assert result["text"] == "Rev 1.0"
 
     @patch("kicad_mcp.tools.pcb_silkscreen.run_pcbnew_script")
-    def test_passes_all_params(self, mock_run, silk_server, pcb_file):
+    def test_passes_all_params(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {"status": "ok", "text": "X", "x_mm": 0,
                                   "y_mm": 0, "layer": "B.SilkS"}
-        fn = _get_tool_fn(silk_server, "add_text_to_pcb")
-        fn(pcb_file, "X", 10, 20, layer="B.SilkS", size_mm=2.0,
+        fn = _get_pcb_fn(pcb_server)
+        fn("add_text",
+           pcb_path=pcb_file, text="X", x_mm=10, y_mm=20,
+           layer="B.SilkS", text_size_mm=2.0,
            thickness_mm=0.2, rotation_deg=45)
         params = mock_run.call_args[1]["params"]
         assert params["text"] == "X"
@@ -75,17 +80,17 @@ class TestAddTextToPcb:
         assert params["rotation_deg"] == 45
 
 
-# -- list_silkscreen_items tests ---------------------------------------------
+# -- list_silkscreen tests ---------------------------------------------------
 
-class TestListSilkscreenItems:
+class TestListSilkscreen:
 
-    def test_file_not_found(self, silk_server):
-        fn = _get_tool_fn(silk_server, "list_silkscreen_items")
-        result = fn("/nonexistent/board.kicad_pcb")
+    def test_file_not_found(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("list_silkscreen", pcb_path="/nonexistent/board.kicad_pcb")
         assert "error" in result
 
     @patch("kicad_mcp.tools.pcb_silkscreen.run_pcbnew_script")
-    def test_lists_items(self, mock_run, silk_server, pcb_file):
+    def test_lists_items(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {
             "status": "ok",
             "item_count": 3,
@@ -101,45 +106,49 @@ class TestListSilkscreenItems:
                  "x_mm": 110, "y_mm": 115, "size_mm": 1.0},
             ],
         }
-        fn = _get_tool_fn(silk_server, "list_silkscreen_items")
-        result = fn(pcb_file)
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("list_silkscreen", pcb_path=pcb_file)
         assert result["item_count"] == 3
         refs = [i for i in result["items"] if i["type"] == "reference"]
         assert len(refs) == 1
 
 
-# -- update_silkscreen_item tests -------------------------------------------
+# -- update_silkscreen tests -------------------------------------------------
 
-class TestUpdateSilkscreenItem:
+class TestUpdateSilkscreen:
 
-    def test_file_not_found(self, silk_server):
-        fn = _get_tool_fn(silk_server, "update_silkscreen_item")
-        result = fn("/nonexistent/board.kicad_pcb", "R1")
+    def test_file_not_found(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("update_silkscreen",
+                    pcb_path="/nonexistent/board.kicad_pcb", reference="R1")
         # Should return error (either file not found or no modifications)
         assert "error" in result
 
-    def test_invalid_field(self, silk_server, pcb_file):
-        fn = _get_tool_fn(silk_server, "update_silkscreen_item")
-        result = fn(pcb_file, "R1", field="invalid")
+    def test_invalid_field(self, pcb_server, pcb_file):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("update_silkscreen",
+                    pcb_path=pcb_file, reference="R1", silk_field="invalid")
         assert "error" in result
         assert "reference" in result["error"] or "value" in result["error"]
 
-    def test_no_modifications(self, silk_server, pcb_file):
-        fn = _get_tool_fn(silk_server, "update_silkscreen_item")
-        result = fn(pcb_file, "R1")
+    def test_no_modifications(self, pcb_server, pcb_file):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("update_silkscreen",
+                    pcb_path=pcb_file, reference="R1")
         assert "error" in result
         assert "No modifications" in result["error"]
 
     @patch("kicad_mcp.tools.pcb_silkscreen.run_pcbnew_script")
-    def test_update_visibility(self, mock_run, silk_server, pcb_file):
+    def test_update_visibility(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {
             "status": "ok",
             "reference": "R1",
             "field": "reference",
             "changes": {"visible": False},
         }
-        fn = _get_tool_fn(silk_server, "update_silkscreen_item")
-        result = fn(pcb_file, "R1", visible=False)
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("update_silkscreen",
+                    pcb_path=pcb_file, reference="R1", visible=False)
         assert result["status"] == "ok"
 
 
@@ -147,24 +156,25 @@ class TestUpdateSilkscreenItem:
 
 class TestCheckSilkscreenOverlaps:
 
-    def test_file_not_found(self, silk_server):
-        fn = _get_tool_fn(silk_server, "check_silkscreen_overlaps")
-        result = fn("/nonexistent/board.kicad_pcb")
+    def test_file_not_found(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("check_silkscreen_overlaps",
+                    pcb_path="/nonexistent/board.kicad_pcb")
         assert "error" in result
 
     @patch("kicad_mcp.tools.pcb_silkscreen.run_pcbnew_script")
-    def test_no_overlaps(self, mock_run, silk_server, pcb_file):
+    def test_no_overlaps(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {
             "status": "ok",
             "overlap_count": 0,
             "overlaps": [],
         }
-        fn = _get_tool_fn(silk_server, "check_silkscreen_overlaps")
-        result = fn(pcb_file)
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("check_silkscreen_overlaps", pcb_path=pcb_file)
         assert result["overlap_count"] == 0
 
     @patch("kicad_mcp.tools.pcb_silkscreen.run_pcbnew_script")
-    def test_reports_overlaps(self, mock_run, silk_server, pcb_file):
+    def test_reports_overlaps(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {
             "status": "ok",
             "overlap_count": 2,
@@ -173,8 +183,8 @@ class TestCheckSilkscreenOverlaps:
                 {"item1": "C1 ref", "item2": "pad U1:1", "type": "text-pad"},
             ],
         }
-        fn = _get_tool_fn(silk_server, "check_silkscreen_overlaps")
-        result = fn(pcb_file)
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("check_silkscreen_overlaps", pcb_path=pcb_file)
         assert result["overlap_count"] == 2
 
 
@@ -182,13 +192,13 @@ class TestCheckSilkscreenOverlaps:
 
 class TestAutoFixSilkscreen:
 
-    def test_file_not_found(self, silk_server):
-        fn = _get_tool_fn(silk_server, "auto_fix_silkscreen")
-        result = fn("/nonexistent/board.kicad_pcb")
+    def test_file_not_found(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("auto_fix_silkscreen", pcb_path="/nonexistent/board.kicad_pcb")
         assert "error" in result
 
     @patch("kicad_mcp.tools.pcb_silkscreen.run_pcbnew_script")
-    def test_fixes_overlaps(self, mock_run, silk_server, pcb_file):
+    def test_fixes_overlaps(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {
             "status": "ok",
             "overlaps_before": 5,
@@ -199,30 +209,7 @@ class TestAutoFixSilkscreen:
                 {"reference": "R2", "action": "hidden", "reason": "persistent overlap"},
             ],
         }
-        fn = _get_tool_fn(silk_server, "auto_fix_silkscreen")
-        result = fn(pcb_file)
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("auto_fix_silkscreen", pcb_path=pcb_file)
         assert result["status"] == "ok"
         assert result["fixes_applied"] == 4
-
-
-# -- edit_text tests ---------------------------------------------------------
-
-class TestEditText:
-
-    def test_file_not_found(self, silk_server):
-        fn = _get_tool_fn(silk_server, "edit_text")
-        result = fn("/nonexistent/board.kicad_pcb", "Rev 1.0", new_text="Rev 2.0")
-        assert "error" in result
-
-    @patch("kicad_mcp.tools.pcb_silkscreen.run_pcbnew_script")
-    def test_edits_text(self, mock_run, silk_server, pcb_file):
-        mock_run.return_value = {
-            "status": "ok",
-            "old_text": "Rev 1.0",
-            "new_text": "Rev 2.0",
-            "items_updated": 1,
-        }
-        fn = _get_tool_fn(silk_server, "edit_text")
-        result = fn(pcb_file, "Rev 1.0", new_text="Rev 2.0")
-        assert result["status"] == "ok"
-        assert result["items_updated"] == 1

--- a/tests/test_pcb_zones.py
+++ b/tests/test_pcb_zones.py
@@ -11,15 +11,15 @@ from unittest.mock import patch
 import pytest
 from fastmcp import FastMCP
 
-from kicad_mcp.tools.pcb_zones import register_pcb_zone_tools
+from kicad_mcp.tools.pcb import register_pcb_tools
 
 
 # -- Fixtures ----------------------------------------------------------------
 
 @pytest.fixture
-def zone_server():
-    mcp = FastMCP("test-zones")
-    register_pcb_zone_tools(mcp)
+def pcb_server():
+    mcp = FastMCP("test-pcb")
+    register_pcb_tools(mcp)
     return mcp
 
 
@@ -30,24 +30,25 @@ def pcb_file(tmp_path):
     return str(pcb)
 
 
-def _get_tool_fn(mcp_server, tool_name):
-    tool = asyncio.run(mcp_server.get_tool(tool_name))
+def _get_pcb_fn(mcp_server):
+    tool = asyncio.run(mcp_server.get_tool("pcb"))
     if tool is None:
-        raise ValueError(f"Tool {tool_name!r} not found")
+        raise ValueError("Tool 'pcb' not found")
     return tool.fn
 
 
-# -- add_copper_zone tests ---------------------------------------------------
+# -- add_zone tests ----------------------------------------------------------
 
-class TestAddCopperZone:
+class TestAddZone:
 
-    def test_file_not_found(self, zone_server):
-        fn = _get_tool_fn(zone_server, "add_copper_zone")
-        result = fn("/nonexistent/board.kicad_pcb", "GND")
+    def test_file_not_found(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("add_zone",
+                    pcb_path="/nonexistent/board.kicad_pcb", net_name="GND")
         assert "error" in result
 
     @patch("kicad_mcp.tools.pcb_zones.run_pcbnew_script")
-    def test_returns_zone_info(self, mock_run, zone_server, pcb_file):
+    def test_returns_zone_info(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {
             "status": "ok",
             "zone": {
@@ -60,8 +61,9 @@ class TestAddCopperZone:
                 "priority": 0,
             },
         }
-        fn = _get_tool_fn(zone_server, "add_copper_zone")
-        result = fn(pcb_file, "GND", layer="B.Cu",
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("add_zone",
+                    pcb_path=pcb_file, net_name="GND", layer="B.Cu",
                     corners=[[0, 0], [50, 0], [50, 30], [0, 30]])
         assert result["status"] == "ok"
         assert result["zone"]["net"] == "GND"
@@ -69,7 +71,7 @@ class TestAddCopperZone:
         assert len(result["zone"]["corners"]) == 4
 
     @patch("kicad_mcp.tools.pcb_zones.run_pcbnew_script")
-    def test_auto_outline_when_no_corners(self, mock_run, zone_server, pcb_file):
+    def test_auto_outline_when_no_corners(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {
             "status": "ok",
             "auto_outline": True,
@@ -78,20 +80,21 @@ class TestAddCopperZone:
                      "clearance_mm": 0.3, "min_width_mm": 0.2,
                      "connect_pads": "thermal", "priority": 0},
         }
-        fn = _get_tool_fn(zone_server, "add_copper_zone")
-        result = fn(pcb_file, "GND")
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("add_zone", pcb_path=pcb_file, net_name="GND")
         assert result["status"] == "ok"
         # Verify empty corners is passed (auto-outline in pcbnew script)
         params = mock_run.call_args[1]["params"]
         assert params["corners"] == []
 
     @patch("kicad_mcp.tools.pcb_zones.run_pcbnew_script")
-    def test_passes_all_params(self, mock_run, zone_server, pcb_file):
+    def test_passes_all_params(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {"status": "ok", "zone": {}}
-        fn = _get_tool_fn(zone_server, "add_copper_zone")
-        fn(pcb_file, "VCC", layer="F.Cu",
+        fn = _get_pcb_fn(pcb_server)
+        fn("add_zone",
+           pcb_path=pcb_file, net_name="VCC", layer="F.Cu",
            corners=[[0, 0], [10, 0], [10, 10], [0, 10]],
-           clearance_mm=0.5, min_width_mm=0.3,
+           zone_clearance_mm=0.5, min_width_mm=0.3,
            connect_pads="solid", priority=1)
         params = mock_run.call_args[1]["params"]
         assert params["net_name"] == "VCC"
@@ -102,10 +105,10 @@ class TestAddCopperZone:
         assert params["priority"] == 1
 
     @patch("kicad_mcp.tools.pcb_zones.run_pcbnew_script")
-    def test_uses_60s_timeout(self, mock_run, zone_server, pcb_file):
+    def test_uses_60s_timeout(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {"status": "ok", "zone": {}}
-        fn = _get_tool_fn(zone_server, "add_copper_zone")
-        fn(pcb_file, "GND")
+        fn = _get_pcb_fn(pcb_server)
+        fn("add_zone", pcb_path=pcb_file, net_name="GND")
         assert mock_run.call_args[1]["timeout"] == 60.0
 
 
@@ -113,13 +116,13 @@ class TestAddCopperZone:
 
 class TestFillZones:
 
-    def test_file_not_found(self, zone_server):
-        fn = _get_tool_fn(zone_server, "fill_zones")
-        result = fn("/nonexistent/board.kicad_pcb")
+    def test_file_not_found(self, pcb_server):
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("fill_zones", pcb_path="/nonexistent/board.kicad_pcb")
         assert "error" in result
 
     @patch("kicad_mcp.tools.pcb_zones.run_pcbnew_script")
-    def test_returns_fill_results(self, mock_run, zone_server, pcb_file):
+    def test_returns_fill_results(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {
             "status": "ok",
             "fill_success": True,
@@ -131,26 +134,26 @@ class TestFillZones:
                  "filled_area_mm2": 800.0},
             ],
         }
-        fn = _get_tool_fn(zone_server, "fill_zones")
-        result = fn(pcb_file)
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("fill_zones", pcb_path=pcb_file)
         assert result["status"] == "ok"
         assert result["zones_filled"] == 2
         assert result["fill_success"] is True
 
     @patch("kicad_mcp.tools.pcb_zones.run_pcbnew_script")
-    def test_no_zones_to_fill(self, mock_run, zone_server, pcb_file):
+    def test_no_zones_to_fill(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {
             "status": "ok",
             "message": "No copper zones to fill",
             "zones_filled": 0,
         }
-        fn = _get_tool_fn(zone_server, "fill_zones")
-        result = fn(pcb_file)
+        fn = _get_pcb_fn(pcb_server)
+        result = fn("fill_zones", pcb_path=pcb_file)
         assert result["zones_filled"] == 0
 
     @patch("kicad_mcp.tools.pcb_zones.run_pcbnew_script")
-    def test_uses_60s_timeout(self, mock_run, zone_server, pcb_file):
+    def test_uses_60s_timeout(self, mock_run, pcb_server, pcb_file):
         mock_run.return_value = {"status": "ok", "zones_filled": 0}
-        fn = _get_tool_fn(zone_server, "fill_zones")
-        fn(pcb_file)
+        fn = _get_pcb_fn(pcb_server)
+        fn("fill_zones", pcb_path=pcb_file)
         assert mock_run.call_args[1]["timeout"] == 60.0

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -33,10 +33,11 @@ class TestCreateServer:
         Target: 14 tools. Current count tracks the in-progress migration.
         Phase 2: 90-12+3=81.
         Phase 3: audit router replaces 9 keepout tools → 81-9+1=73.
+        Phase 4: pcb router replaces 29 individual pcb_* tools → 73-29+1=45.
         """
         tools = asyncio.run(mcp_server.list_tools())
-        assert len(tools) == 73, (
-            f"Expected 73 tools, got {len(tools)}. "
+        assert len(tools) == 45, (
+            f"Expected 45 tools, got {len(tools)}. "
             "Update this test if tools were intentionally added or removed."
         )
 
@@ -45,35 +46,8 @@ class TestExpectedToolsExist:
     """Verify that specific important tools are registered."""
 
     EXPECTED_TOOLS = [
-        # PCB board tools
-        "create_pcb",
-        "load_pcb",
-        "add_board_outline",
-        # PCB footprint tools
-        "place_footprint",
-        "move_footprint",
-        "list_pcb_footprints",
-        "get_pad_positions",
-        "get_footprint_dimensions",
-        # PCB net tools
-        "add_net",
-        "assign_pad_net",
-        "bulk_assign_pad_nets",
-        "list_pcb_nets",
-        # PCB routing tools
-        "add_trace",
-        "add_via",
-        "clear_routing",
-        "set_design_rules",
-        # PCB zone tools
-        "add_copper_zone",
-        "fill_zones",
-        # PCB silkscreen tools
-        "list_silkscreen_items",
-        "update_silkscreen_item",
-        "check_silkscreen_overlaps",
-        "auto_fix_silkscreen",
-        "add_text_to_pcb",
+        # Phase 4 router (pcb — replaces all individual pcb_* tools)
+        "pcb",
         # PCB panelize tools
         "panelize_pcb",
         # Phase 3 router (audit)


### PR DESCRIPTION
## Summary
Phase 4 of the Tool Consolidation spec — the **pcb router**, second-largest in scope. Stacked on [phase 3 (#24)](https://github.com/blwfish/kicad-mcp/pull/24).

Folds 28 PCB editing tools (board lifecycle + footprints + nets + routing + zones + silkscreen + text) into one ``pcb`` router.

## Layout
- New file: ``src/kicad_mcp/tools/pcb.py`` — the router and its dispatch.
- Source files (``pcb_board/footprints/nets/routing/zones/silkscreen.py``) reduced to module-level ``_op_*`` helpers.
- Existing helpers stay where they live (``KEEPOUT_HELPER``, ``LIB_SEARCH_HELPER``, geometry utils, etc.).

## Shared with audit (spec Resolved Q2)
- ``pcb.check_silkscreen_overlaps`` and ``audit.check_silkscreen_overlaps`` both call the **same** ``_op_check_silkscreen_overlaps`` impl.
- ``pcb.get_constraints`` and ``audit.constraints`` both call the same impl in ``pcb_keepout.py``.
- No duplication — one source of truth per semantic op.

## Docstring decision
- Router docstring is 117 lines (one line per op grouped by sub-domain).
- Within FastMCP's tool-description limit. **Not splitting** to pcb + pcb_text. If phase 5 (schematic) bumps into the limit and we need to revisit, the seam (silkscreen + text) is still pre-decided per the spec.

## Test plan
- [x] 626 tests pass.
- [x] Tool count: 73 → 45 (spec target was 47; spec slightly over-counted; not a defect).
- [x] All 28 old PCB tool names absent.
- [x] All 6 PCB test files rewritten through the pcb router.
- [x] Manual: ``audit.check_silkscreen_overlaps`` and ``pcb.check_silkscreen_overlaps`` both reachable and resolve to the same impl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)