### PR TITLE
chore: bump version to 0.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kicad-mcp"
-version = "0.10.0.dev0"
+version = "0.10.0"
 description = "MCP server for KiCad electronic design automation — schematic, PCB layout, and analysis"
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -977,7 +977,7 @@ wheels = [
 
 [[package]]
 name = "kicad-mcp"
-version = "0.10.0.dev0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
## Summary

Version bump for the v0.10.0 release.  All v0.10.0-scope work landed in #35.  This PR is the bookkeeping step before tagging.

- `pyproject.toml`: `0.10.0.dev0` → `0.10.0`
- `uv.lock`: regenerated via `uv lock` (single-line metadata change)
- Suite still 969/969; mypy clean

After merge, tag `v0.10.0` on main to fire `release.yml`.

## Test plan
- [ ] `pytest` matrix green on PR
- [ ] `check-mypy` green
- [ ] `check-docs` green (no tool-count changes here)
- [ ] After merge: trigger `pip-audit` workflow manually, then tag `v0.10.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)