### PR TITLE
test(integration): bring multi-version KiCad integration suite to green

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.8.0",
     "pip-audit>=2.10.0",
+    "pytest-timeout>=2.3.0",
 ]
 
 [tool.ruff]

--- a/tests/integration/test_kicad_versions.py
+++ b/tests/integration/test_kicad_versions.py
@@ -12,6 +12,7 @@ Assertion rules:
 """
 
 import asyncio
+import inspect
 import os
 import shutil
 
@@ -28,11 +29,47 @@ pytestmark = pytest.mark.skipif(
 # ---------------------------------------------------------------------------
 
 def _get_tool(mcp, name):
-    return asyncio.run(mcp.get_tool(name)).fn
+    """Return a callable that takes a kwargs-dict and invokes the named tool.
+
+    Handles two flavours of tool function exposed by the FastMCP registry:
+    - sync tools (the majority) return a result dict directly
+    - async tools (DRC, BOM, netlist, patterns) return a coroutine
+
+    The returned callable accepts a positional dict of arguments
+    (matching the convention the rest of this file uses) and unpacks
+    them as kwargs because each registered tool declares an explicit
+    parameter list (e.g. `search(query, type, library, limit)`), not a
+    single args-dict.
+    """
+    fn = asyncio.run(mcp.get_tool(name)).fn
+
+    # Async tools (DRC, BOM, netlist, patterns) declare a required `ctx:
+    # Context | None` parameter for progress reporting.  In integration
+    # tests we have no MCP context to pass, so auto-inject None whenever
+    # the tool's signature requires it and the caller hasn't supplied it.
+    needs_ctx = "ctx" in inspect.signature(fn).parameters
+
+    def call(args=None):
+        args = dict(args or {})
+        if needs_ctx and "ctx" not in args:
+            args["ctx"] = None
+        result = fn(**args)
+        if inspect.iscoroutine(result):
+            result = asyncio.run(result)
+        return result
+
+    return call
 
 
-def _run(coro):
-    return asyncio.run(coro)
+def _run(value):
+    """Legacy passthrough kept so existing call sites read symmetrically.
+
+    `_get_tool(...)(args)` already drives sync/async; this just unwraps any
+    coroutine a caller hands us directly.
+    """
+    if inspect.iscoroutine(value):
+        return asyncio.run(value)
+    return value
 
 
 # ---------------------------------------------------------------------------
@@ -41,8 +78,8 @@ def _run(coro):
 
 @pytest.fixture(scope="module")
 def mcp_server():
-    from kicad_mcp.server import mcp
-    return mcp
+    from kicad_mcp.server import create_server
+    return create_server()
 
 
 @pytest.fixture()
@@ -87,31 +124,36 @@ def test_search_footprints(mcp_server):
 # ---------------------------------------------------------------------------
 
 def test_schematic_create_and_save(mcp_server, workspace):
-    """kicad-sch-api compatibility: create, add component, save."""
+    """kicad-sch-api compatibility: create, add component, save.
+
+    create_schematic / add_component operate on a module-level in-memory
+    schematic; the path is supplied only at save time via save_schematic's
+    `file_path` argument.  Earlier test versions passed a `schematic_path`
+    kwarg to all three — none of those functions accepts it.
+    """
     sch_path = str(workspace / "test.kicad_sch")
 
     create = _get_tool(mcp_server, "create_schematic")
-    result = _run(create({"schematic_path": sch_path}))
+    result = create({"name": "integration_test"})
     assert result.get("status") == "ok"
 
     # Find a real resistor lib_id before adding
     search = _get_tool(mcp_server, "search")
-    sr = _run(search({"query": "resistor", "type": "symbol"}))
+    sr = search({"query": "resistor", "type": "symbol"})
     assert sr.get("status") == "ok" and sr.get("results")
     lib_id = sr["results"][0]["lib_id"]
 
     add = _get_tool(mcp_server, "add_component")
-    result = _run(add({
-        "schematic_path": sch_path,
+    result = add({
         "lib_id": lib_id,
         "reference": "R1",
         "value": "10k",
         "position": [100, 100],
-    }))
+    })
     assert result.get("status") == "ok"
 
     save = _get_tool(mcp_server, "save_schematic")
-    result = _run(save({"schematic_path": sch_path}))
+    result = save({"file_path": sch_path})
     assert result.get("status") == "ok"
     assert os.path.isfile(sch_path)
 
@@ -172,10 +214,12 @@ def test_place_footprint_and_audit(mcp_server, workspace):
     assert result.get("status") == "ok"
 
     audit = _get_tool(mcp_server, "audit_all")
-    result = _run(audit({"pcb_path": pcb_path}))
-    assert result.get("status") == "ok"
-    # audit_all returns overlap/silkscreen/keepout sub-keys
-    assert "overlaps" in result or "placement" in result or "results" in result
+    result = audit({"pcb_path": pcb_path})
+    # audit_all returns separate lists per check type — assert each exists
+    # as a list (length will vary by KiCad version & footprint geometry).
+    for key in ("footprint_overlaps", "keepout_violations", "silkscreen_overlaps"):
+        assert key in result, f"audit_all output missing expected key {key!r}; got {list(result)}"
+        assert isinstance(result[key], list)
 
 
 # ---------------------------------------------------------------------------
@@ -193,7 +237,9 @@ def test_drc_returns_structure(mcp_server, workspace):
     }))
 
     drc = _get_tool(mcp_server, "run_drc_check")
-    result = _run(drc({"project_path": pro_path, "pcb_path": pcb_path}))
+    # run_drc_check is async + ctx-aware; _get_tool's wrapper injects ctx=None.
+    # It only takes project_path (no pcb_path) — finds the .kicad_pcb beside the .kicad_pro.
+    result = drc({"project_path": pro_path})
     # DRC may return violations on an empty board; assert on structure only
     assert "violations" in result or "drc_results" in result or result.get("status") == "ok"
 
@@ -233,9 +279,12 @@ def test_autoroute_smoke(mcp_server, workspace):
     }))
 
     autoroute = _get_tool(mcp_server, "autoroute_pcb")
-    result = _run(autoroute({"pcb_path": pcb_path, "passes": 1}))
-    assert result.get("status") == "ok"
-    assert "routed" in result or "unrouted" in result or "connections" in result
+    result = autoroute({"pcb_path": pcb_path, "passes": 1})
+    # FreeRouter pipeline reports per-net progress; assert structural keys
+    # only (counts vary with FreeRouter version + board geometry).
+    assert "net_count" in result
+    assert "best_incomplete" in result
+    assert isinstance(result["net_count"], int) and result["net_count"] >= 0
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -925,6 +925,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
 ]
 
@@ -946,6 +947,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-mock", specifier = ">=3.10.0" },
+    { name = "pytest-timeout", specifier = ">=2.3.0" },
     { name = "ruff", specifier = ">=0.1.0" },
 ]
 
@@ -1761,6 +1763,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Brings the previously-broken multi-version KiCad integration suite to **8/8 green on both KiCad 9.0.9 and 10.0.3**, verified locally on the self-hosted runner machine.

Supersedes #22 (which parked the triggers to stop the email-flood from broken integration runs). Once this merges, close #22 — its parking change is no longer needed.

## What was broken
The suite was scaffolded in `adf7f4c feat: multi-version KiCad regression testing (phases 1–4)` but had **0 successful runs in 50 attempts** before this PR. Every layer was wrong:

| Issue | Fix |
|---|---|
| `pytest-timeout` not declared; `--timeout=120` → exit 4 in ~3 sec | Added to `[dependency-groups].dev` |
| `from kicad_mcp.server import mcp` — phantom name | Use `create_server()` like every other test |
| `_get_tool(...)(dict)` passed whole dict as first kwarg → `AttributeError` on `.strip()` | Helper now unpacks `**args` |
| Async tools (DRC, etc.) need `ctx: Context \| None` | Helper auto-injects `ctx=None` via `inspect.signature` |
| Sync vs async return values | Helper detects coroutines and runs in fresh event loop |
| `create_schematic`/`add_component`/`save_schematic` got phantom `schematic_path` | Use real signature (`name`, then state, save with `file_path`) |
| `run_drc_check` got phantom `pcb_path` | Drop it (derived from `project_path`) |
| `audit_all` assertion: `'overlaps' in result` | Real keys: `footprint_overlaps`, `keepout_violations`, `silkscreen_overlaps` |
| `autoroute_pcb` assertion: `'routed' in result` | Real keys: `net_count`, `best_incomplete` |

## Verification
```
KICAD_INTEGRATION=1 KICAD_APP_PATH=.../10.0/KiCad.app uv run pytest tests/integration/ -v
# 8 passed in 6.75s

KICAD_INTEGRATION=1 KICAD_APP_PATH=.../9.0/KiCad.app uv run pytest tests/integration/ -v
# 8 passed in 14.65s

uv run pytest -q
# 652 passed in 8.26s  (unit suite unaffected)
```

## Test plan
- [ ] CI's `Integration Tests (KiCad multi-version)` workflow runs and passes both `kicad-9.0` and `kicad-10.0` jobs
- [ ] Existing `pytest`, `pytest (3.10/3.12/3.13)`, `check-docs` checks continue to pass
- [ ] After merge: close PR #22 (parking-the-triggers) as superseded

## Followups not in scope
- Runner workdir at `actions-runner/_work/kicad-mcp/kicad-mcp/` is inside the repo it operates on — unusual layout; relocate someday
- `KICAD_INTEGRATION=1` gating could be moved into `conftest.py` for less per-call ceremony

🤖 Generated with [Claude Code](https://claude.com/claude-code)