### PR TITLE
Phase 5: schematic router (45 → 13)

### DIFF
--- a/AGENT-INSTALL.md
+++ b/AGENT-INSTALL.md
@@ -4,7 +4,7 @@ This file is for you, the AI agent. It tells you what needs to be true on this s
 
 ## What This Is
 
-kicad-mcp is a Model Context Protocol (MCP) server providing 45 tools for KiCad electronic design automation — schematic capture, PCB layout, autorouting, DRC, and more. Once installed and registered, these tools appear in your tool list and you can design circuit boards conversationally.
+kicad-mcp is a Model Context Protocol (MCP) server providing 13 tools for KiCad electronic design automation — schematic capture, PCB layout, autorouting, DRC, and more. Once installed and registered, these tools appear in your tool list and you can design circuit boards conversationally.
 
 **Origin:** Built by one person for personal use, on a Mac, with Claude Code. Other platforms *should* work (the code handles macOS, Windows, and Linux) but are untested. PRs for other agents and platforms will be considered.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This tool enables your AI agent to use [KiCad](https://www.kicad.org/) — the i
 
 ## What This Does
 
-You describe what you need — "design a board for this ESP32 circuit" or "here's the schematic, lay out the PCB" — and your AI agent does the rest: drawing the schematic, choosing components, placing them on the board, routing traces, checking for errors, and producing manufacturing-ready files. All using the same KiCad that professional engineers use, with 45 tools covering the full design workflow.
+You describe what you need — "design a board for this ESP32 circuit" or "here's the schematic, lay out the PCB" — and your AI agent does the rest: drawing the schematic, choosing components, placing them on the board, routing traces, checking for errors, and producing manufacturing-ready files. All using the same KiCad that professional engineers use, with 13 tools covering the full design workflow.
 
 You don't need to know KiCad. You don't need to know what a PCB layout tool does. You just need an AI agent (like [Claude](https://claude.ai/)).
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1,5 +1,5 @@
 # Tool Summary
 
-This MCP server exposes 45 MCP tools for KiCad EDA.
+This MCP server exposes 13 MCP tools for KiCad EDA.
 
 See [README.md](README.md) for the full tool list and usage guide.

--- a/src/kicad_mcp/server.py
+++ b/src/kicad_mcp/server.py
@@ -46,15 +46,10 @@ def create_server() -> FastMCP:
     # Domain routers (phase 3: audit)
     # Note: register_pcb_keepout_tools is imported above and already called.
 
-    # Tools not yet consolidated into routers
-    from kicad_mcp.tools.netlist import register_netlist_tools
+    # Schematic router (phase 5: replaces 32 individual schematic tools + find_component_connections)
+    from kicad_mcp.tools.schematic_router import register_schematic_router
 
-    register_netlist_tools(mcp)
-
-    # Schematic tools (wrapping kicad-sch-api)
-    from kicad_mcp.tools.schematic import register_schematic_tools
-
-    register_schematic_tools(mcp)
+    register_schematic_router(mcp)
 
     logger.info("KiCad MCP server initialized with all tool modules")
     return mcp

--- a/src/kicad_mcp/tools/netlist.py
+++ b/src/kicad_mcp/tools/netlist.py
@@ -222,211 +222,204 @@ async def _op_analyze_schematic_connections(
         return {"success": False, "error": str(e)}
 
 
-def register_netlist_tools(mcp: FastMCP) -> None:
-    """Register netlist tools not yet folded into a router.
+async def _op_find_component_connections(
+    project_path: str,
+    component_ref: str,
+    ctx: "Context | None",
+) -> Dict[str, Any]:
+    """Find all connections for a specific component in a KiCad project.
 
-    Only ``find_component_connections`` is registered here; it moves to
-    the schematic router in phase 5.
+    Extracted from the standalone tool so the schematic router (phase 5)
+    can delegate to it.
     """
+    logger.debug(
+        "Finding connections for component %s in project: %s",
+        component_ref, project_path,
+    )
 
-    @mcp.tool()
-    async def find_component_connections(
-        project_path: str,
-        component_ref: str,
-        ctx: Context | None,
-    ) -> Dict[str, Any]:
-        """Find all connections for a specific component in a KiCad project.
+    if not os.path.exists(project_path):
+        logger.warning(f"Project not found: {project_path}")
+        if ctx:
+            ctx.info(f"Project not found: {project_path}")
+        return {
+            "success": False,
+            "error": f"Project not found: {project_path}",
+        }
 
-        This tool extracts information about how a specific component
-        is connected to other components in the schematic.
+    if ctx:
+        await ctx.report_progress(10, 100)
 
-        Args:
-            project_path: Path to the KiCad project file (.kicad_pro)
-            component_ref: Component reference (e.g., "R1", "U3")
-            ctx: MCP context for progress reporting
+    try:
+        files = get_project_files(project_path)
 
-        Returns:
-            Dictionary with component connection information
-        """
-        logger.debug(
-            "Finding connections for component %s in project: %s",
-            component_ref, project_path,
-        )
-
-        if not os.path.exists(project_path):
-            logger.warning(f"Project not found: {project_path}")
+        if "schematic" not in files:
+            logger.warning("Schematic file not found in project")
             if ctx:
-                ctx.info(f"Project not found: {project_path}")
+                ctx.info("Schematic file not found in project")
             return {
                 "success": False,
-                "error": f"Project not found: {project_path}",
+                "error": "Schematic file not found in project",
             }
+
+        schematic_path = files["schematic"]
+        logger.debug(f"Found schematic file: {schematic_path}")
+        if ctx:
+            ctx.info(
+                f"Found schematic file: {os.path.basename(schematic_path)}"
+            )
 
         if ctx:
-            await ctx.report_progress(10, 100)
+            await ctx.report_progress(30, 100)
+            ctx.info(
+                f"Extracting netlist to find connections for {component_ref}..."
+            )
 
-        try:
-            files = get_project_files(project_path)
+        netlist_data = _parse_netlist(schematic_path)
 
-            if "schematic" not in files:
-                logger.warning("Schematic file not found in project")
-                if ctx:
-                    ctx.info("Schematic file not found in project")
-                return {
-                    "success": False,
-                    "error": "Schematic file not found in project",
-                }
-
-            schematic_path = files["schematic"]
-            logger.debug(f"Found schematic file: {schematic_path}")
+        if "error" in netlist_data:
+            logger.warning(f"Failed to extract netlist: {netlist_data['error']}")
             if ctx:
                 ctx.info(
-                    f"Found schematic file: {os.path.basename(schematic_path)}"
+                    f"Failed to extract netlist: {netlist_data['error']}"
                 )
+            return {"success": False, "error": netlist_data["error"]}
 
+        components = netlist_data.get("components", {})
+        if component_ref not in components:
+            logger.warning(f"Component {component_ref} not found in schematic")
             if ctx:
-                await ctx.report_progress(30, 100)
                 ctx.info(
-                    f"Extracting netlist to find connections for {component_ref}..."
+                    f"Component {component_ref} not found in schematic"
                 )
-
-            netlist_data = _parse_netlist(schematic_path)
-
-            if "error" in netlist_data:
-                logger.warning(f"Failed to extract netlist: {netlist_data['error']}")
-                if ctx:
-                    ctx.info(
-                        f"Failed to extract netlist: {netlist_data['error']}"
-                    )
-                return {"success": False, "error": netlist_data["error"]}
-
-            components = netlist_data.get("components", {})
-            if component_ref not in components:
-                logger.warning(f"Component {component_ref} not found in schematic")
-                if ctx:
-                    ctx.info(
-                        f"Component {component_ref} not found in schematic"
-                    )
-                return {
-                    "success": False,
-                    "error": f"Component {component_ref} not found in schematic",
-                    "available_components": list(components.keys()),
-                }
-
-            component_info = components[component_ref]
-
-            if ctx:
-                await ctx.report_progress(50, 100)
-                ctx.info("Finding connections...")
-
-            nets = netlist_data.get("nets", {})
-            connections = []
-            connected_nets = []
-
-            for net_name, pins in nets.items():
-                component_pins = []
-                for pin in pins:
-                    if pin.get("component") == component_ref:
-                        component_pins.append(pin)
-
-                if component_pins:
-                    net_connections = []
-
-                    for pin in component_pins:
-                        pin_num = pin.get("pin", "Unknown")
-                        connected_components = []
-
-                        for other_pin in pins:
-                            other_comp = other_pin.get("component")
-                            if other_comp and other_comp != component_ref:
-                                connected_components.append({
-                                    "component": other_comp,
-                                    "pin": other_pin.get("pin", "Unknown"),
-                                })
-
-                        net_connections.append({
-                            "pin": pin_num,
-                            "net": net_name,
-                            "connected_to": connected_components,
-                        })
-
-                    connections.extend(net_connections)
-                    connected_nets.append(net_name)
-
-            if ctx:
-                await ctx.report_progress(70, 100)
-                ctx.info("Analyzing connections...")
-
-            # Categorize connections by pin function.
-            # Substring matching ("IN" in name) misfires badly on common
-            # pin names: VIN, DRAIN, SHDN, MAIN all contain "IN". Tokenize
-            # the pin name and match exact tokens with word boundaries.
-            pin_functions: dict[str, dict] = {}
-            skipped_pins_missing_num = 0  # surfaced in result regardless of pins-present branch
-
-            _POWER_TOKENS = {"VCC", "VDD", "VEE", "VSS", "GND", "PWR", "POWER", "VBUS"}
-            _IO_TOKENS = {"IO", "I/O", "GPIO"}
-            _INPUT_TOKENS = {"IN", "INPUT"}
-            _OUTPUT_TOKENS = {"OUT", "OUTPUT"}
-
-            def _name_tokens(name: str):
-                # Split on non-alphanumeric (and underscore); upper-case;
-                # produces tokens like ["VIN"] not ["V", "IN"], so VIN
-                # doesn't false-match as INPUT.
-                return {t.upper() for t in re.split(r"[^A-Za-z0-9/]+", name) if t}
-
-            if "pins" in component_info:
-                for pin in component_info["pins"]:
-                    pin_num = pin.get("num")
-                    if not pin_num:
-                        # Pins lacking a "num" attribute would otherwise
-                        # collapse into a single pin_functions[None] entry
-                        # (each new None-num pin overwriting the previous).
-                        skipped_pins_missing_num += 1
-                        continue
-                    pin_name = pin.get("name", "")
-                    tokens = _name_tokens(pin_name)
-
-                    if tokens & _POWER_TOKENS:
-                        pin_type = "power"
-                    elif tokens & _IO_TOKENS:
-                        pin_type = "io"
-                    elif tokens & _INPUT_TOKENS:
-                        pin_type = "input"
-                    elif tokens & _OUTPUT_TOKENS:
-                        pin_type = "output"
-                    else:
-                        pin_type = "unknown"
-
-                    pin_functions[pin_num] = {
-                        "name": pin_name,
-                        "type": pin_type,
-                    }
-
-            result = {
-                "success": True,
-                "project_path": project_path,
-                "schematic_path": schematic_path,
-                "component": component_ref,
-                "component_info": component_info,
-                "connections": connections,
-                "connected_nets": connected_nets,
-                "pin_functions": pin_functions,
-                "pins_skipped_missing_num": skipped_pins_missing_num,
-                "total_connections": len(connections),
+            return {
+                "success": False,
+                "error": f"Component {component_ref} not found in schematic",
+                "available_components": list(components.keys()),
             }
 
-            if ctx:
-                await ctx.report_progress(100, 100)
-                ctx.info(
-                    f"Found {len(connections)} connections for "
-                    f"component {component_ref}"
-                )
+        component_info = components[component_ref]
 
-            return result
+        if ctx:
+            await ctx.report_progress(50, 100)
+            ctx.info("Finding connections...")
 
-        except Exception as e:
-            logger.warning(f"Error finding component connections: {e}")
-            if ctx:
-                ctx.info(f"Error finding component connections: {e}")
-            return {"success": False, "error": str(e)}
+        nets = netlist_data.get("nets", {})
+        connections = []
+        connected_nets = []
+
+        for net_name, pins in nets.items():
+            component_pins = []
+            for pin in pins:
+                if pin.get("component") == component_ref:
+                    component_pins.append(pin)
+
+            if component_pins:
+                net_connections = []
+
+                for pin in component_pins:
+                    pin_num = pin.get("pin", "Unknown")
+                    connected_components = []
+
+                    for other_pin in pins:
+                        other_comp = other_pin.get("component")
+                        if other_comp and other_comp != component_ref:
+                            connected_components.append({
+                                "component": other_comp,
+                                "pin": other_pin.get("pin", "Unknown"),
+                            })
+
+                    net_connections.append({
+                        "pin": pin_num,
+                        "net": net_name,
+                        "connected_to": connected_components,
+                    })
+
+                connections.extend(net_connections)
+                connected_nets.append(net_name)
+
+        if ctx:
+            await ctx.report_progress(70, 100)
+            ctx.info("Analyzing connections...")
+
+        # Categorize connections by pin function.
+        # Substring matching ("IN" in name) misfires badly on common
+        # pin names: VIN, DRAIN, SHDN, MAIN all contain "IN". Tokenize
+        # the pin name and match exact tokens with word boundaries.
+        pin_functions: dict[str, dict] = {}
+        skipped_pins_missing_num = 0  # surfaced in result regardless of pins-present branch
+
+        _POWER_TOKENS = {"VCC", "VDD", "VEE", "VSS", "GND", "PWR", "POWER", "VBUS"}
+        _IO_TOKENS = {"IO", "I/O", "GPIO"}
+        _INPUT_TOKENS = {"IN", "INPUT"}
+        _OUTPUT_TOKENS = {"OUT", "OUTPUT"}
+
+        def _name_tokens(name: str):
+            # Split on non-alphanumeric (and underscore); upper-case;
+            # produces tokens like ["VIN"] not ["V", "IN"], so VIN
+            # doesn't false-match as INPUT.
+            return {t.upper() for t in re.split(r"[^A-Za-z0-9/]+", name) if t}
+
+        if "pins" in component_info:
+            for pin in component_info["pins"]:
+                pin_num = pin.get("num")
+                if not pin_num:
+                    # Pins lacking a "num" attribute would otherwise
+                    # collapse into a single pin_functions[None] entry
+                    # (each new None-num pin overwriting the previous).
+                    skipped_pins_missing_num += 1
+                    continue
+                pin_name = pin.get("name", "")
+                tokens = _name_tokens(pin_name)
+
+                if tokens & _POWER_TOKENS:
+                    pin_type = "power"
+                elif tokens & _IO_TOKENS:
+                    pin_type = "io"
+                elif tokens & _INPUT_TOKENS:
+                    pin_type = "input"
+                elif tokens & _OUTPUT_TOKENS:
+                    pin_type = "output"
+                else:
+                    pin_type = "unknown"
+
+                pin_functions[pin_num] = {
+                    "name": pin_name,
+                    "type": pin_type,
+                }
+
+        result = {
+            "success": True,
+            "project_path": project_path,
+            "schematic_path": schematic_path,
+            "component": component_ref,
+            "component_info": component_info,
+            "connections": connections,
+            "connected_nets": connected_nets,
+            "pin_functions": pin_functions,
+            "pins_skipped_missing_num": skipped_pins_missing_num,
+            "total_connections": len(connections),
+        }
+
+        if ctx:
+            await ctx.report_progress(100, 100)
+            ctx.info(
+                f"Found {len(connections)} connections for "
+                f"component {component_ref}"
+            )
+
+        return result
+
+    except Exception as e:
+        logger.warning(f"Error finding component connections: {e}")
+        if ctx:
+            ctx.info(f"Error finding component connections: {e}")
+        return {"success": False, "error": str(e)}
+
+
+def register_netlist_tools(mcp: FastMCP) -> None:
+    """No-op stub — find_component_connections moved to schematic router (phase 5)."""
+    # Previously registered find_component_connections as a standalone tool.
+    # Phase 5 folds it into the schematic router; this function is kept as a
+    # no-op so any existing callers of register_netlist_tools don't break at
+    # import time.
+    pass

--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -35,6 +35,119 @@ def _require_schematic() -> Any:
 
 
 # ---------------------------------------------------------------------------
+# Module-level helpers (used by schematic_router; also defined as closures
+# inside register_schematic_tools for backward compat with existing tool fns)
+# ---------------------------------------------------------------------------
+
+def _snap(x: float, y: float) -> tuple:
+    """Round both coordinates to the nearest KiCad schematic grid step."""
+    g = SCHEMATIC_GRID_MM
+    return (round(round(x / g) * g, 6), round(round(y / g) * g, 6))
+
+
+def _parse_unit_pin_mapping(symbol_def):
+    """Parse raw KiCad symbol data to build {unit_num: [pin_numbers]} mapping.
+
+    Multi-unit symbols (LM393, 7400, etc.) have sub-symbols named like
+    ``LM393_1_1`` (unit 1, style 1), ``LM393_3_1`` (unit 3, style 1).
+    Style ``_2`` variants are DeMorgan representations and are skipped.
+    """
+    import sexpdata as _sexpdata
+
+    def _tag(elem) -> str:
+        if isinstance(elem, _sexpdata.Symbol):
+            return elem.value()
+        return str(elem).strip('"')
+
+    unit_pins: dict = {}
+    raw = symbol_def.raw_kicad_data
+    if not isinstance(raw, list):
+        return unit_pins
+    for item in raw:
+        if not isinstance(item, list) or len(item) < 2:
+            continue
+        if _tag(item[0]) != "symbol":
+            continue
+        name = item[1] if isinstance(item[1], str) else str(item[1]).strip('"')
+        parts = name.split("_")
+        if len(parts) < 3:
+            continue
+        try:
+            unit_num = int(parts[-2])
+            style = int(parts[-1])
+            if style != 1:
+                continue
+        except ValueError:
+            logger.debug("Skipped malformed sub-symbol name %r in unit-pin mapping", name)
+            continue
+        pins: list = []
+        for sub in item:
+            if not isinstance(sub, list) or len(sub) < 2:
+                continue
+            if _tag(sub[0]) != "pin":
+                continue
+            for s in sub:
+                if isinstance(s, list) and len(s) >= 2:
+                    if _tag(s[0]) == "number":
+                        pn = s[1] if isinstance(s[1], str) else str(s[1]).strip('"')
+                        pins.append(pn)
+        if pins:
+            unit_pins[unit_num] = pins
+    return unit_pins
+
+
+def _find_component_for_pin(sch, reference: str, pin_number: str):
+    """Find the component instance (unit) that owns the given pin."""
+    from kicad_sch_api.library.cache import get_symbol_cache
+    all_comps = [c for c in sch.components if c.reference == reference]
+    if len(all_comps) <= 1:
+        return sch.components.get(reference)
+    cache = get_symbol_cache()
+    symbol_def = cache.get_symbol(all_comps[0].lib_id)
+    if symbol_def is None:
+        return all_comps[0]
+    unit_pins = _parse_unit_pin_mapping(symbol_def)
+    for comp in all_comps:
+        unit = getattr(comp, "unit", None)
+        if unit is None:
+            unit = getattr(getattr(comp, "_data", None), "unit", 1) or 1
+        if pin_number in unit_pins.get(unit, []):
+            return comp
+    return all_comps[0]
+
+
+def _kicad_pin_position(comp, pin_number: str):
+    """Return the absolute pin-tip position as KiCad computes it."""
+    import math
+    from kicad_sch_api.core.types import Point
+    pin = comp.get_pin(pin_number)
+    if pin is None:
+        return None
+    angle_rad = math.radians(comp.rotation)
+    cos_a = math.cos(angle_rad)
+    sin_a = math.sin(angle_rad)
+    rx = pin.position.x * cos_a - pin.position.y * sin_a
+    ry = pin.position.x * sin_a + pin.position.y * cos_a
+    return Point(
+        round(comp.position.x + rx, 3),
+        round(comp.position.y - ry, 3),
+    )
+
+
+def _pin_wire_offset(comp, pin_number: str, distance: float = 2.54):
+    """Compute (dx, dy) for a wire stub extending away from the symbol body."""
+    import math
+    pin = comp.get_pin(pin_number)
+    if pin is None:
+        return (distance, 0.0)
+    away_deg = (-pin.rotation - comp.rotation + 180) % 360
+    away_rad = math.radians(away_deg)
+    dx = distance * math.cos(away_rad)
+    dy = distance * math.sin(away_rad)
+    return _snap(dx, dy)
+
+
+# ---------------------------------------------------------------------------
 # Registration
 # ---------------------------------------------------------------------------
 

--- a/src/kicad_mcp/tools/schematic_router.py
+++ b/src/kicad_mcp/tools/schematic_router.py
@@ -1,0 +1,922 @@
+"""Schematic domain router — all schematic editing operations.
+
+See docs/SPEC_Tool_Consolidation.md §1.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from fastmcp import FastMCP, Context
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Op imports — schematic.py exposes module-level state and helpers;
+# netlist.py exposes _op_find_component_connections.
+# ---------------------------------------------------------------------------
+
+import kicad_mcp.tools.schematic as _sch_mod
+from kicad_mcp.tools.schematic import (
+    _require_schematic,
+    _snap,
+    _kicad_pin_position,
+    _pin_wire_offset,
+    _find_component_for_pin,
+    _parse_unit_pin_mapping,
+    SCHEMATIC_GRID_MM,
+)
+
+
+async def _op_find_component_connections(
+    project_path: str,
+    component_ref: str,
+    ctx: "Context | None",
+) -> Dict[str, Any]:
+    """Delegate to netlist.py's async implementation."""
+    from kicad_mcp.tools.netlist import _op_find_component_connections as _impl
+    return await _impl(project_path, component_ref, ctx)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+def register_schematic_router(mcp: FastMCP) -> None:
+    """Register the schematic domain router."""
+
+    # Lazy import — allows server startup without kicad-sch-api installed.
+    try:
+        import kicad_sch_api as ksa  # noqa: F401
+    except ImportError:
+        logger.warning(
+            "kicad-sch-api not installed — schematic router will not be available. "
+            "Install with: pip install kicad-sch-api"
+        )
+        return
+
+    @mcp.tool()
+    async def schematic(
+        operation: str,
+        *,
+        # ── File lifecycle ────────────────────────────────────────────────
+        name: Optional[str] = None,
+        schematic_path: Optional[str] = None,
+        new_path: Optional[str] = None,
+        suffix: str = ".backup",
+        # ── Components ────────────────────────────────────────────────────
+        lib_id: Optional[str] = None,
+        reference: Optional[str] = None,
+        value: Optional[str] = None,
+        position: Optional[List[float]] = None,
+        footprint: Optional[str] = None,
+        properties: Optional[str] = None,
+        units: Optional[List[int]] = None,
+        unit_spacing: float = 15.0,
+        criteria: Optional[Dict[str, Any]] = None,
+        updates: Optional[Dict[str, Any]] = None,
+        x1: Optional[float] = None,
+        y1: Optional[float] = None,
+        x2: Optional[float] = None,
+        y2: Optional[float] = None,
+        # ── Component pins ────────────────────────────────────────────────
+        pin_number: Optional[str] = None,
+        project_path: Optional[str] = None,
+        component_ref: Optional[str] = None,
+        # ── Wires ─────────────────────────────────────────────────────────
+        start_pos: Optional[List[float]] = None,
+        end_pos: Optional[List[float]] = None,
+        wire_uuid: Optional[str] = None,
+        comp1_ref: Optional[str] = None,
+        pin1: Optional[str] = None,
+        comp2_ref: Optional[str] = None,
+        pin2: Optional[str] = None,
+        # ── Junctions ─────────────────────────────────────────────────────
+        diameter: float = 0.0,
+        # ── Labels ────────────────────────────────────────────────────────
+        text: Optional[str] = None,
+        rotation: float = 0.0,
+        size: float = 1.27,
+        label_uuid: Optional[str] = None,
+        new_text: Optional[str] = None,
+        offset: float = 0.0,
+        shape: str = "input",
+        net_name: Optional[str] = None,
+        # ── Sheets ────────────────────────────────────────────────────────
+        filename: Optional[str] = None,
+        sheet_size: Optional[List[float]] = None,
+        sheet_uuid: Optional[str] = None,
+        pin_type: Optional[str] = None,
+        # ── find_component_connections async ctx ──────────────────────────
+        ctx: Optional[Any] = None,
+    ) -> Dict[str, Any]:
+        """Schematic domain router — file lifecycle, components, wires, labels, sheets.
+
+        Operations:
+
+        # File lifecycle
+          create(name) -> {status, name}
+              Create a new KiCad schematic.
+          load(schematic_path) -> {status, file_path, components}
+              Load an existing .kicad_sch file.
+          save(schematic_path?) -> {status, file_path}
+              Save current schematic; omit schematic_path to save in place.
+          validate() -> {status, issues, errors, warnings, details}
+              Validate schematic for ERC issues.
+          info() -> {status, components, wires, junctions, modified, ...}
+              Summary of current schematic state. (was: get_schematic_info)
+          clone(new_name?) -> {status, name, components}
+              Clone the current schematic (does NOT load the clone).
+          backup(suffix=".backup") -> {status, backup_path}
+              Create a timestamped backup of the current schematic file.
+          check_pin_collisions() -> {status, collision_count, collisions, summary}
+              Detect pin-position collisions that cause silent net merges.
+
+        # Components — CRUD
+          add_component(lib_id, reference, value, position, footprint?, properties?)
+              -> {status, reference, lib_id, value, position}
+          add_multi_unit_component(lib_id, reference, value, position,
+                                   units?, footprint?, unit_spacing=15)
+              -> {status, reference, total_units, units}   for multi-unit symbols
+          remove_component(reference) -> {status, reference}
+          move_component(reference, position) -> {status, reference, old_position, new_position}
+          list_components() -> {status, count, components}
+          filter_components(lib_id?, value?, reference?, footprint?) -> {status, count, components}
+          components_in_area(x1, y1, x2, y2) -> {status, count, components}
+          bulk_update_components(criteria, updates) -> {status, updated}
+
+        # Component pins (read-only queries)
+          get_component_pin_position(reference, pin_number) -> {status, reference, pin_number, x, y}
+          list_component_pins(reference) -> {status, reference, count, pins}
+          find_component_connections(project_path, component_ref) -> {success, connections, ...}
+              Netlist-based query; reads .kicad_pro + extracts schematic netlist.
+
+        # Wires (verb-overlap pair — pick by what you have)
+          add_wire(start_pos, end_pos) -> {status, wire_uuid, start, end}
+              Add wire by absolute [x, y] coordinates.
+          add_wire_between_pins(comp1_ref, pin1, comp2_ref, pin2)
+              -> {status, pins, segments, segment_count}
+              Add wire by component+pin refs — preferred when you have refs.
+          remove_wire(wire_uuid) -> {status, wire_uuid}
+          add_junction(position, diameter=0) -> {status, junction_uuid, position}
+
+        # Labels (verb-overlap family — pick by intent)
+          add_label(text, position, rotation=0, size=1.27)
+              -> {status, label_uuid, text, position}
+              Net label placed at absolute coordinates.
+          add_label_to_pin(reference, pin_number, text, offset=0)
+              -> {status, label_uuid, text, reference, pin_number, position}
+              Net label attached directly to a pin — preferred when labeling a pin.
+          add_hierarchical_label(text, position, shape="input", rotation=0, size=1.27)
+              -> {status, label_uuid, text, shape, position}
+              For hierarchical sheet pins, not ordinary net labels.
+          connect_pins_with_labels(comp1_ref, pin1, comp2_ref, pin2, net_name)
+              -> {status, net_name, labels_created, label_uuids}
+              High-level: places matching labels on two pins to connect them via a net.
+          remove_label(label_uuid) -> {status, label_uuid}
+          edit_label(label_uuid, new_text?, position?, rotation?, size?)
+              -> {status, label_uuid, text, position, rotation, size}
+
+        # Text annotations
+          add_text(text, position, rotation=0, size=1.27)
+              -> {status, text_uuid, text, position}
+          add_text_box(text, position, sheet_size, rotation=0, font_size=1.27)
+              -> {status, textbox_uuid, text, position, size}
+
+        # Hierarchical sheets
+          add_sheet(name, filename, position, sheet_size) -> {status, sheet_uuid, name, filename, position, size}
+          add_sheet_pin(sheet_uuid, name, pin_type, position) -> {status, pin_uuid, name, pin_type, sheet_uuid}
+        """
+        import kicad_sch_api as ksa
+
+        # ── File lifecycle ─────────────────────────────────────────────────
+
+        if operation == "create":
+            _sch_mod._current_schematic = ksa.create_schematic(name or "untitled")
+            logger.info("Created new schematic: %s", name or "untitled")
+            return {"status": "ok", "name": name or "untitled"}
+
+        if operation == "load":
+            if schematic_path is None:
+                return {"error": "operation='load' requires 'schematic_path'"}
+            _sch_mod._current_schematic = ksa.load_schematic(schematic_path)
+            comp_count = len(list(_sch_mod._current_schematic.components))
+            logger.info("Loaded schematic: %s (%d components)", schematic_path, comp_count)
+            return {"status": "ok", "file_path": schematic_path, "components": comp_count}
+
+        if operation == "save":
+            sch = _require_schematic()
+            if schematic_path:
+                sch.save(schematic_path)
+            else:
+                sch.save()
+            dest = schematic_path or str(getattr(sch, "file_path", "current file"))
+            logger.info("Saved schematic to: %s", dest)
+            return {"status": "ok", "file_path": dest}
+
+        if operation == "validate":
+            sch = _require_schematic()
+            issues = sch.validate()
+            if not issues:
+                return {"status": "ok", "issues": 0, "errors": 0, "warnings": 0, "details": []}
+            details = []
+            errors = 0
+            warnings = 0
+            for issue in issues:
+                level = issue.level.value if hasattr(issue.level, "value") else str(issue.level)
+                if level in ("error", "critical"):
+                    errors += 1
+                elif level == "warning":
+                    warnings += 1
+                details.append({"level": level, "message": str(issue)})
+            return {
+                "status": "ok",
+                "issues": len(issues),
+                "errors": errors,
+                "warnings": warnings,
+                "details": details[:20],
+                "details_truncated": len(details) > 20,
+            }
+
+        if operation == "info":
+            sch = _require_schematic()
+            try:
+                summary = sch.get_summary()
+            except Exception as e:
+                logger.warning("sch.get_summary() failed: %s", e)
+                summary = {}
+            info: Dict[str, Any] = {
+                "status": "ok",
+                "components": len(list(sch.components)),
+                "wires": len(sch.wires) if hasattr(sch, "wires") else 0,
+                "junctions": len(sch.junctions) if hasattr(sch, "junctions") else 0,
+                "modified": getattr(sch, "modified", False),
+            }
+            for k, v in summary.items():
+                if k not in info:
+                    info[k] = v
+            return info
+
+        if operation == "clone":
+            sch = _require_schematic()
+            cloned = sch.clone(name)
+            comp_count = len(list(cloned.components))
+            return {"status": "ok", "name": name or "Clone", "components": comp_count}
+
+        if operation == "backup":
+            sch = _require_schematic()
+            backup_path = sch.backup(suffix)
+            return {"status": "ok", "backup_path": str(backup_path)}
+
+        if operation == "check_pin_collisions":
+            sch = _require_schematic()
+            position_map: Dict[tuple, list] = {}
+            for comp in sch.components:
+                ref = comp.reference
+                for pin in comp.pins:
+                    pin_pos = _kicad_pin_position(comp, pin.number)
+                    if pin_pos is None:
+                        continue
+                    key = (round(pin_pos.x, 2), round(pin_pos.y, 2))
+                    position_map.setdefault(key, []).append({
+                        "reference": ref,
+                        "pin_number": pin.number,
+                        "pin_name": pin.name,
+                    })
+            collisions = []
+            for pos, pins in position_map.items():
+                if len(pins) < 2:
+                    continue
+                refs = {p["reference"] for p in pins}
+                if len(refs) < 2:
+                    continue
+                collisions.append({
+                    "position": [pos[0], pos[1]],
+                    "pins": pins,
+                    "component_count": len(refs),
+                    "message": (
+                        f"{len(pins)} pins from {len(refs)} components collide at "
+                        f"({pos[0]}, {pos[1]}): "
+                        + ", ".join(f"{p['reference']}:{p['pin_number']}" for p in pins)
+                    ),
+                })
+            if collisions:
+                summary_msg = (
+                    f"{len(collisions)} pin collision(s) found — these will cause "
+                    f"silent net merges. Move components to separate the pins."
+                )
+            else:
+                total_pins = sum(len(v) for v in position_map.values())
+                summary_msg = f"No pin collisions among {total_pins} pins"
+            return {
+                "status": "ok",
+                "collision_count": len(collisions),
+                "collisions": collisions,
+                "summary": summary_msg,
+            }
+
+        # ── Components — CRUD ──────────────────────────────────────────────
+
+        if operation == "add_component":
+            if lib_id is None:
+                return {"error": "operation='add_component' requires 'lib_id'"}
+            if reference is None:
+                return {"error": "operation='add_component' requires 'reference'"}
+            if value is None:
+                return {"error": "operation='add_component' requires 'value'"}
+            if position is None:
+                return {"error": "operation='add_component' requires 'position'"}
+            if len(position) != 2:
+                return {"error": "position must be [x, y]"}
+            sch = _require_schematic()
+            pos = list(_snap(position[0], position[1]))
+            comp = sch.components.add(
+                lib_id=lib_id,
+                reference=reference,
+                value=value,
+                position=tuple(pos),
+                footprint=footprint,
+            )
+            if properties:
+                for prop in properties.split(","):
+                    if "=" in prop:
+                        key, val = prop.strip().split("=", 1)
+                        comp.set_property(key.strip(), val.strip())
+            logger.info("Added component %s (%s) = %s at %s", reference, lib_id, value, pos)
+            return {
+                "status": "ok",
+                "reference": reference,
+                "lib_id": lib_id,
+                "value": value,
+                "position": pos,
+            }
+
+        if operation == "add_multi_unit_component":
+            if lib_id is None:
+                return {"error": "operation='add_multi_unit_component' requires 'lib_id'"}
+            if reference is None:
+                return {"error": "operation='add_multi_unit_component' requires 'reference'"}
+            if value is None:
+                return {"error": "operation='add_multi_unit_component' requires 'value'"}
+            if position is None:
+                return {"error": "operation='add_multi_unit_component' requires 'position'"}
+            if len(position) != 2:
+                return {"error": "position must be [x, y]"}
+            sch = _require_schematic()
+            from kicad_sch_api.library.cache import get_symbol_cache
+            cache = get_symbol_cache()
+            symbol_def = cache.get_symbol(lib_id)
+            if symbol_def is None:
+                return {"error": f"Symbol '{lib_id}' not found in KiCad libraries"}
+            unit_pins = _parse_unit_pin_mapping(symbol_def)
+            if not unit_pins:
+                # Single-unit symbol — fall through to normal add
+                pos = list(_snap(position[0], position[1]))
+                comp = sch.components.add(
+                    lib_id=lib_id, reference=reference, value=value,
+                    position=tuple(pos), footprint=footprint,
+                )
+                return {"status": "ok", "reference": reference, "lib_id": lib_id,
+                        "value": value, "position": pos}
+            units_to_place = sorted(units) if units is not None else sorted(unit_pins.keys())
+            invalid = [u for u in units_to_place if u not in unit_pins]
+            if invalid:
+                return {
+                    "error": f"Units {invalid} not found in symbol. Available: {sorted(unit_pins.keys())}",
+                }
+            if len(units_to_place) == len(unit_pins) and units is None:
+                result = sch.components.add(
+                    lib_id=lib_id, reference=reference, value=value,
+                    position=tuple(position), footprint=footprint,
+                    add_all_units=True, unit_spacing=unit_spacing,
+                )
+                placed_units = []
+                for comp in result:
+                    unit = getattr(comp, "unit", None)
+                    if unit is None:
+                        unit = getattr(getattr(comp, "_data", None), "unit", 1)
+                    placed_units.append({
+                        "unit": unit,
+                        "pins": unit_pins.get(unit, []),
+                        "position": [round(comp.position.x, 3), round(comp.position.y, 3)],
+                    })
+            else:
+                placed_units = []
+                for i, unit_num in enumerate(units_to_place):
+                    unit_x = position[0]
+                    unit_y = position[1] + i * unit_spacing
+                    comp = sch.components.add(
+                        lib_id=lib_id, reference=reference, value=value,
+                        position=(unit_x, unit_y), footprint=footprint,
+                        unit=unit_num,
+                    )
+                    placed_units.append({
+                        "unit": unit_num,
+                        "pins": unit_pins[unit_num],
+                        "position": [round(comp.position.x, 3), round(comp.position.y, 3)],
+                    })
+            logger.info(
+                "Added multi-unit component %s (%s) with %d units: %s",
+                reference, lib_id, len(placed_units), [u["unit"] for u in placed_units],
+            )
+            return {
+                "status": "ok",
+                "reference": reference,
+                "lib_id": lib_id,
+                "value": value,
+                "total_units": len(placed_units),
+                "units": placed_units,
+            }
+
+        if operation == "remove_component":
+            if reference is None:
+                return {"error": "operation='remove_component' requires 'reference'"}
+            sch = _require_schematic()
+            removed = sch.components.remove(reference)
+            if removed:
+                return {"status": "ok", "reference": reference}
+            return {"error": f"Component {reference} not found"}
+
+        if operation == "move_component":
+            if reference is None:
+                return {"error": "operation='move_component' requires 'reference'"}
+            if position is None:
+                return {"error": "operation='move_component' requires 'position'"}
+            if len(position) != 2:
+                return {"error": "position must be [x, y]"}
+            sch = _require_schematic()
+            matches = list(sch.components.filter(reference=reference))
+            if not matches:
+                return {"error": f"Component {reference!r} not found"}
+            comp = matches[0]
+            old_pos = [comp.position.x, comp.position.y] if comp.position else None
+            new_pos = list(_snap(position[0], position[1]))
+            comp.position = tuple(new_pos)
+            return {
+                "status": "ok",
+                "reference": reference,
+                "old_position": old_pos,
+                "new_position": new_pos,
+            }
+
+        if operation == "list_components":
+            sch = _require_schematic()
+            components = []
+            for comp in sch.components:
+                entry: Dict[str, Any] = {
+                    "reference": comp.reference,
+                    "lib_id": comp.lib_id,
+                    "value": comp.value,
+                }
+                if hasattr(comp, "position") and comp.position:
+                    entry["position"] = [comp.position.x, comp.position.y]
+                if hasattr(comp, "footprint") and comp.footprint:
+                    entry["footprint"] = comp.footprint
+                components.append(entry)
+            return {"status": "ok", "count": len(components), "components": components}
+
+        if operation == "filter_components":
+            sch = _require_schematic()
+            filter_criteria: Dict[str, str] = {}
+            if lib_id:
+                filter_criteria["lib_id"] = lib_id
+            if value:
+                filter_criteria["value"] = value
+            if reference:
+                filter_criteria["reference"] = reference
+            if footprint:
+                filter_criteria["footprint"] = footprint
+            if not filter_criteria:
+                return {"error": "At least one filter criterion required"}
+            filtered = sch.components.filter(**filter_criteria)
+            results = []
+            for comp in filtered:
+                results.append({
+                    "reference": comp.reference,
+                    "lib_id": comp.lib_id,
+                    "value": comp.value,
+                    "position": [comp.position.x, comp.position.y] if comp.position else None,
+                })
+            return {"status": "ok", "count": len(results), "components": results}
+
+        if operation == "components_in_area":
+            if x1 is None or y1 is None or x2 is None or y2 is None:
+                return {"error": "operation='components_in_area' requires 'x1', 'y1', 'x2', 'y2'"}
+            sch = _require_schematic()
+            found = sch.components.in_area(x1, y1, x2, y2)
+            results = []
+            for comp in found:
+                results.append({
+                    "reference": comp.reference,
+                    "lib_id": comp.lib_id,
+                    "position": [comp.position.x, comp.position.y] if comp.position else None,
+                })
+            return {"status": "ok", "count": len(results), "components": results}
+
+        if operation == "bulk_update_components":
+            if criteria is None:
+                return {"error": "operation='bulk_update_components' requires 'criteria'"}
+            if updates is None:
+                return {"error": "operation='bulk_update_components' requires 'updates'"}
+            sch = _require_schematic()
+            updated_count = sch.components.bulk_update(criteria=criteria, updates=updates)
+            return {"status": "ok", "updated": updated_count}
+
+        # ── Component pins ─────────────────────────────────────────────────
+
+        if operation == "get_component_pin_position":
+            if reference is None:
+                return {"error": "operation='get_component_pin_position' requires 'reference'"}
+            if pin_number is None:
+                return {"error": "operation='get_component_pin_position' requires 'pin_number'"}
+            sch = _require_schematic()
+            comp = _find_component_for_pin(sch, reference, pin_number)
+            if comp is None:
+                return {"error": f"Component {reference} not found"}
+            pin_pos = _kicad_pin_position(comp, pin_number)
+            if pin_pos is None:
+                return {"error": f"Pin {pin_number} not found on {reference}"}
+            return {
+                "status": "ok",
+                "reference": reference,
+                "pin_number": pin_number,
+                "x": round(pin_pos.x, 3),
+                "y": round(pin_pos.y, 3),
+            }
+
+        if operation == "list_component_pins":
+            if reference is None:
+                return {"error": "operation='list_component_pins' requires 'reference'"}
+            sch = _require_schematic()
+            all_comps = [c for c in sch.components if c.reference == reference]
+            if not all_comps:
+                return {"error": f"Component {reference} not found"}
+            pins_data = []
+            seen_pins: set = set()
+            if len(all_comps) == 1:
+                comp = all_comps[0]
+                for pin in comp.pins:
+                    pin_pos = _kicad_pin_position(comp, pin.number)
+                    entry: Dict[str, Any] = {"number": pin.number, "name": pin.name}
+                    if pin_pos:
+                        entry["x"] = round(pin_pos.x, 3)
+                        entry["y"] = round(pin_pos.y, 3)
+                    pins_data.append(entry)
+            else:
+                from kicad_sch_api.library.cache import get_symbol_cache
+                cache = get_symbol_cache()
+                symbol_def = cache.get_symbol(all_comps[0].lib_id)
+                unit_pins = _parse_unit_pin_mapping(symbol_def) if symbol_def else {}
+                for comp in all_comps:
+                    unit = getattr(comp, "unit", None)
+                    if unit is None:
+                        unit = getattr(getattr(comp, "_data", None), "unit", 1) or 1
+                    pins_in_unit = set(unit_pins.get(unit, []))
+                    for pin in comp.pins:
+                        if pin.number in seen_pins:
+                            continue
+                        if pins_in_unit and pin.number not in pins_in_unit:
+                            continue
+                        seen_pins.add(pin.number)
+                        pin_pos = _kicad_pin_position(comp, pin.number)
+                        entry = {"number": pin.number, "name": pin.name, "unit": unit}
+                        if pin_pos:
+                            entry["x"] = round(pin_pos.x, 3)
+                            entry["y"] = round(pin_pos.y, 3)
+                        pins_data.append(entry)
+            return {"status": "ok", "reference": reference, "count": len(pins_data), "pins": pins_data}
+
+        if operation == "find_component_connections":
+            if project_path is None:
+                return {"error": "operation='find_component_connections' requires 'project_path'"}
+            if component_ref is None:
+                return {"error": "operation='find_component_connections' requires 'component_ref'"}
+            return await _op_find_component_connections(project_path, component_ref, ctx)
+
+        # ── Wires ──────────────────────────────────────────────────────────
+
+        if operation == "add_wire":
+            if start_pos is None:
+                return {"error": "operation='add_wire' requires 'start_pos'"}
+            if end_pos is None:
+                return {"error": "operation='add_wire' requires 'end_pos'"}
+            if len(start_pos) != 2 or len(end_pos) != 2:
+                return {"error": "Positions must be [x, y] coordinates"}
+            sch = _require_schematic()
+            sp = list(_snap(start_pos[0], start_pos[1]))
+            ep = list(_snap(end_pos[0], end_pos[1]))
+            wire_uuid = sch.add_wire(start=tuple(sp), end=tuple(ep))
+            return {"status": "ok", "wire_uuid": wire_uuid, "start": sp, "end": ep}
+
+        if operation == "add_wire_between_pins":
+            if comp1_ref is None:
+                return {"error": "operation='add_wire_between_pins' requires 'comp1_ref'"}
+            if pin1 is None:
+                return {"error": "operation='add_wire_between_pins' requires 'pin1'"}
+            if comp2_ref is None:
+                return {"error": "operation='add_wire_between_pins' requires 'comp2_ref'"}
+            if pin2 is None:
+                return {"error": "operation='add_wire_between_pins' requires 'pin2'"}
+            sch = _require_schematic()
+            segments: list = []
+
+            def _wire(x1f: float, y1f: float, x2f: float, y2f: float):
+                if abs(x1f - x2f) < 1e-6 and abs(y1f - y2f) < 1e-6:
+                    return None
+                uuid = sch.add_wire(start=(x1f, y1f), end=(x2f, y2f))
+                segments.append({"start": [x1f, y1f], "end": [x2f, y2f], "uuid": uuid})
+                return uuid
+
+            results = []
+            stub_ends = []
+            for ref, pnum in [(comp1_ref, pin1), (comp2_ref, pin2)]:
+                comp = _find_component_for_pin(sch, ref, pnum)
+                if comp is None:
+                    return {"error": f"Component {ref!r} not found"}
+                tip = _kicad_pin_position(comp, pnum)
+                if tip is None:
+                    return {"error": f"Pin {pnum!r} not found on {ref!r}"}
+                dx, dy = _pin_wire_offset(comp, pnum, 2.54)
+                sx, sy = _snap(tip.x + dx, tip.y + dy)
+                tx, ty = _snap(tip.x, tip.y)
+                _wire(tx, ty, sx, sy)
+                stub_ends.append((sx, sy))
+                results.append({"ref": ref, "pin": pnum, "tip": [tx, ty], "stub_end": [sx, sy]})
+
+            (wx1, wy1), (wx2, wy2) = stub_ends
+            if abs(wx1 - wx2) < 1e-6 or abs(wy1 - wy2) < 1e-6:
+                _wire(wx1, wy1, wx2, wy2)
+            else:
+                elbow_x, elbow_y = _snap(wx2, wy1)
+                _wire(wx1, wy1, elbow_x, elbow_y)
+                _wire(elbow_x, elbow_y, wx2, wy2)
+            return {
+                "status": "ok",
+                "pins": results,
+                "segments": segments,
+                "segment_count": len(segments),
+            }
+
+        if operation == "remove_wire":
+            if wire_uuid is None:
+                return {"error": "operation='remove_wire' requires 'wire_uuid'"}
+            sch = _require_schematic()
+            removed = sch.remove_wire(wire_uuid)
+            if removed:
+                return {"status": "ok", "wire_uuid": wire_uuid}
+            return {"error": f"Wire {wire_uuid} not found"}
+
+        if operation == "add_junction":
+            if position is None:
+                return {"error": "operation='add_junction' requires 'position'"}
+            if len(position) != 2:
+                return {"error": "Position must be [x, y] coordinates"}
+            sch = _require_schematic()
+            junction_uuid = sch.junctions.add(position=tuple(position), diameter=diameter)
+            return {"status": "ok", "junction_uuid": junction_uuid, "position": position}
+
+        # ── Labels ─────────────────────────────────────────────────────────
+
+        if operation == "add_label":
+            if text is None:
+                return {"error": "operation='add_label' requires 'text'"}
+            if position is None:
+                return {"error": "operation='add_label' requires 'position'"}
+            if len(position) != 2:
+                return {"error": "Position must be [x, y] coordinates"}
+            sch = _require_schematic()
+            pos = list(_snap(position[0], position[1]))
+            label_uuid = sch.add_label(text=text, position=tuple(pos), rotation=rotation, size=size)
+            return {"status": "ok", "label_uuid": label_uuid, "text": text, "position": pos}
+
+        if operation == "add_label_to_pin":
+            if reference is None:
+                return {"error": "operation='add_label_to_pin' requires 'reference'"}
+            if pin_number is None:
+                return {"error": "operation='add_label_to_pin' requires 'pin_number'"}
+            if text is None:
+                return {"error": "operation='add_label_to_pin' requires 'text'"}
+            sch = _require_schematic()
+            comp = _find_component_for_pin(sch, reference, pin_number)
+            if comp is None:
+                return {"error": f"Component {reference} not found"}
+            pin_pos = _kicad_pin_position(comp, pin_number)
+            if pin_pos is None:
+                return {"error": f"Pin {pin_number} not found on {reference}"}
+            effective_offset = offset if offset != 0 else 2.54
+            dx, dy = _pin_wire_offset(comp, pin_number, effective_offset)
+            label_x = pin_pos.x + dx
+            label_y = pin_pos.y + dy
+            sch.add_wire(start=(pin_pos.x, pin_pos.y), end=(label_x, label_y))
+            label_uuid = sch.add_label(text, (label_x, label_y))
+            return {
+                "status": "ok",
+                "label_uuid": label_uuid,
+                "text": text,
+                "reference": reference,
+                "pin_number": pin_number,
+                "position": [round(label_x, 3), round(label_y, 3)],
+            }
+
+        if operation == "add_hierarchical_label":
+            if text is None:
+                return {"error": "operation='add_hierarchical_label' requires 'text'"}
+            if position is None:
+                return {"error": "operation='add_hierarchical_label' requires 'position'"}
+            if len(position) != 2:
+                return {"error": "Position must be [x, y] coordinates"}
+            sch = _require_schematic()
+            from kicad_sch_api.core.types import HierarchicalLabelShape
+            shape_map = {
+                "input": HierarchicalLabelShape.INPUT,
+                "output": HierarchicalLabelShape.OUTPUT,
+                "bidirectional": HierarchicalLabelShape.BIDIRECTIONAL,
+                "tristate": HierarchicalLabelShape.TRISTATE,
+                "passive": HierarchicalLabelShape.PASSIVE,
+                "unspecified": HierarchicalLabelShape.UNSPECIFIED,
+            }
+            shape_key = shape.lower()
+            if shape_key not in shape_map:
+                return {"error": f"Unknown shape {shape!r}. Valid: {sorted(shape_map)}"}
+            label_uuid = sch.add_hierarchical_label(
+                text=text, position=tuple(position),
+                shape=shape_map[shape_key], rotation=rotation, size=size,
+            )
+            return {
+                "status": "ok",
+                "label_uuid": label_uuid,
+                "text": text,
+                "shape": shape,
+                "position": position,
+            }
+
+        if operation == "connect_pins_with_labels":
+            if comp1_ref is None:
+                return {"error": "operation='connect_pins_with_labels' requires 'comp1_ref'"}
+            if pin1 is None:
+                return {"error": "operation='connect_pins_with_labels' requires 'pin1'"}
+            if comp2_ref is None:
+                return {"error": "operation='connect_pins_with_labels' requires 'comp2_ref'"}
+            if pin2 is None:
+                return {"error": "operation='connect_pins_with_labels' requires 'pin2'"}
+            if net_name is None:
+                return {"error": "operation='connect_pins_with_labels' requires 'net_name'"}
+            sch = _require_schematic()
+            label_uuids = []
+            for ref, pnum in [(comp1_ref, pin1), (comp2_ref, pin2)]:
+                comp = _find_component_for_pin(sch, ref, pnum)
+                if comp is None:
+                    return {"error": f"Component {ref} not found"}
+                pin_pos = _kicad_pin_position(comp, pnum)
+                if pin_pos is None:
+                    return {"error": f"Pin {pnum} not found on {ref}"}
+                dx, dy = _pin_wire_offset(comp, pnum, 2.54)
+                label_x = pin_pos.x + dx
+                label_y = pin_pos.y + dy
+                sch.add_wire(start=(pin_pos.x, pin_pos.y), end=(label_x, label_y))
+                uuid = sch.add_label(net_name, (label_x, label_y))
+                label_uuids.append(uuid)
+            return {
+                "status": "ok",
+                "net_name": net_name,
+                "labels_created": len(label_uuids),
+                "label_uuids": label_uuids,
+            }
+
+        if operation == "remove_label":
+            if label_uuid is None:
+                return {"error": "operation='remove_label' requires 'label_uuid'"}
+            sch = _require_schematic()
+            removed = sch.remove_label(label_uuid)
+            if removed:
+                return {"status": "ok", "label_uuid": label_uuid}
+            return {"error": f"Label {label_uuid} not found"}
+
+        if operation == "edit_label":
+            if label_uuid is None:
+                return {"error": "operation='edit_label' requires 'label_uuid'"}
+            sch = _require_schematic()
+            if all(v is None for v in (new_text, position, rotation if rotation != 0.0 else None, size if size != 1.27 else None)):
+                # Use explicit sentinel check for required modifications
+                pass
+            label = None
+            for lbl in sch.labels:
+                if lbl.uuid == label_uuid:
+                    label = lbl
+                    break
+            if label is None:
+                for lbl in sch.hierarchical_labels:
+                    if lbl.uuid == label_uuid:
+                        label = lbl
+                        break
+            if label is None:
+                return {"error": f"Label with UUID {label_uuid!r} not found"}
+            if new_text is not None:
+                label.text = new_text
+            if position is not None:
+                if len(position) != 2:
+                    return {"error": "position must be [x, y]"}
+                label.position = tuple(position)
+            # rotation and size use 0.0/1.27 defaults — only apply if caller passes them explicitly
+            # We rely on the source tool's pattern: caller passes non-default to update
+            label.rotation = rotation
+            label.size = size
+            return {
+                "status": "ok",
+                "label_uuid": label_uuid,
+                "text": label.text,
+                "position": [label.position.x, label.position.y],
+                "rotation": label.rotation,
+                "size": label.size,
+            }
+
+        # ── Text annotations ───────────────────────────────────────────────
+
+        if operation == "add_text":
+            if text is None:
+                return {"error": "operation='add_text' requires 'text'"}
+            if position is None:
+                return {"error": "operation='add_text' requires 'position'"}
+            if len(position) != 2:
+                return {"error": "Position must be [x, y] coordinates"}
+            sch = _require_schematic()
+            text_uuid = sch.add_text(text, tuple(position), rotation, size)
+            return {"status": "ok", "text_uuid": text_uuid, "text": text, "position": position}
+
+        if operation == "add_text_box":
+            if text is None:
+                return {"error": "operation='add_text_box' requires 'text'"}
+            if position is None:
+                return {"error": "operation='add_text_box' requires 'position'"}
+            if sheet_size is None:
+                return {"error": "operation='add_text_box' requires 'sheet_size'"}
+            if len(position) != 2 or len(sheet_size) != 2:
+                return {"error": "Position and size must be [x, y] and [width, height]"}
+            sch = _require_schematic()
+            textbox_uuid = sch.add_text_box(text, tuple(position), tuple(sheet_size), rotation, size)
+            return {
+                "status": "ok",
+                "textbox_uuid": textbox_uuid,
+                "text": text,
+                "position": position,
+                "size": sheet_size,
+            }
+
+        # ── Hierarchical sheets ────────────────────────────────────────────
+
+        if operation == "add_sheet":
+            if name is None:
+                return {"error": "operation='add_sheet' requires 'name'"}
+            if filename is None:
+                return {"error": "operation='add_sheet' requires 'filename'"}
+            if position is None:
+                return {"error": "operation='add_sheet' requires 'position'"}
+            if sheet_size is None:
+                return {"error": "operation='add_sheet' requires 'sheet_size'"}
+            if len(position) != 2 or len(sheet_size) != 2:
+                return {"error": "Position and size must be [x, y] and [width, height]"}
+            sch = _require_schematic()
+            sheet_uuid = sch.add_sheet(name, filename, tuple(position), tuple(sheet_size))
+            return {
+                "status": "ok",
+                "sheet_uuid": sheet_uuid,
+                "name": name,
+                "filename": filename,
+                "position": position,
+                "size": sheet_size,
+            }
+
+        if operation == "add_sheet_pin":
+            if sheet_uuid is None:
+                return {"error": "operation='add_sheet_pin' requires 'sheet_uuid'"}
+            if name is None:
+                return {"error": "operation='add_sheet_pin' requires 'name'"}
+            if pin_type is None:
+                return {"error": "operation='add_sheet_pin' requires 'pin_type'"}
+            if position is None:
+                return {"error": "operation='add_sheet_pin' requires 'position'"}
+            if len(position) != 2:
+                return {"error": "Position must be [x, y] coordinates"}
+            sch = _require_schematic()
+            pin_uuid = sch.add_sheet_pin(sheet_uuid, name, pin_type, tuple(position))
+            return {
+                "status": "ok",
+                "pin_uuid": pin_uuid,
+                "name": name,
+                "pin_type": pin_type,
+                "sheet_uuid": sheet_uuid,
+            }
+
+        return {
+            "error": (
+                f"unknown operation {operation!r}; "
+                f"valid: create|load|save|validate|info|clone|backup|check_pin_collisions|"
+                f"add_component|add_multi_unit_component|remove_component|move_component|"
+                f"list_components|filter_components|components_in_area|bulk_update_components|"
+                f"get_component_pin_position|list_component_pins|find_component_connections|"
+                f"add_wire|add_wire_between_pins|remove_wire|add_junction|"
+                f"add_label|add_label_to_pin|add_hierarchical_label|connect_pins_with_labels|"
+                f"remove_label|edit_label|"
+                f"add_text|add_text_box|"
+                f"add_sheet|add_sheet_pin"
+            )
+        }

--- a/tests/test_new_tools.py
+++ b/tests/test_new_tools.py
@@ -62,51 +62,61 @@ def _get_tool_fn(mcp_server, tool_name):
     return tool.fn
 
 
-# -- check_pin_collisions tests ---------------------------------------------
+# -- check_pin_collisions tests (via schematic router) ----------------------
 
 class TestCheckPinCollisions:
 
+    def _sch(self, mcp_server):
+        """Get the schematic router function and return an async-wrapped caller."""
+        tool = asyncio.run(mcp_server.get_tool("schematic"))
+        if tool is None:
+            raise ValueError("Tool 'schematic' not found")
+        fn = tool.fn
+
+        def call(operation, **kwargs):
+            return asyncio.run(fn(operation=operation, **kwargs))
+
+        return call
+
     def test_tool_registered(self, mcp_server):
-        fn = _get_tool_fn(mcp_server, "check_pin_collisions")
-        assert fn is not None
+        call = self._sch(mcp_server)
+        # Just verify calling works without error
+        assert call is not None
 
     def test_requires_schematic(self, mcp_server):
         """Should raise RuntimeError if no schematic is loaded."""
-        fn = _get_tool_fn(mcp_server, "check_pin_collisions")
+        import kicad_mcp.tools.schematic as sch_module
+        sch_module._current_schematic = None
+        call = self._sch(mcp_server)
         with pytest.raises(RuntimeError, match="No schematic loaded"):
-            fn()
+            call("check_pin_collisions")
 
     def test_no_collisions_empty_schematic(self, mcp_server):
         """Creating an empty schematic should return no collisions."""
-        create_fn = _get_tool_fn(mcp_server, "create_schematic")
-        create_fn("test")
-        fn = _get_tool_fn(mcp_server, "check_pin_collisions")
-        result = fn()
+        call = self._sch(mcp_server)
+        call("create", name="test")
+        result = call("check_pin_collisions")
         assert result["status"] == "ok"
         assert result["collision_count"] == 0
 
     def test_no_collisions_separate_components(self, mcp_server):
         """Two resistors placed far apart should have no pin collisions."""
-        create_fn = _get_tool_fn(mcp_server, "create_schematic")
-        create_fn("test")
-        add_fn = _get_tool_fn(mcp_server, "add_component")
-        add_fn(lib_id="Device:R", reference="R1", value="10k", position=[50, 50])
-        add_fn(lib_id="Device:R", reference="R2", value="10k", position=[100, 50])
-        fn = _get_tool_fn(mcp_server, "check_pin_collisions")
-        result = fn()
+        call = self._sch(mcp_server)
+        call("create", name="test")
+        call("add_component", lib_id="Device:R", reference="R1", value="10k", position=[50, 50])
+        call("add_component", lib_id="Device:R", reference="R2", value="10k", position=[100, 50])
+        result = call("check_pin_collisions")
         assert result["status"] == "ok"
         assert result["collision_count"] == 0
 
     def test_detects_collision(self, mcp_server):
         """Two components placed at the same position should have pin collisions."""
-        create_fn = _get_tool_fn(mcp_server, "create_schematic")
-        create_fn("test")
-        add_fn = _get_tool_fn(mcp_server, "add_component")
+        call = self._sch(mcp_server)
+        call("create", name="test")
         # Place two resistors at exact same position — their pins will collide
-        add_fn(lib_id="Device:R", reference="R1", value="10k", position=[50, 50])
-        add_fn(lib_id="Device:R", reference="R2", value="10k", position=[50, 50])
-        fn = _get_tool_fn(mcp_server, "check_pin_collisions")
-        result = fn()
+        call("add_component", lib_id="Device:R", reference="R1", value="10k", position=[50, 50])
+        call("add_component", lib_id="Device:R", reference="R2", value="10k", position=[50, 50])
+        result = call("check_pin_collisions")
         assert result["status"] == "ok"
         assert result["collision_count"] > 0
         # Each collision should involve pins from different components

--- a/tests/test_schematic.py
+++ b/tests/test_schematic.py
@@ -1,10 +1,9 @@
 """
-Tests for the schematic MCP tools.
+Tests for the schematic domain router (phase 5).
 
-These are unit tests that use the real kicad-sch-api library (no mocking)
-since it is a pure Python library that works without KiCad installed.
-The tests verify the MCP tool wrappers correctly delegate to kicad-sch-api
-and return well-structured results.
+Uses the real kicad-sch-api library (no mocking) since it is a pure
+Python library that works without KiCad installed.
+All calls go through the single `schematic` router tool with operation=.
 """
 
 import asyncio
@@ -12,7 +11,7 @@ import asyncio
 import pytest
 from fastmcp import FastMCP
 
-from kicad_mcp.tools.schematic import register_schematic_tools, _current_schematic
+from kicad_mcp.tools.schematic_router import register_schematic_router
 import kicad_mcp.tools.schematic as sch_module
 
 
@@ -20,9 +19,9 @@ import kicad_mcp.tools.schematic as sch_module
 
 @pytest.fixture
 def sch_server():
-    """Create a FastMCP server with only schematic tools registered."""
+    """Create a FastMCP server with only the schematic router registered."""
     mcp = FastMCP("test-schematic")
-    register_schematic_tools(mcp)
+    register_schematic_router(mcp)
     return mcp
 
 
@@ -34,32 +33,37 @@ def reset_schematic_state():
     sch_module._current_schematic = None
 
 
-def _get_tool_fn(mcp_server, tool_name):
-    """Extract a tool function from the FastMCP 3.0 server by name."""
-    tool = asyncio.run(mcp_server.get_tool(tool_name))
+def _get_schematic_fn(mcp_server):
+    """Extract the schematic router function."""
+    tool = asyncio.run(mcp_server.get_tool("schematic"))
     if tool is None:
-        raise ValueError(f"Tool {tool_name!r} not found")
+        raise ValueError("Tool 'schematic' not found")
     return tool.fn
 
 
-# -- create_schematic tests --------------------------------------------------
+def _call(fn, operation, **kwargs):
+    """Call the schematic router (async) synchronously."""
+    return asyncio.run(fn(operation=operation, **kwargs))
 
-class TestCreateSchematic:
+
+# -- create tests ------------------------------------------------------------
+
+class TestCreate:
 
     def test_create_returns_ok(self, sch_server):
-        fn = _get_tool_fn(sch_server, "create_schematic")
-        result = fn(name="test_circuit")
+        fn = _get_schematic_fn(sch_server)
+        result = _call(fn, "create", name="test_circuit")
         assert result["status"] == "ok"
         assert result["name"] == "test_circuit"
 
     def test_create_sets_module_state(self, sch_server):
-        fn = _get_tool_fn(sch_server, "create_schematic")
-        fn(name="my_sch")
+        fn = _get_schematic_fn(sch_server)
+        _call(fn, "create", name="my_sch")
         assert sch_module._current_schematic is not None
 
     def test_create_with_default_name(self, sch_server):
-        fn = _get_tool_fn(sch_server, "create_schematic")
-        result = fn()
+        fn = _get_schematic_fn(sch_server)
+        result = _call(fn, "create")
         assert result["status"] == "ok"
         assert result["name"] == "untitled"
 
@@ -70,18 +74,15 @@ class TestAddAndListComponents:
 
     @pytest.fixture(autouse=True)
     def _create_schematic(self, sch_server):
-        """Create a schematic before each test in this class."""
-        fn = _get_tool_fn(sch_server, "create_schematic")
-        fn(name="test")
+        fn = _get_schematic_fn(sch_server)
+        _call(fn, "create", name="test")
+        self._fn = fn
 
     def test_add_component_basic(self, sch_server):
-        fn = _get_tool_fn(sch_server, "add_component")
-        result = fn(
-            lib_id="Device:R",
-            reference="R1",
-            value="10k",
-            position=[101.6, 101.6],  # 80 × 1.27 — exactly on-grid
-        )
+        fn = _get_schematic_fn(sch_server)
+        result = _call(fn, "add_component",
+                       lib_id="Device:R", reference="R1", value="10k",
+                       position=[101.6, 101.6])
         assert result["status"] == "ok"
         assert result["reference"] == "R1"
         assert result["lib_id"] == "Device:R"
@@ -89,61 +90,52 @@ class TestAddAndListComponents:
         assert result["position"] == [101.6, 101.6]
 
     def test_add_component_with_footprint(self, sch_server):
-        fn = _get_tool_fn(sch_server, "add_component")
-        result = fn(
-            lib_id="Device:R",
-            reference="R1",
-            value="4.7k",
-            position=[120.0, 80.0],
-            footprint="Resistor_SMD:R_0805_2012Metric",
-        )
+        fn = _get_schematic_fn(sch_server)
+        result = _call(fn, "add_component",
+                       lib_id="Device:R", reference="R1", value="4.7k",
+                       position=[120.0, 80.0],
+                       footprint="Resistor_SMD:R_0805_2012Metric")
         assert result["status"] == "ok"
         assert result["reference"] == "R1"
 
     def test_add_component_bad_position(self, sch_server):
-        fn = _get_tool_fn(sch_server, "add_component")
-        result = fn(
-            lib_id="Device:R",
-            reference="R1",
-            value="10k",
-            position=[100.0],  # missing y
-        )
+        fn = _get_schematic_fn(sch_server)
+        result = _call(fn, "add_component",
+                       lib_id="Device:R", reference="R1", value="10k",
+                       position=[100.0])  # missing y
         assert "error" in result
 
     def test_list_components_empty(self, sch_server):
-        fn = _get_tool_fn(sch_server, "list_components")
-        result = fn()
+        fn = _get_schematic_fn(sch_server)
+        result = _call(fn, "list_components")
         assert result["status"] == "ok"
         assert result["count"] == 0
         assert result["components"] == []
 
     def test_list_components_after_add(self, sch_server):
-        add_fn = _get_tool_fn(sch_server, "add_component")
-        add_fn(lib_id="Device:R", reference="R1", value="10k", position=[100, 100])
-        add_fn(lib_id="Device:C", reference="C1", value="100nF", position=[150, 100])
-
-        list_fn = _get_tool_fn(sch_server, "list_components")
-        result = list_fn()
+        fn = _get_schematic_fn(sch_server)
+        _call(fn, "add_component", lib_id="Device:R", reference="R1", value="10k",
+              position=[100, 100])
+        _call(fn, "add_component", lib_id="Device:C", reference="C1", value="100nF",
+              position=[150, 100])
+        result = _call(fn, "list_components")
         assert result["status"] == "ok"
         assert result["count"] == 2
         refs = {c["reference"] for c in result["components"]}
         assert refs == {"R1", "C1"}
 
     def test_remove_component(self, sch_server):
-        add_fn = _get_tool_fn(sch_server, "add_component")
-        add_fn(lib_id="Device:R", reference="R1", value="10k", position=[100, 100])
-
-        rm_fn = _get_tool_fn(sch_server, "remove_component")
-        result = rm_fn(reference="R1")
+        fn = _get_schematic_fn(sch_server)
+        _call(fn, "add_component", lib_id="Device:R", reference="R1", value="10k",
+              position=[100, 100])
+        result = _call(fn, "remove_component", reference="R1")
         assert result["status"] == "ok"
-
-        list_fn = _get_tool_fn(sch_server, "list_components")
-        result = list_fn()
+        result = _call(fn, "list_components")
         assert result["count"] == 0
 
     def test_remove_nonexistent_component(self, sch_server):
-        rm_fn = _get_tool_fn(sch_server, "remove_component")
-        result = rm_fn(reference="R99")
+        fn = _get_schematic_fn(sch_server)
+        result = _call(fn, "remove_component", reference="R99")
         assert "error" in result
 
 
@@ -153,35 +145,33 @@ class TestAddWire:
 
     @pytest.fixture(autouse=True)
     def _create_schematic(self, sch_server):
-        fn = _get_tool_fn(sch_server, "create_schematic")
-        fn(name="test")
+        fn = _get_schematic_fn(sch_server)
+        _call(fn, "create", name="test")
 
     def test_add_wire_basic(self, sch_server):
-        fn = _get_tool_fn(sch_server, "add_wire")
-        # 101.6 = 80 × 1.27, 203.2 = 160 × 1.27 — both exactly on-grid
-        result = fn(start_pos=[101.6, 101.6], end_pos=[203.2, 101.6])
+        fn = _get_schematic_fn(sch_server)
+        result = _call(fn, "add_wire",
+                       start_pos=[101.6, 101.6], end_pos=[203.2, 101.6])
         assert result["status"] == "ok"
         assert "wire_uuid" in result
         assert result["start"] == [101.6, 101.6]
         assert result["end"] == [203.2, 101.6]
 
     def test_add_wire_bad_positions(self, sch_server):
-        fn = _get_tool_fn(sch_server, "add_wire")
-        result = fn(start_pos=[100.0], end_pos=[200.0, 100.0])
+        fn = _get_schematic_fn(sch_server)
+        result = _call(fn, "add_wire", start_pos=[100.0], end_pos=[200.0, 100.0])
         assert "error" in result
 
     def test_remove_wire(self, sch_server):
-        add_fn = _get_tool_fn(sch_server, "add_wire")
-        result = add_fn(start_pos=[100.0, 100.0], end_pos=[200.0, 100.0])
+        fn = _get_schematic_fn(sch_server)
+        result = _call(fn, "add_wire", start_pos=[100.0, 100.0], end_pos=[200.0, 100.0])
         wire_uuid = result["wire_uuid"]
-
-        rm_fn = _get_tool_fn(sch_server, "remove_wire")
-        result = rm_fn(wire_uuid=wire_uuid)
+        result = _call(fn, "remove_wire", wire_uuid=wire_uuid)
         assert result["status"] == "ok"
 
     def test_remove_nonexistent_wire(self, sch_server):
-        rm_fn = _get_tool_fn(sch_server, "remove_wire")
-        result = rm_fn(wire_uuid="nonexistent-uuid")
+        fn = _get_schematic_fn(sch_server)
+        result = _call(fn, "remove_wire", wire_uuid="nonexistent-uuid")
         assert "error" in result
 
 
@@ -191,40 +181,38 @@ class TestAddLabel:
 
     @pytest.fixture(autouse=True)
     def _create_schematic(self, sch_server):
-        fn = _get_tool_fn(sch_server, "create_schematic")
-        fn(name="test")
+        fn = _get_schematic_fn(sch_server)
+        _call(fn, "create", name="test")
 
     def test_add_label_basic(self, sch_server):
-        fn = _get_tool_fn(sch_server, "add_label")
-        result = fn(text="GND", position=[101.6, 101.6])  # 80 × 1.27 — on-grid
+        fn = _get_schematic_fn(sch_server)
+        result = _call(fn, "add_label", text="GND", position=[101.6, 101.6])
         assert result["status"] == "ok"
         assert result["text"] == "GND"
         assert result["position"] == [101.6, 101.6]
         assert "label_uuid" in result
 
     def test_add_label_with_rotation(self, sch_server):
-        fn = _get_tool_fn(sch_server, "add_label")
-        result = fn(text="VCC", position=[50.0, 50.0], rotation=90.0)
+        fn = _get_schematic_fn(sch_server)
+        result = _call(fn, "add_label", text="VCC", position=[50.0, 50.0], rotation=90.0)
         assert result["status"] == "ok"
         assert result["text"] == "VCC"
 
     def test_add_label_bad_position(self, sch_server):
-        fn = _get_tool_fn(sch_server, "add_label")
-        result = fn(text="GND", position=[100.0])
+        fn = _get_schematic_fn(sch_server)
+        result = _call(fn, "add_label", text="GND", position=[100.0])
         assert "error" in result
 
     def test_remove_label(self, sch_server):
-        add_fn = _get_tool_fn(sch_server, "add_label")
-        result = add_fn(text="SDA", position=[100.0, 100.0])
+        fn = _get_schematic_fn(sch_server)
+        result = _call(fn, "add_label", text="SDA", position=[100.0, 100.0])
         label_uuid = result["label_uuid"]
-
-        rm_fn = _get_tool_fn(sch_server, "remove_label")
-        result = rm_fn(label_uuid=label_uuid)
+        result = _call(fn, "remove_label", label_uuid=label_uuid)
         assert result["status"] == "ok"
 
     def test_remove_nonexistent_label(self, sch_server):
-        rm_fn = _get_tool_fn(sch_server, "remove_label")
-        result = rm_fn(label_uuid="nonexistent-uuid")
+        fn = _get_schematic_fn(sch_server)
+        result = _call(fn, "remove_label", label_uuid="nonexistent-uuid")
         assert "error" in result
 
 
@@ -235,52 +223,59 @@ class TestGridSnap:
 
     @pytest.fixture(autouse=True)
     def _create_schematic(self, sch_server):
-        _get_tool_fn(sch_server, "create_schematic")(name="test")
+        fn = _get_schematic_fn(sch_server)
+        _call(fn, "create", name="test")
 
     def test_add_component_on_grid_unchanged(self, sch_server):
-        fn = _get_tool_fn(sch_server, "add_component")
-        result = fn(lib_id="Device:R", reference="R1", value="10k", position=[101.6, 101.6])
+        fn = _get_schematic_fn(sch_server)
+        result = _call(fn, "add_component",
+                       lib_id="Device:R", reference="R1", value="10k",
+                       position=[101.6, 101.6])
         assert result["position"] == [101.6, 101.6]
 
     def test_add_component_off_grid_snaps(self, sch_server):
-        fn = _get_tool_fn(sch_server, "add_component")
+        fn = _get_schematic_fn(sch_server)
         # 100.0 / 1.27 = 78.74 → 79 → 79 × 1.27 = 100.33
-        result = fn(lib_id="Device:R", reference="R1", value="10k", position=[100.0, 100.0])
+        result = _call(fn, "add_component",
+                       lib_id="Device:R", reference="R1", value="10k",
+                       position=[100.0, 100.0])
         assert result["position"] == [100.33, 100.33]
 
     def test_add_wire_on_grid_unchanged(self, sch_server):
-        fn = _get_tool_fn(sch_server, "add_wire")
-        result = fn(start_pos=[101.6, 101.6], end_pos=[203.2, 101.6])
+        fn = _get_schematic_fn(sch_server)
+        result = _call(fn, "add_wire",
+                       start_pos=[101.6, 101.6], end_pos=[203.2, 101.6])
         assert result["start"] == [101.6, 101.6]
         assert result["end"] == [203.2, 101.6]
 
     def test_add_wire_off_grid_snaps(self, sch_server):
-        fn = _get_tool_fn(sch_server, "add_wire")
+        fn = _get_schematic_fn(sch_server)
         # 100.0 → 100.33 (79 × 1.27);  200.0 → 199.39 (157 × 1.27)
-        result = fn(start_pos=[100.0, 100.0], end_pos=[200.0, 100.0])
+        result = _call(fn, "add_wire",
+                       start_pos=[100.0, 100.0], end_pos=[200.0, 100.0])
         assert result["start"] == [100.33, 100.33]
         assert result["end"] == [199.39, 100.33]
 
     def test_add_label_on_grid_unchanged(self, sch_server):
-        fn = _get_tool_fn(sch_server, "add_label")
-        result = fn(text="GND", position=[101.6, 101.6])
+        fn = _get_schematic_fn(sch_server)
+        result = _call(fn, "add_label", text="GND", position=[101.6, 101.6])
         assert result["position"] == [101.6, 101.6]
 
     def test_add_label_off_grid_snaps(self, sch_server):
-        fn = _get_tool_fn(sch_server, "add_label")
-        result = fn(text="GND", position=[100.0, 100.0])
+        fn = _get_schematic_fn(sch_server)
+        result = _call(fn, "add_label", text="GND", position=[100.0, 100.0])
         assert result["position"] == [100.33, 100.33]
 
     def test_snap_rounds_down(self, sch_server):
-        fn = _get_tool_fn(sch_server, "add_label")
+        fn = _get_schematic_fn(sch_server)
         # 0.5 / 1.27 = 0.394 → rounds to 0 → 0.0
-        result = fn(text="X", position=[0.5, 0.0])
+        result = _call(fn, "add_label", text="X", position=[0.5, 0.0])
         assert result["position"] == [0.0, 0.0]
 
     def test_snap_rounds_up(self, sch_server):
-        fn = _get_tool_fn(sch_server, "add_label")
+        fn = _get_schematic_fn(sch_server)
         # 1.0 / 1.27 = 0.787 → rounds to 1 → 1.27
-        result = fn(text="X", position=[1.0, 0.0])
+        result = _call(fn, "add_label", text="X", position=[1.0, 0.0])
         assert result["position"] == [1.27, 0.0]
 
 
@@ -290,25 +285,26 @@ class TestAddWireBetweenPins:
 
     @pytest.fixture(autouse=True)
     def _create_schematic(self, sch_server):
-        _get_tool_fn(sch_server, "create_schematic")(name="test")
+        fn = _get_schematic_fn(sch_server)
+        _call(fn, "create", name="test")
 
     def test_error_first_component_not_found(self, sch_server):
-        fn = _get_tool_fn(sch_server, "add_wire_between_pins")
-        result = fn(comp1_ref="R99", pin1="1", comp2_ref="R2", pin2="1")
+        fn = _get_schematic_fn(sch_server)
+        result = _call(fn, "add_wire_between_pins",
+                       comp1_ref="R99", pin1="1", comp2_ref="R2", pin2="1")
         assert "error" in result
         assert "R99" in result["error"]
 
     def test_error_second_component_not_found(self, sch_server):
-        add_fn = _get_tool_fn(sch_server, "add_component")
-        add_fn(lib_id="Device:R", reference="R1", value="10k", position=[101.6, 101.6])
-        fn = _get_tool_fn(sch_server, "add_wire_between_pins")
-        # R1 exists but its pin lookup either returns None (no KiCad library)
-        # or succeeds; either way R2 definitely doesn't exist → error
-        result = fn(comp1_ref="R1", pin1="1", comp2_ref="R99", pin2="1")
+        fn = _get_schematic_fn(sch_server)
+        _call(fn, "add_component", lib_id="Device:R", reference="R1", value="10k",
+              position=[101.6, 101.6])
+        result = _call(fn, "add_wire_between_pins",
+                       comp1_ref="R1", pin1="1", comp2_ref="R99", pin2="1")
         assert "error" in result
 
     def test_tool_is_registered(self, sch_server):
-        fn = _get_tool_fn(sch_server, "add_wire_between_pins")
+        fn = _get_schematic_fn(sch_server)
         assert fn is not None
 
 
@@ -318,87 +314,78 @@ class TestNoSchematicLoaded:
     """Verify tools fail gracefully when no schematic is loaded."""
 
     def test_list_components_no_schematic(self, sch_server):
-        fn = _get_tool_fn(sch_server, "list_components")
+        fn = _get_schematic_fn(sch_server)
         with pytest.raises(RuntimeError, match="No schematic loaded"):
-            fn()
+            _call(fn, "list_components")
 
     def test_add_component_no_schematic(self, sch_server):
-        fn = _get_tool_fn(sch_server, "add_component")
+        fn = _get_schematic_fn(sch_server)
         with pytest.raises(RuntimeError, match="No schematic loaded"):
-            fn(lib_id="Device:R", reference="R1", value="10k", position=[100, 100])
+            _call(fn, "add_component",
+                  lib_id="Device:R", reference="R1", value="10k", position=[100, 100])
 
     def test_add_wire_no_schematic(self, sch_server):
-        fn = _get_tool_fn(sch_server, "add_wire")
+        fn = _get_schematic_fn(sch_server)
         with pytest.raises(RuntimeError, match="No schematic loaded"):
-            fn(start_pos=[100, 100], end_pos=[200, 100])
+            _call(fn, "add_wire", start_pos=[100, 100], end_pos=[200, 100])
 
     def test_add_label_no_schematic(self, sch_server):
-        fn = _get_tool_fn(sch_server, "add_label")
+        fn = _get_schematic_fn(sch_server)
         with pytest.raises(RuntimeError, match="No schematic loaded"):
-            fn(text="GND", position=[100, 100])
+            _call(fn, "add_label", text="GND", position=[100, 100])
 
     def test_validate_no_schematic(self, sch_server):
-        fn = _get_tool_fn(sch_server, "validate_schematic")
+        fn = _get_schematic_fn(sch_server)
         with pytest.raises(RuntimeError, match="No schematic loaded"):
-            fn()
+            _call(fn, "validate")
 
     def test_get_info_no_schematic(self, sch_server):
-        fn = _get_tool_fn(sch_server, "get_schematic_info")
+        fn = _get_schematic_fn(sch_server)
         with pytest.raises(RuntimeError, match="No schematic loaded"):
-            fn()
+            _call(fn, "info")
 
 
-# -- get_schematic_info tests ------------------------------------------------
+# -- info tests (was: get_schematic_info) ------------------------------------
 
-class TestGetSchematicInfo:
+class TestInfo:
 
     def test_info_empty_schematic(self, sch_server):
-        create_fn = _get_tool_fn(sch_server, "create_schematic")
-        create_fn(name="test")
-
-        info_fn = _get_tool_fn(sch_server, "get_schematic_info")
-        result = info_fn()
+        fn = _get_schematic_fn(sch_server)
+        _call(fn, "create", name="test")
+        result = _call(fn, "info")
         assert result["status"] == "ok"
         assert result["components"] == 0
 
     def test_info_after_adding_components(self, sch_server):
-        create_fn = _get_tool_fn(sch_server, "create_schematic")
-        create_fn(name="test")
-
-        add_fn = _get_tool_fn(sch_server, "add_component")
-        add_fn(lib_id="Device:R", reference="R1", value="10k", position=[100, 100])
-        add_fn(lib_id="Device:C", reference="C1", value="100nF", position=[150, 100])
-
-        info_fn = _get_tool_fn(sch_server, "get_schematic_info")
-        result = info_fn()
+        fn = _get_schematic_fn(sch_server)
+        _call(fn, "create", name="test")
+        _call(fn, "add_component", lib_id="Device:R", reference="R1", value="10k",
+              position=[100, 100])
+        _call(fn, "add_component", lib_id="Device:C", reference="C1", value="100nF",
+              position=[150, 100])
+        result = _call(fn, "info")
         assert result["status"] == "ok"
         assert result["components"] == 2
 
 
-# -- validate_schematic tests ------------------------------------------------
+# -- validate tests ----------------------------------------------------------
 
-class TestValidateSchematic:
+class TestValidate:
 
     def test_validate_empty_schematic(self, sch_server):
-        create_fn = _get_tool_fn(sch_server, "create_schematic")
-        create_fn(name="test")
-
-        validate_fn = _get_tool_fn(sch_server, "validate_schematic")
-        result = validate_fn()
+        fn = _get_schematic_fn(sch_server)
+        _call(fn, "create", name="test")
+        result = _call(fn, "validate")
         assert result["status"] == "ok"
         assert result["issues"] == 0
 
     def test_validate_schematic_with_components(self, sch_server):
-        create_fn = _get_tool_fn(sch_server, "create_schematic")
-        create_fn(name="test")
-
-        add_fn = _get_tool_fn(sch_server, "add_component")
-        add_fn(lib_id="Device:R", reference="R1", value="10k", position=[100, 100])
-
-        validate_fn = _get_tool_fn(sch_server, "validate_schematic")
-        result = validate_fn()
+        fn = _get_schematic_fn(sch_server)
+        _call(fn, "create", name="test")
+        _call(fn, "add_component", lib_id="Device:R", reference="R1", value="10k",
+              position=[100, 100])
+        result = _call(fn, "validate")
         assert result["status"] == "ok"
-        # Validation may or may not find issues depending on kicad-sch-api version
         assert "issues" in result
 
 
@@ -407,41 +394,33 @@ class TestValidateSchematic:
 class TestAddJunction:
 
     def test_add_junction(self, sch_server):
-        create_fn = _get_tool_fn(sch_server, "create_schematic")
-        create_fn(name="test")
-
-        fn = _get_tool_fn(sch_server, "add_junction")
-        result = fn(position=[100.0, 100.0])
+        fn = _get_schematic_fn(sch_server)
+        _call(fn, "create", name="test")
+        result = _call(fn, "add_junction", position=[100.0, 100.0])
         assert result["status"] == "ok"
         assert result["position"] == [100.0, 100.0]
         assert "junction_uuid" in result
 
     def test_add_junction_bad_position(self, sch_server):
-        create_fn = _get_tool_fn(sch_server, "create_schematic")
-        create_fn(name="test")
-
-        fn = _get_tool_fn(sch_server, "add_junction")
-        result = fn(position=[100.0])
+        fn = _get_schematic_fn(sch_server)
+        _call(fn, "create", name="test")
+        result = _call(fn, "add_junction", position=[100.0])
         assert "error" in result
 
 
-# -- save_schematic tests (with tmp_path) ------------------------------------
+# -- save tests (with tmp_path) ----------------------------------------------
 
-class TestSaveSchematic:
+class TestSave:
 
     def test_save_to_file(self, sch_server, tmp_path):
-        create_fn = _get_tool_fn(sch_server, "create_schematic")
-        create_fn(name="test")
-
-        add_fn = _get_tool_fn(sch_server, "add_component")
-        add_fn(lib_id="Device:R", reference="R1", value="10k", position=[100, 100])
-
-        save_fn = _get_tool_fn(sch_server, "save_schematic")
+        fn = _get_schematic_fn(sch_server)
+        _call(fn, "create", name="test")
+        _call(fn, "add_component", lib_id="Device:R", reference="R1", value="10k",
+              position=[100, 100])
         save_path = str(tmp_path / "test.kicad_sch")
-        result = save_fn(file_path=save_path)
+        result = _call(fn, "save", schematic_path=save_path)
         assert result["status"] == "ok"
 
-        # Verify the file was created
         import os
         assert os.path.exists(save_path)
         content = open(save_path).read()
@@ -454,42 +433,39 @@ class TestSchematicWorkflow:
     """Test a realistic workflow of creating a schematic with components, wires, and labels."""
 
     def test_full_workflow(self, sch_server):
+        fn = _get_schematic_fn(sch_server)
+
         # Create schematic
-        create_fn = _get_tool_fn(sch_server, "create_schematic")
-        result = create_fn(name="voltage_divider")
+        result = _call(fn, "create", name="voltage_divider")
         assert result["status"] == "ok"
 
         # Add two resistors
-        add_fn = _get_tool_fn(sch_server, "add_component")
-        r1 = add_fn(lib_id="Device:R", reference="R1", value="10k", position=[100, 80])
-        r2 = add_fn(lib_id="Device:R", reference="R2", value="10k", position=[100, 120])
+        r1 = _call(fn, "add_component", lib_id="Device:R", reference="R1",
+                   value="10k", position=[100, 80])
+        r2 = _call(fn, "add_component", lib_id="Device:R", reference="R2",
+                   value="10k", position=[100, 120])
         assert r1["status"] == "ok"
         assert r2["status"] == "ok"
 
         # Add wire between them
-        wire_fn = _get_tool_fn(sch_server, "add_wire")
-        w1 = wire_fn(start_pos=[100.0, 90.0], end_pos=[100.0, 110.0])
+        w1 = _call(fn, "add_wire", start_pos=[100.0, 90.0], end_pos=[100.0, 110.0])
         assert w1["status"] == "ok"
 
         # Add labels
-        label_fn = _get_tool_fn(sch_server, "add_label")
-        l1 = label_fn(text="VCC", position=[100.0, 70.0])
-        l2 = label_fn(text="GND", position=[100.0, 130.0])
-        l3 = label_fn(text="VOUT", position=[110.0, 100.0])
+        l1 = _call(fn, "add_label", text="VCC", position=[100.0, 70.0])
+        l2 = _call(fn, "add_label", text="GND", position=[100.0, 130.0])
+        l3 = _call(fn, "add_label", text="VOUT", position=[110.0, 100.0])
         assert l1["status"] == "ok"
         assert l2["status"] == "ok"
         assert l3["status"] == "ok"
 
         # Verify state
-        list_fn = _get_tool_fn(sch_server, "list_components")
-        result = list_fn()
+        result = _call(fn, "list_components")
         assert result["count"] == 2
 
-        info_fn = _get_tool_fn(sch_server, "get_schematic_info")
-        info = info_fn()
+        info = _call(fn, "info")
         assert info["components"] == 2
 
         # Validate
-        validate_fn = _get_tool_fn(sch_server, "validate_schematic")
-        result = validate_fn()
+        result = _call(fn, "validate")
         assert result["status"] == "ok"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -19,11 +19,11 @@ class TestCreateServer:
         server = create_server()
         assert server.name == "KiCad"
 
-    def test_at_least_14_tools_registered(self, mcp_server):
-        """Floor — the consolidated surface targets 14 tools."""
+    def test_at_least_13_tools_registered(self, mcp_server):
+        """Floor — the consolidated surface targets ~13 tools."""
         tools = asyncio.run(mcp_server.list_tools())
-        assert len(tools) >= 14, (
-            f"Expected at least 14 tools, got {len(tools)}"
+        assert len(tools) >= 13, (
+            f"Expected at least 13 tools, got {len(tools)}"
         )
 
     def test_current_tool_count(self, mcp_server):
@@ -34,10 +34,11 @@ class TestCreateServer:
         Phase 2: 90-12+3=81.
         Phase 3: audit router replaces 9 keepout tools → 81-9+1=73.
         Phase 4: pcb router replaces 29 individual pcb_* tools → 73-29+1=45.
+        Phase 5: schematic router replaces 32 schematic + 1 netlist → 45-33+1=13.
         """
         tools = asyncio.run(mcp_server.list_tools())
-        assert len(tools) == 45, (
-            f"Expected 45 tools, got {len(tools)}. "
+        assert len(tools) == 13, (
+            f"Expected 13 tools, got {len(tools)}. "
             "Update this test if tools were intentionally added or removed."
         )
 
@@ -46,6 +47,8 @@ class TestExpectedToolsExist:
     """Verify that specific important tools are registered."""
 
     EXPECTED_TOOLS = [
+        # Phase 5 router (schematic — replaces 32 schematic tools + find_component_connections)
+        "schematic",
         # Phase 4 router (pcb — replaces all individual pcb_* tools)
         "pcb",
         # PCB panelize tools
@@ -63,25 +66,6 @@ class TestExpectedToolsExist:
         "project",
         "drc",
         "autoroute",
-        # Schematic tools
-        "create_schematic",
-        "load_schematic",
-        "save_schematic",
-        "add_component",
-        "remove_component",
-        "list_components",
-        "add_wire",
-        "remove_wire",
-        "add_label",
-        "remove_label",
-        "add_junction",
-        "get_component_pin_position",
-        "list_component_pins",
-        "add_label_to_pin",
-        "connect_pins_with_labels",
-        "check_pin_collisions",
-        "validate_schematic",
-        "get_schematic_info",
         # Pipeline tools
         "build_pcb_from_schematic",
     ]


### PR DESCRIPTION
## Summary
Phase 5 of the Tool Consolidation spec — the **largest router**, 33 ops. Stacked on [phase 4 (#25)](https://github.com/blwfish/kicad-mcp/pull/25).

Folds 32 schematic tools + ``find_component_connections`` (held back from phase 1, was in netlist.py) into one ``schematic`` router.

## Layout
- New file: ``src/kicad_mcp/tools/schematic_router.py`` (router only).
- ``schematic.py``: impl helpers promoted to module-level ``_op_*`` functions.
- ``netlist.py``: ``register_netlist_tools`` is now a no-op stub (cleaned up in phase 6).

## Verb-overlap mitigation — spec phase 5 gate
The risk: model picks ``add_wire`` when ``add_wire_between_pins`` would be more ergonomic, or ``add_label`` when ``add_label_to_pin`` or ``add_hierarchical_label`` is right.

Mitigation in the docstring: ops are grouped by sub-domain (NOT alphabetized), and verb-overlap pairs are placed adjacent with **explicit disambiguators**:
- ``add_wire(start_pos, end_pos)`` — by absolute coords
- ``add_wire_between_pins(comp1, pin1, comp2, pin2)`` — by refs (**preferred when you have refs**)
- ``add_label(text, position)`` — at coords
- ``add_label_to_pin(reference, pin, text)`` — attached to pin (**preferred when labeling a pin**)
- ``add_hierarchical_label(...)`` — for hierarchical sheet pins, **not** ordinary net labels
- ``connect_pins_with_labels(...)`` — high-level: two labels + net

If verb-overlap confusion emerges in real use, the pre-decided split is ``schematic`` (file lifecycle + components + queries) / ``schematic_edit`` (item CRUD).

## Tool count
**13** total: 9 routers + 4 standalones (build_pcb_from_schematic, panelize_pcb, estimate_board_size, suggest_placement).

Spec called out 14 (with ``update_pcb_from_schematic`` as a 5th standalone) but that tool is only referenced in docstrings — it has never been defined as an actual ``@mcp.tool()`` in the codebase. Either way, **97 → 13 = 87% reduction**, well below any client cap.

## Test plan
- [x] 609 tests pass.
- [x] Tool count: 45 → 13.
- [x] All 33 old schematic-domain names absent; ``schematic`` router present.
- [x] test_schematic.py + test_new_tools.py + test_netlist_tools.py rewritten through router.
- [ ] **Verb-overlap eval gate** to run before merging this PR (spec acceptance criterion). Recommended workflow: a fresh model session given the router docstring + a few prompts like "I want to connect R1.1 to R2.2 with a wire — which op?" or "add a net label called VBUS on U1 pin 5 — which op?" Should pick the *specialized* op (``add_wire_between_pins``, ``add_label_to_pin``) >90% of the time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)