### PR TITLE
docs: add SPECs for OOB events, feedback infra, component intelligence, placement

### DIFF
--- a/docs/SPEC_Component_Intelligence_LCSC.md
+++ b/docs/SPEC_Component_Intelligence_LCSC.md
@@ -1,0 +1,494 @@
+# SPEC — Component Intelligence (LCSC)
+
+**Status:** Approved for implementation
+**Author:** Brian + Claude
+**Date:** 2026-05-27
+**Target:** Spec-based component selection for kicad-mcp with LCSC/JLCPCB data; replaces the manual Chrome-extension kludge with a first-class MCP tool.
+**Scope:** LCSC only in v1. DigiKey is a planned future supplier; `ResolvedPart` is designed to accommodate it but the v1 implementation is LCSC-specific.
+
+## Motivation
+
+Selecting components currently requires the human (Brian) to bridge between the LLM's design intent and a supplier catalog. The workflow involves a Chrome extension that scrapes LCSC search results and pipes them back to the conversation. This:
+
+- **Doesn't work for external users.** kicad-mcp is consumed by AI assistants without Brian's Chrome setup; they have no component-selection workflow at all.
+- **Puts the human in the loop for every component.** Brian lacks deep component domain knowledge and is functionally an obstruction in the iteration loop.
+- **Doesn't integrate KiCad symbol/footprint resolution.** Even after finding a part, the user separately searches for a symbol and footprint, and may pick mismatched ones.
+
+This SPEC defines a tool that accepts a functional specification (`"3.3V LDO, SOT-23, JLCPCB basic tier"`) and returns vetted candidates with their KiCad symbol/footprint resolved, prices, and stock — closing the loop without a human relay.
+
+It is the highest near-term impact item for both Brian and external users.
+
+## Non-goals
+
+- **Not a price tracker** — current price + stock are returned at query time; we don't build a price history.
+- **Not a BOM tool** — single-component lookups; no multi-part assembly/cost optimization.
+- **Not DigiKey in v1** — the `ResolvedPart` shape accommodates DigiKey but the v1 surface and implementation are LCSC-only.
+- **Not a substitute suggester** — given part X, we don't suggest alternates. (Spec a new search to find candidates.)
+- **Not a circuit reasoning engine** — we don't infer "you probably need a buck converter, not an LDO." The LLM provides the functional spec.
+- **Not bundling the jlcpcb-parts SQLite into the kicad-mcp repo** — see Dependencies and Legal posture below.
+
+## Dependencies
+
+This SPEC depends on:
+
+- **`mcp-events` package** (per [`SPEC_OOB_Events.md`](SPEC_OOB_Events.md), **implemented 2026-05-27** at `/Volumes/Files/claude/mcp-events/`, 47 tests passing) — for surfacing first-use ToS prompts, snapshot staleness warnings, and uncertain-match warnings to the calling LLM.
+- **Feedback Infrastructure** (per [`SPEC_Feedback_Infrastructure.md`](SPEC_Feedback_Infrastructure.md)) — for persisting telemetry needed to tune the staleness thresholds and match scoring over time. Not strictly blocking (the tool can ship and emit no-op telemetry calls if feedback infra hasn't landed yet), but strongly preferred for the calibration loop.
+- **`library_index.db`** (already in kicad-mcp) — for resolving manufacturer part numbers to KiCad symbol `lib_id`s.
+
+**PyPI publication blocker.** kicad-mcp's CI uses `uv sync --frozen`, which fails on local-path-only dependencies. This SPEC's PR cannot merge until `mcp-events 0.1.0` is published to PyPI. The implementation can begin with a local-path source for dev, but coordinate the PyPI publication of `mcp-events` BEFORE opening the PR for review.
+
+Optional but recommended:
+- **`yaqwsx/jlcparts` upstream availability** — we depend on their CI continuing to publish the SQLite snapshot. If they go down, we degrade to "last cached snapshot" mode and surface a strong warning. Escape hatch (own scraping) documented but not in v1.
+
+## Data sources
+
+The investigation in this session (see memory: `project_component_intelligence.md`) revealed that the originally-assumed `open-apis.lcsc.com` is dead. The real data landscape:
+
+### 1. JLCPCB cart API (unofficial, no auth required)
+- `GET https://cart.jlcpcb.com/shoppingCart/smtGood/getComponentDetail?componentCode=Cxxxx` — per-part details
+- `POST https://jlcpcb.com/api/overseas-pcb-order/v1/shoppingCart/smtGood/selectSmtComponentList/v2` — keyword search
+- **Critical**: requires a browser User-Agent header (their CDN blocks `python-requests` defaults)
+- No documented rate limit; we self-throttle to ~1 req/sec
+- Used for **on-demand fresh data** (current stock, current price) when the snapshot would be too stale
+
+### 2. yaqwsx/jlcparts SQLite snapshot (community-maintained)
+- Downloaded from `https://bouni.github.io/jlcparts/data/` (Bouni's GitHub Pages hosting the processed SQLite, ~100-500 MB across split zip chunks)
+- Schema: `components(lcsc, category_id, mfr, package, joints, basic, preferred, description, datasheet, stock, price, last_update, extra, jlc_extra)` — see `project_component_intelligence.md` for full field reference
+- Updated 3×/day by yaqwsx's CI (which has the LCSC partner-API credentials we don't)
+- Used for **bulk search/filter** (parametric queries across the catalog)
+
+### 3. kicad-mcp `library_index.db` (existing)
+- Full-text search over KiCad's bundled symbol libraries
+- Used to resolve manufacturer part number → KiCad `lib_id` (e.g., `"AMS1117-3.3"` → `"Regulator_Linear:AMS1117-3.3"`)
+
+### 4. Package → KiCad footprint mapping table (new, hand-curated)
+- Static lookup: LCSC's `componentSpecificationEn` strings ("SOT-223", "SOIC-8", "0603") → KiCad footprint paths (`"Package_TO_SOT_SMD:SOT-223-3"`, `"Package_SO:SOIC-8_3.9x4.9mm_P1.27mm"`, `"Resistor_SMD:R_0603_1608Metric"`)
+- ~200 entries covers ~95% of JLCPCB's catalog
+- Lives in the repo as a YAML or Python dict; updated by hand as new packages are observed
+- Unmapped packages return `kicad_footprint_path=None` (caller can still proceed; manual footprint assignment needed)
+
+### Legal posture (must read before implementation)
+
+LCSC's API terms of service explicitly prohibit redistribution of catalog data. The jlcparts upstream operates under a private arrangement with LCSC that does NOT extend to downstream consumers. The ecosystem (Bouni, tscircuit, etc.) universally downloads at runtime rather than bundles.
+
+This SPEC inherits that posture: **download at runtime with explicit user opt-in**, never bundle. See "First-use ToS acceptance flow" below.
+
+## The `ResolvedPart` record
+
+The shared data type returned by `lcsc(operation="resolve", ...)` and the items in `lcsc(operation="search", ...)` results. Designed to work for LCSC v1 and DigiKey v2 (and other future suppliers) without changes — fields that don't apply to a given supplier are `None`.
+
+```python
+@dataclass
+class ResolvedPart:
+    # Identity
+    supplier_name: str              # "lcsc" | "digikey" (future)
+    supplier_part_number: str       # "C6186" or "P5555-ND" (DigiKey future)
+    mpn: str                        # manufacturer part number
+    manufacturer: str               # "Advanced Monolithic Systems"
+
+    # Description
+    description: str                # short description; the supplier's text
+    package: str                    # normalized package string, e.g. "SOT-223"
+    pin_count: int | None           # solder pad count (from jlcparts.joints) if available
+
+    # Parametric attributes
+    attributes: dict[str, str]      # {"Output Voltage": "3.3V", "Output Current": "1A", ...}
+                                    # Values are strings (not parsed/typed); caller interprets
+
+    # Commercial
+    price_tiers: list[dict]         # [{"qty_min": 1, "qty_max": 49, "unit_price_usd": 0.2022}, ...]
+                                    # qty_max=None means "and above"
+    stock: int                      # global stock at time of snapshot
+    lifecycle: str                  # "active" | "nrnd" | "obsolete" | "unknown"
+
+    # LCSC/JLCPCB-specific
+    assembly_tier: str | None       # "basic" | "extended" | "preferred" — None for non-JLCPCB
+
+    # KiCad resolution
+    kicad_symbol_lib_id: str | None      # "Regulator_Linear:AMS1117-3.3" if resolvable, else None
+    kicad_footprint_path: str | None     # "Package_TO_SOT_SMD:SOT-223-3" if mapped, else None
+
+    # Documentation
+    datasheet_url: str | None       # if available
+
+    # Match metadata (when returned from a search)
+    match_score: float | None       # 0.0-1.0; None when returned from `resolve` (exact lookup)
+    match_deviations: list[str]     # human-readable explanations of how this differs from query
+                                    # Empty list = exact match. Example items:
+                                    # "package: SOT-223 differs from requested SOT-23"
+                                    # "assembly_tier: 'extended' differs from requested 'basic'"
+
+    # Provenance
+    snapshot_date: str              # ISO-8601 date of the jlcparts snapshot used
+    fetched_live: bool              # True if any field was fetched from the live JLCPCB API
+                                    # (rather than from the snapshot); affects freshness
+```
+
+JSON-serializable shape mirrors the dataclass. All fields present in every response (None where not applicable), so callers can rely on the shape.
+
+## Tool surface
+
+A single router `lcsc` with three operations.
+
+### `lcsc(operation="search", ...)`
+
+```python
+lcsc(
+    operation="search",
+    description: str,                      # "3.3V LDO regulator"
+    package: str | None = None,            # "SOT-23", "0402", etc.
+    assembly_tier: str = "basic",          # "basic" | "extended" | "preferred" | "any"
+    max_results: int = 3,                  # cap; default 3
+    include_unresolvable: bool = False,    # if False (default), filter out results with no kicad_footprint_path mapping
+    extra_filters: dict | None = None,     # optional parametric filters, e.g. {"voltage": "3.3V"}
+)
+-> {
+    "status": "ok",
+    "results": [ResolvedPart, ResolvedPart, ResolvedPart],  # ranked best-match first
+    "events": [...],                       # populated when uncertain (per OOB envelope)
+}
+```
+
+**Returns up to `max_results` ranked best-match-first.** If no exact matches exist, the closest matches are returned with `match_score < 1.0` AND a `warn`-level event in `events` saying "no exact match; returning closest candidates". Caller decides whether to accept or refine.
+
+### `lcsc(operation="resolve", ...)`
+
+```python
+lcsc(
+    operation="resolve",
+    part_number: str,                      # "C6186"
+)
+-> {
+    "status": "ok",
+    "part": ResolvedPart,
+    "events": [...],
+}
+```
+
+Exact lookup by LCSC number. `match_score` is None (not applicable). Use this when the LLM has already chosen a specific candidate or knows the LCSC number from another source.
+
+### `lcsc(operation="assign", ...)`
+
+```python
+lcsc(
+    operation="assign",
+    reference: str,                        # "U1"
+    part_number: str,                      # "C6186"
+    schematic_path: str | None = None,     # defaults to currently-loaded schematic
+)
+-> {
+    "status": "ok",
+    "applied": {
+        "value": "AMS1117-3.3",            # set on the schematic component
+        "lcsc_property": "C6186",
+        "footprint": "Package_TO_SOT_SMD:SOT-223-3",  # or None if unmapped
+        "symbol": "Regulator_Linear:AMS1117-3.3",     # or unchanged if symbol was already set
+    },
+    "events": [...],
+}
+```
+
+Applies a resolved part to a schematic component:
+- Sets the `Value` field to the MPN
+- Sets a `LCSC` property to the part number (used by JLCPCB assembly BOM tooling)
+- Sets the `Footprint` field if mapping exists
+- Updates the symbol if currently unset or mismatched
+- Emits a `warn` event if any field had to be skipped (e.g., footprint unmappable)
+
+This is the **explicit confirmation step** — search/resolve are read-only; assign mutates the schematic.
+
+## Match scoring and ranking
+
+The search algorithm scores each candidate against the query and returns the top N.
+
+### Scoring criteria (with weights)
+
+The score is computed as a weighted average of per-criterion match scores:
+
+| Criterion | Weight | Match scoring |
+|---|---|---|
+| Description / functional match | 0.40 | Full-text relevance against `description` and `attributes`; 1.0 = all query keywords match, 0.0 = none |
+| Package | 0.25 | Exact package string match = 1.0; close family (e.g., SOT-23 vs SOT-23-5) = 0.7; different = 0.0 |
+| Assembly tier | 0.15 | Exact = 1.0; "extended" when "basic" requested = 0.5; "obsolete"/"unknown" = 0.0 |
+| Stock availability | 0.10 | stock ≥ 1000 = 1.0; stock 100-999 = 0.7; stock 1-99 = 0.3; stock 0 = 0.0 |
+| KiCad footprint resolvable | 0.10 | Has mapping = 1.0; no mapping = 0.5 (reduced; user can still proceed) |
+
+Overall score = sum of (weight × per-criterion score). Score in [0, 1]. The configurable parameter is whether unresolvable-footprint candidates are returned at all (`include_unresolvable` arg, default False).
+
+### Deviation reporting
+
+For each returned candidate, `match_deviations` lists every criterion where the score was less than 1.0, in human-readable form. Examples:
+
+- `"package: SOT-223 (requested SOT-23)"`
+- `"assembly_tier: 'extended' (requested 'basic') — adds JLCPCB assembly fee"`
+- `"stock: 47 (low; consider alternates)"`
+- `"kicad_footprint_path: no mapping for 'XQFN-24'; assign manually"`
+
+The LLM consumes these to decide whether to accept the top result, propose a different one to the user, or re-query with looser constraints.
+
+### Why a list, not a single recommendation
+
+A single recommendation makes the tool feel decisive but obscures the trade-offs the LLM should be reasoning about. With three candidates and their deviations, the LLM can articulate "I picked C6186 over C70569 because stock is 100x higher even though current rating is overspec'd" — that's the right level of judgment for the LLM to exercise.
+
+## First-use ToS acceptance flow
+
+The first time `lcsc(operation=...)` is called in an installation, the user must accept that downloading the JLCPCB component catalog uses LCSC's catalog data under terms they're responsible for. Specifics:
+
+### Acceptance record
+
+A small file at `~/.cache/kicad-mcp/lcsc_tos_acceptance.json`:
+
+```json
+{
+  "accepted_at": "2026-05-27T15:32:11Z",
+  "acceptance_hash": "<sha256 of the ToS notice text shown>",
+  "snapshot_first_used": "2026-05-26"
+}
+```
+
+### Acceptance prompt
+
+On first call with no acceptance record, the tool:
+- Does NOT download anything
+- Returns `status: "error"` with `code: "lcsc_tos_acceptance_required"` and a `message` containing the full notice text:
+  > "This will download a ~300 MB component-catalog snapshot from the community yaqwsx/jlcparts project. The snapshot contains data from LCSC's product catalog. LCSC's API terms of service prohibit redistribution of bulk catalog data; the snapshot is downloaded directly from the community source, not from this MCP server. By proceeding, you accept responsibility for compliance with LCSC's terms. To accept and continue, call `lcsc(operation='accept_tos')`. To decline, do not call further LCSC operations."
+- The LLM relays this to the user and waits for explicit affirmation.
+- The user (via the LLM) then calls `lcsc(operation="accept_tos")` which writes the acceptance file.
+
+### Re-prompting
+
+If the ToS notice text ever changes (different `acceptance_hash`), the next call surfaces the new notice and requires re-acceptance. Acceptance is per-install, not per-session.
+
+### Bypassing acceptance (for tests / CI)
+
+`KICAD_MCP_LCSC_TOS_ACCEPTED=1` environment variable skips the prompt (for CI / automated testing). Documented; not the recommended path for users.
+
+## Snapshot management
+
+The jlcparts SQLite is downloaded on first ToS-accepted call and cached at `~/.cache/kicad-mcp/jlcparts.db`. A small metadata file alongside tracks its provenance:
+
+```json
+{
+  "downloaded_at": "2026-05-27T15:35:22Z",
+  "source_url": "https://bouni.github.io/jlcparts/data/cache.sqlite3.zip.001",
+  "snapshot_date": "2026-05-26",   // last_update column max from the data itself
+  "size_bytes": 327145728
+}
+```
+
+### Freshness thresholds
+
+| Age | Behavior |
+|---|---|
+| 0-7 days | Quietly use snapshot; no event emitted |
+| 8-14 days | Use snapshot; emit `info` event `lcsc_snapshot_aging` (not surfaced to LLM by default) |
+| 15-30 days | Use snapshot; emit `warn` event `lcsc_snapshot_stale`; LLM sees in response `events` |
+| 31+ days | Use snapshot; emit `warn` event `lcsc_snapshot_very_stale`; suggest refresh |
+
+These thresholds are **initial guesses**. Telemetry records snapshot age at every call (in `calls.output_summary`). Once we have data on actual LCSC catalog churn rate, we tune.
+
+### Refresh
+
+The user (via the LLM) explicitly refreshes by calling `lcsc(operation="refresh_snapshot")`. This:
+- Re-downloads the latest snapshot from the same source URL
+- Replaces the cached file
+- Updates the metadata file
+- Emits an `info` event with the old and new snapshot dates
+
+We do NOT auto-refresh on each call (network cost) or on each session (user surprise). The LLM can decide to refresh based on the staleness warning + user preference.
+
+### Upstream unavailable
+
+If the download fails (jlcparts CI offline, GitHub Pages down, network error):
+- If a cached snapshot exists (any age): use it; emit a `warn` event `lcsc_snapshot_offline_fallback` with the age.
+- If no cached snapshot exists: return `status: "error"` with `code: "lcsc_snapshot_unavailable"`; tool is unusable until network/upstream restored.
+
+## Package → KiCad footprint mapping
+
+A static lookup file at `src/kicad_mcp/data/lcsc_footprint_mapping.yaml`:
+
+```yaml
+"SOT-23":        "Package_TO_SOT_SMD:SOT-23"
+"SOT-23-3":      "Package_TO_SOT_SMD:SOT-23"
+"SOT-23-5":      "Package_TO_SOT_SMD:SOT-23-5"
+"SOT-23-6":      "Package_TO_SOT_SMD:SOT-23-6"
+"SOT-223":       "Package_TO_SOT_SMD:SOT-223-3_TabPin2"
+"SOT-223-3":     "Package_TO_SOT_SMD:SOT-223-3_TabPin2"
+"SOIC-8":        "Package_SO:SOIC-8_3.9x4.9mm_P1.27mm"
+"SOIC-14":       "Package_SO:SOIC-14_3.9x8.7mm_P1.27mm"
+"0402":          "Resistor_SMD:R_0402_1005Metric"     # also used for caps; package alone doesn't disambiguate
+"0603":          "Resistor_SMD:R_0603_1608Metric"
+# ... ~200 entries total ...
+```
+
+Caveats:
+- **Resistor vs capacitor at the same package size**: the file maps to the resistor variant by default. The `lcsc` tool inspects the part's category (resistor / capacitor / inductor) before picking the appropriate footprint family.
+- **Hand-soldering vs reflow variants**: KiCad libraries often have multiple footprints for the same package (e.g., `SOIC-8_3.9x4.9mm_P1.27mm` vs `SOIC-8_3.9x4.9mm_P1.27mm_HandSoldering`). The default is the reflow variant; assembly-aware projects can override.
+
+This file is hand-maintained. When a part comes back with an unmapped package, the tool emits a `warn` event noting the unmapped package; over time the maintenance pattern is "see the warnings, add entries."
+
+## Telemetry & event surfacing
+
+This tool is a heavy producer of both telemetry data (for tuning) and OOB events (for surfacing to the LLM). The integration:
+
+### Telemetry calls per operation
+
+For each `lcsc(operation="search"|"resolve"|"assign", ...)` call:
+- `record_call` with `tool_name="lcsc.{operation}"`, `output_summary` including `result_count`, `top_match_score`, `snapshot_age_days`, `fetched_live` flag
+- `record_warning` for any uncertain-match (low score) or unresolvable-footprint cases
+
+### OOB events surfaced to the calling LLM
+
+| Event code | Severity | When |
+|---|---|---|
+| `lcsc_tos_acceptance_required` | `error` | First call, no acceptance record |
+| `lcsc_snapshot_aging` | `info` | Snapshot 8-14 days old (not surfaced by default) |
+| `lcsc_snapshot_stale` | `warn` | Snapshot 15-30 days old |
+| `lcsc_snapshot_very_stale` | `warn` | Snapshot 31+ days old |
+| `lcsc_snapshot_offline_fallback` | `warn` | Network/upstream unavailable; using cached |
+| `lcsc_snapshot_unavailable` | `error` | No cache + offline; tool unusable |
+| `lcsc_no_exact_match` | `warn` | Search returned only sub-1.0 match_score candidates |
+| `lcsc_footprint_unmapped` | `warn` | Result has no kicad_footprint_path; assign-time |
+| `lcsc_assembly_tier_downgrade` | `info` | Best match is in a more expensive tier than requested |
+
+### Future analyze queries (Feedback Infrastructure)
+
+Not in v1, but documented as targets for the calibration loop:
+- Distribution of `snapshot_age_days` across calls — tunes the freshness thresholds
+- Distribution of `top_match_score` for successful workflows vs. abandoned ones — tunes scoring weights
+- Most-frequently-emitted unmapped-package codes — drives footprint-mapping additions
+
+## v1 scope
+
+Ship:
+- `lcsc` router with operations `search`, `resolve`, `assign`, `accept_tos`, `refresh_snapshot`
+- `ResolvedPart` dataclass + JSON serialization
+- First-use ToS acceptance flow (file at `~/.cache/kicad-mcp/lcsc_tos_acceptance.json`)
+- jlcparts snapshot download + metadata tracking
+- Freshness thresholds (14/30 days) with `mcp-events` emissions
+- Static package → footprint mapping (~200 entries; see `lcsc_footprint_mapping.yaml`)
+- Match scoring per the criteria/weights table above
+- Telemetry integration: every call records to `calls`; events persist via OOB
+- Tests: unit tests for ranking, scoring, package mapping; integration tests with a small synthetic jlcparts SQLite fixture
+- `KICAD_MCP_LCSC_TOS_ACCEPTED=1` env var for CI/testing
+
+### Tool count after this PR
+
+13 → 14 (`lcsc` router).
+
+### Test count target
+
+Approximately +50 tests. The match-scoring algorithm needs thorough boundary coverage per project's threshold-testing rule.
+
+### Estimated wall-clock to ship
+
+5-7 days of pairing-mode work (per the original memory estimate of "~1 week" for component intelligence). Slightly longer than the original estimate because the ToS flow and snapshot management were not in the original scope.
+
+## Deferred from v1
+
+- **DigiKey supplier integration.** Separate router (`digikey`) sharing only the `ResolvedPart` type. Planned for soon-after; spec to be written separately when prioritized.
+- **Auto-best-pick mode.** A `lcsc(operation="search_one", ...)` that returns just the top result without the list. Aggressive default, can be added once base usage patterns are observed.
+- **Reverse MPN → LCSC lookup.** Given a manufacturer part number, find its LCSC equivalent. Useful for "I designed against this part, now find a JLCPCB-stocked equivalent" — a real workflow but not v1.
+- **Substitution suggestions.** Given a part, suggest functionally-equivalent alternates. Requires deeper attribute analysis than v1 can support.
+- **BOM-level operations.** Multi-part workflows (cost optimization, basic-tier maximization across a BOM, etc.). Each component selected one at a time in v1.
+- **Smart cache eviction.** v1 keeps the cached snapshot indefinitely; manual refresh only. Auto-eviction at age 90+ days is a v2 nice-to-have.
+- **Multi-snapshot history.** v1 holds one snapshot; v2 could keep history for "compare prices across snapshots" workflows.
+- **`refresh_snapshot` progress streaming.** v1 downloads silently and reports success/failure at end. v2 could stream progress via `mcp-events` for the user experience.
+
+## Open questions (proposed answers — confirm during implementation)
+
+1. **Should `lcsc(operation="assign", ...)` automatically resolve part_number, or require the caller to have already called `resolve` first?** Proposal: it resolves internally (single round-trip from the LLM's view). The downside is the LLM might be surprised by what `resolve` would have returned. Surface a `Resolved` summary in the `assign` response.
+2. **What happens if `assign` is called for a reference that doesn't exist in the schematic?** Proposal: `status: "error"` with `code: "reference_not_found"`. Don't silently no-op.
+3. **What happens if `assign` is called for a part whose `kicad_symbol_lib_id` is None?** Proposal: still proceed with `Value` and `LCSC` property; skip the symbol; emit a `warn` event. Assign is a "do as much as you can" operation.
+4. **Should `search` honor a `min_score` threshold to filter out very-poor matches?** Proposal: not in v1. Return up to `max_results` regardless of score; let the caller filter. The `match_score` is in the response for caller decisions.
+5. **What's the maximum `description` length the search engine handles cleanly?** Proposal: 256 chars; truncate longer queries with a `warn` event. Forces concise spec, avoids confusion when an LLM accidentally pastes a paragraph.
+
+## Testing strategy
+
+Tests live in `tests/test_lcsc.py`. No network access required for tests; no real jlcparts download.
+
+### Synthetic snapshot fixture
+
+A small (~100-row) SQLite file at `tests/fixtures/jlcparts_synthetic.sqlite3` matching the production schema. Covers:
+- Multiple parts at the same package (for ranking-by-stock tests)
+- Multiple parts at adjacent assembly tiers (for tier-downgrade test)
+- Parts with and without resolvable footprints
+- Parts with and without datasheet URLs
+- Parts in each lifecycle state
+
+### Test cases
+
+**Search ranking and scoring:**
+- Exact match (all criteria match) → match_score = 1.0
+- Close match (one criterion off) → 0.5 < match_score < 1.0
+- Far match (multiple criteria off) → match_score < 0.5
+- Package family fallback (SOT-23 → SOT-23-5) → 0.7 score on package criterion
+- Unmapped footprint → 0.5 score on footprint criterion when `include_unresolvable=True`
+- Default `include_unresolvable=False` filters out unmapped-footprint candidates
+- `max_results` honored
+- Ranking is stable (same query → same order)
+
+**ToS flow:**
+- First call without acceptance file → returns `lcsc_tos_acceptance_required` error
+- `accept_tos` creates the file
+- After acceptance, subsequent calls succeed
+- Changing the embedded ToS text changes the acceptance_hash; old acceptance becomes invalid
+- `KICAD_MCP_LCSC_TOS_ACCEPTED=1` bypasses prompt
+
+**Freshness:**
+- Snapshot ≤7 days: no event emitted
+- Snapshot 8-14 days: `info` event (not in default response envelope)
+- Snapshot 15-30 days: `warn` event in response envelope
+- Snapshot 31+ days: `warn` (different code) in response envelope
+- Boundary: exactly 14 days → still `info`; exactly 15 days → `warn`
+- Boundary: exactly 30 days → still `warn` (`lcsc_snapshot_stale`); exactly 31 days → `warn` (`lcsc_snapshot_very_stale`)
+
+**Snapshot download:**
+- Refresh fetches; metadata updated
+- Download failure with cached snapshot → fallback + `warn`
+- Download failure without cached snapshot → `error`
+
+**Match deviations:**
+- Returned candidate with wrong package has `"package: ..."` in deviations
+- Tier downgrade adds appropriate deviation
+- Exact match has empty deviations list
+
+**Assign operation:**
+- Sets Value, LCSC property, Footprint when all available
+- Skips Footprint when unmapped; emits `warn`
+- Errors when reference doesn't exist in schematic
+
+**Boundary tests (per project CLAUDE.md threshold-testing rule):**
+- `match_score=1.0` is achievable; `match_score=0.0` is achievable
+- `stock=999` vs `stock=1000` boundary in stock scoring criterion
+- `assembly_tier="any"` matches all tiers; `"basic"` matches only basic
+- Empty result list when no candidates pass `include_unresolvable=False` filter (returns ok status, empty results, `warn` event)
+
+### Integration tests (KiCad required, marked appropriately)
+
+- `lcsc(operation="assign", ...)` on a real schematic: file gets the expected property updates; no DRC violations introduced
+- Round-trip: search → resolve → assign → re-load schematic → fields match
+
+## Hand-off summary
+
+For an implementer picking this up cold:
+
+1. Read this SPEC end-to-end.
+2. Read the design-philosophy feedback memories: `feedback_context_frugality.md`, `feedback_synchronous_at_call_boundary.md`, `feedback_prefer_packaging_over_vendoring.md`.
+3. **Verify the `mcp-events` package exists** at `/Volumes/Files/claude/mcp-events/` and is installed. If not, this PR blocks on that.
+4. **Verify the Feedback Infrastructure is implemented** (`SPEC_Feedback_Infrastructure.md`). If not, this tool can ship with no-op telemetry calls, but the calibration loop is missing — prefer to land it first.
+5. Implement against the v1 scope above. Defer everything in "Deferred from v1."
+6. The test suite is the acceptance criterion. Unit tests run in the existing `uv run pytest` invocation with no KiCad installation required (using the synthetic SQLite fixture). Integration tests require KiCad and are marked accordingly.
+7. Hand-curate the initial `lcsc_footprint_mapping.yaml` from ~200 most-common JLCPCB packages. The dataset audit in this session noted the canonical sources; consult `project_component_intelligence.md`.
+8. Update `MEMORY.md` and `project_component_intelligence.md` to mark this as **implemented** when the PR merges; note any deviations.
+
+Tool count after this PR: 13 → 14. Test count target: ~+50 tests.
+
+Implementation order context:
+
+```
+✅ OOB Events Subsystem       (per SPEC_OOB_Events.md — landed first)
+✅ Feedback Infrastructure    (per SPEC_Feedback_Infrastructure.md — landed second)
+→  Component Intelligence     (this SPEC — landed third)
+✗  Schematic Auto-Placement   (spec still in design; lands fourth, uses all of the above)
+```

--- a/docs/SPEC_Feedback_Infrastructure.md
+++ b/docs/SPEC_Feedback_Infrastructure.md
@@ -1,0 +1,582 @@
+# SPEC — Feedback Infrastructure
+
+**Status:** Approved for implementation
+**Author:** Brian + Claude
+**Date:** 2026-05-27
+**Target:** Local telemetry + action-attribution for kicad-mcp tools
+**First consumer:** `suggest_schematic_placement` (in design; see `project_schematic_placement.md` in memory)
+
+## Motivation
+
+Two intertwined needs surfaced from the schematic-placement spec session:
+
+1. **Calibration measurement.** When a tool labels a result with confidence C, what fraction of those labels actually hold up under caller scrutiny? When a warning fires, what fraction get acted on vs. ignored as noise? Without this, "calibration > coverage" is a design principle with no measurement loop, and we can't tell whether our confidence scores mean anything.
+
+2. **Iteration debugging.** When a caller iterates against a tool, what's the convergence pattern? Which warnings keep re-firing? Which hints get repeated across calls (signal that the algorithm is being stubbornly wrong about the same thing)?
+
+Together these answer the load-bearing question: *is our tool's signal honest?* For an MCP designed around an AI assistant as the consumer, an honestly-uncertain answer beats a confidently-wrong one. We need data to know which we're delivering.
+
+## Non-goals
+
+- **Not** a general-purpose observability platform. This is local-only SQLite for the maintainer; no network, no upload, no dashboards.
+- **Not** in scope for v1: cross-tool telemetry beyond placement. The schema is designed to extend, but only placement writes in v1.
+- **Not** a real-time monitoring system. Queries run on demand; freshness is whatever the last call wrote.
+- **Not** storing schematic contents. We persist ref-level identifiers (component refs like "U1", net names like "VCC", cluster IDs), aggregate counts, and timing data. We do NOT store the schematic file, component values, or anything that would let an observer reconstruct the design. Schematic identity is captured by an opaque hash only.
+
+## Dependencies
+
+This SPEC depends on the **Out-of-Band Events Subsystem**, distributed as the `mcp-events` Python package (see [`docs/SPEC_OOB_Events.md`](SPEC_OOB_Events.md), 2026-05-27). The package lives at `/Volumes/Files/claude/mcp-events/` and is consumed via editable path-source in dev + `mcp-events>=0.1.0` in `pyproject.toml`. The package provides:
+
+- The `mcp_events` Python module — `from mcp_events import event_context, soft_failure, emit_event, with_events`
+- A `soft_failure(code, message, context=None)` function that records a `warn`-severity event without raising
+- An `emit_event(severity, code, message, context=None)` function for general-purpose events at any severity
+- An `events` field in tool response envelopes for surfacing accumulated events to the calling LLM
+
+Telemetry persistence (the `system_events` table, defined below) is **kicad-mcp's local concern** — it's the durable-store side of the picture, for events that need to survive between tool calls. The shared module handles in-call accumulation; this SPEC handles persistence.
+
+Telemetry uses the OOB subsystem for:
+
+- **Failure surfacing**: telemetry write failures call `mcp_events.soft_failure("telemetry_write_failed", ...)`. The event flushes into the calling tool's `events` envelope and is also persisted to `system_events`. Failures do NOT propagate to the calling tool's main behavior.
+- **Schema migration events**: applied migrations call `emit_event("info", "telemetry_schema_migrated", ...)`. Persisted (between-call event surfaces on next call's response).
+- **Sweep events**: `sweep_abandoned` emits an info-severity event with a count summary. Also persisted.
+
+**Implementation order**: OOB → telemetry → placement. This SPEC should not be implemented before the OOB subsystem.
+
+If OOB ships with a different API surface than sketched above, this section gets updated to match.
+
+## Design principles applied
+
+- **Synchronous at call boundary.** Action attribution happens inline at `suggest_schematic_placement` entry, before computation. No daemon, no periodic backfill pass, no scheduling. See the `synchronous-at-call-boundary` feedback memory for rationale.
+- **Context-frugal.** The write path is invisible to tool responses. The `analyze_placement_telemetry` read path defaults to terse summary output. Verbose mode is opt-in. See the `context-frugality` feedback memory.
+- **Opt-out.** `KICAD_MCP_NO_TELEMETRY=1` disables writes entirely; reads still work on whatever's accumulated.
+
+## Data model
+
+SQLite at `~/.cache/kicad-mcp/telemetry.db`. Four primary tables + one schema-version table.
+
+### Schema (v1)
+
+```sql
+CREATE TABLE schema_version (
+    version INTEGER PRIMARY KEY,
+    applied_at TIMESTAMP NOT NULL
+);
+
+CREATE TABLE calls (
+    call_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tool_name TEXT NOT NULL,                -- e.g. 'suggest_schematic_placement'
+    schematic_hash TEXT NOT NULL,           -- content hash of the schematic file at call time
+    timestamp TIMESTAMP NOT NULL,
+
+    -- Iteration tracking (within a schematic)
+    iteration_index INTEGER NOT NULL,       -- N-th call on this schematic_hash
+    state_id TEXT,                          -- for stateful mode; correlates to placement_state cache
+    is_fresh_state BOOLEAN NOT NULL,        -- caller passed state=null AND no state_id
+
+    -- Inputs (terse summary, not full payload)
+    inputs_summary TEXT NOT NULL,           -- JSON: counts and key types of hints/constraints/scope
+    output_summary TEXT,                    -- JSON: tool-specific; for placement: cluster_count, etc.
+
+    -- Performance
+    elapsed_ms INTEGER NOT NULL,
+    phase_breakdown_ms TEXT,                -- JSON: {"netlist_export": 150, "cluster": 80, ...}
+
+    -- Environment
+    kicad_cli_version TEXT,                 -- e.g. '10.0.3'
+    netlist_schema_hash TEXT                -- for external-interface-verification correlation
+);
+
+CREATE INDEX idx_calls_schematic ON calls(schematic_hash, timestamp);
+CREATE INDEX idx_calls_tool ON calls(tool_name, timestamp);
+
+CREATE TABLE cluster_decisions (
+    decision_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    call_id INTEGER NOT NULL REFERENCES calls(call_id),
+    cluster_id TEXT NOT NULL,               -- e.g. 'c0', 'c3'
+
+    member_count INTEGER NOT NULL,
+    anchor_ref TEXT,                        -- ref of the anchor component, or NULL
+
+    label TEXT,                             -- e.g. 'mcu', 'ldo', 'unclassified'
+    label_confidence REAL,                  -- 0.0 - 1.0
+    label_source TEXT,                      -- 'pattern_recognition' | 'resolved_part' | 'caller_hint' | 'topology_only' | 'none'
+
+    tier INTEGER,
+    louvain_modularity REAL                 -- the modularity score for this cluster (if topology-based)
+);
+
+CREATE INDEX idx_cluster_call ON cluster_decisions(call_id);
+
+CREATE TABLE warnings_emitted (
+    warning_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    call_id INTEGER NOT NULL REFERENCES calls(call_id),
+
+    warning_type TEXT NOT NULL,             -- 'bus_bridge_suspected' | 'singleton_orphan' | ...
+    severity TEXT NOT NULL,                 -- 'info' | 'warn' | 'error'
+    affected_refs TEXT NOT NULL,            -- JSON array of refs
+    affected_cluster_ids TEXT NOT NULL,     -- JSON array of cluster_ids
+
+    -- Action attribution (synchronously updated)
+    status TEXT NOT NULL DEFAULT 'pending', -- 'pending' | 'addressed' | 'abandoned'
+    addressed_in_call_id INTEGER REFERENCES calls(call_id),
+    addressed_how TEXT,                     -- 'hint' | 'cluster_assignment' | 'fixed_position' | NULL
+    addressed_at TIMESTAMP
+);
+
+CREATE INDEX idx_warnings_pending ON warnings_emitted(status, call_id) WHERE status = 'pending';
+CREATE INDEX idx_warnings_type ON warnings_emitted(warning_type, status);
+
+CREATE TABLE system_events (
+    event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TIMESTAMP NOT NULL,
+    severity TEXT NOT NULL,                 -- 'info' | 'warn' | 'error'
+    code TEXT NOT NULL,                     -- short identifier, e.g. 'telemetry_write_failed', 'telemetry_schema_migrated'
+    message TEXT NOT NULL,                  -- human-readable
+    context TEXT,                           -- JSON; relevant state at time of event
+    seen INTEGER NOT NULL DEFAULT 0         -- flipped to 1 when returned by an analyze query
+);
+
+CREATE INDEX idx_system_events_unseen ON system_events(seen, timestamp);
+CREATE INDEX idx_system_events_severity ON system_events(severity, timestamp);
+
+CREATE TABLE sweep_state (
+    -- Single-row table holding the timestamp of the last sweep_abandoned run.
+    -- Used to throttle sweep frequency.
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    last_sweep_at TIMESTAMP
+);
+```
+
+### Schema versioning and migration
+
+`schema_version` starts at row `(1, <install_time>)`. Future migrations append rows and run forward-only DDL. No rollback path needed; this is local development data.
+
+**When migrations run:** lazily, on first connection per process. The `telemetry` module checks `schema_version.MAX(version)` on its first DB operation. If less than the current code's expected version, it runs the missing migrations in order, then inserts a row recording each application.
+
+**On migration:** emit an info-severity event via `emit_event("info", "telemetry_schema_migrated", ...)`. The event is persisted (will appear in the next call's `events` envelope if surfacing rules apply).
+
+**On migration failure:** emit an error-severity event; subsequent telemetry writes are skipped for the lifetime of the process; the calling tool is unaffected. A future `kicad-mcp doctor` command (out of scope here) could surface this for repair.
+
+## Write API
+
+Module: `kicad_mcp/utils/telemetry.py`
+
+```python
+def record_call(
+    tool_name: str,
+    schematic_hash: str,
+    inputs_summary: dict,
+    output_summary: dict | None = None,
+    elapsed_ms: int = 0,
+    phase_breakdown_ms: dict | None = None,
+    state_id: str | None = None,
+    is_fresh_state: bool = True,
+    kicad_cli_version: str | None = None,
+    netlist_schema_hash: str | None = None,
+) -> int:  # returns call_id
+    """Insert one row into calls. Auto-computes iteration_index by counting prior
+    calls on the same schematic_hash. Returns the new call_id."""
+
+def record_cluster_decision(
+    call_id: int,
+    cluster_id: str,
+    member_count: int,
+    anchor_ref: str | None,
+    label: str | None,
+    label_confidence: float | None,
+    label_source: str,
+    tier: int | None,
+    louvain_modularity: float | None,
+) -> None:
+    """Insert one row into cluster_decisions."""
+
+def record_warning(
+    call_id: int,
+    warning_type: str,
+    severity: str,
+    affected_refs: list[str],
+    affected_cluster_ids: list[str],
+) -> None:
+    """Insert one row into warnings_emitted with status='pending'.
+
+    Validation: at least one of affected_refs or affected_cluster_ids must be
+    non-empty. A warning with no targets has no way to be matched against
+    caller actions. If both are empty, the function emits a soft_failure
+    event (code='warning_emit_invalid') and skips the insert — this catches
+    bad emitter code at source rather than letting a useless row accumulate."""
+
+def attribute_pending_warnings(
+    schematic_hash: str,
+    new_call_id: int,
+    inputs: dict,
+) -> int:
+    """For each pending warning on this schematic, scan the new call's inputs for
+    a matching action. Update status to 'addressed' for matches. Returns count
+    of newly-addressed warnings.
+
+    `inputs` is the RAW caller payload (e.g., the kwargs dict passed to
+    suggest_schematic_placement), NOT the inputs_summary stored in the calls
+    table. The matching logic needs to walk the actual structure of hints /
+    cluster_assignments / fixed_positions to compare against affected_refs.
+
+    Called by the consumer tool BEFORE it does its main computation, so the
+    new call_id is already known (record_call ran first)."""
+
+def sweep_abandoned(max_age_days: int = 7) -> int:
+    """Mark warnings older than max_age_days as 'abandoned'. Also sweeps
+    warnings whose next call on the same schematic used fresh state.
+    Returns count of newly-abandoned warnings.
+
+    Called opportunistically — at the start of any record_call() invocation,
+    if a configurable interval has passed since last sweep."""
+```
+
+All writes are wrapped in `if not _telemetry_disabled():`. The env var check happens once at module load.
+
+### `inputs_summary` shape
+
+The terse JSON summary, NOT the full input payload. For placement:
+
+```json
+{
+  "hints": {"count": 3, "refs": ["U1", "U7", "C3"]},
+  "cluster_assignments": {"count": 0},
+  "fixed_positions": {"count": 1, "refs": ["U1"]},
+  "merge_clusters": {"count": 0},
+  "split_cluster": {"count": 0},
+  "redo_scope": {"count": 2, "cluster_ids": ["c3", "c5"]}
+}
+```
+
+Keeps storage small; preserves what attribution needs.
+
+### `output_summary` shape (placement-specific)
+
+```json
+{
+  "cluster_count": 7,
+  "tier_count": 3,
+  "label_source_breakdown": {
+    "pattern_recognition": 3,
+    "resolved_part": 1,
+    "caller_hint": 2,
+    "topology_only": 1
+  },
+  "low_confidence_cluster_count": 2,
+  "warnings_emitted_count": 4
+}
+```
+
+Other future tools can define their own `output_summary` shapes. The column is opaque JSON — no schema enforced at the DB level, by design.
+
+### Call ordering (suggest_schematic_placement integration)
+
+The integration sequence for a consumer tool:
+
+1. **`record_call(...)`** — get the new `call_id` for this invocation.
+2. **`attribute_pending_warnings(schematic_hash, call_id, inputs=raw_kwargs)`** — backfill any pending warnings that this call's inputs address. Must run BEFORE the main computation so that the algorithm doesn't process inputs whose attribution hasn't been recorded yet (subtle but matters for consistent ordering in the DB).
+3. **(tool's main computation runs)** — clustering, ranking, packing, etc.
+4. **`record_cluster_decision(...)`** — one call per cluster in the output state.
+5. **`record_warning(...)`** — one call per warning emitted by the algorithm.
+
+All five steps run synchronously within the tool's call. Total telemetry overhead: a handful of small INSERTs, ~1-2 ms on a typical SSD.
+
+## Synchronous action attribution
+
+The matching function used by `attribute_pending_warnings`.
+
+For each pending warning W with `affected_refs=R` and `affected_cluster_ids=K`, scan the new call's inputs:
+
+| Input present | Match condition | `addressed_how` |
+|---|---|---|
+| `hints={ref: ...}` | any ref ∈ R | `'hint'` |
+| `cluster_assignments={cluster: [refs...]}` | any ref in assignments ∈ R | `'cluster_assignment'` |
+| `fixed_positions={ref: ...}` | any ref ∈ R | `'fixed_position'` |
+
+First match wins. If no match, leave `status='pending'`.
+
+### Cluster ID drift handling
+
+If the new call is fresh-state (`is_fresh_state=True`), cluster IDs may not correspond to previous IDs in K. Fall back to matching on `affected_refs` only — if any ref in R appears in any of the new call's `cluster_assignments` value lists, count as `cluster_assignment` regardless of cluster_id matching.
+
+### Re-emission detection (v1: query-time only)
+
+A warning of the same `warning_type` with overlapping `affected_refs` firing again in a later call is logically a re-emission. v1 does not store this relationship at write time; the analyze tool computes it at query time using this algorithm:
+
+```
+For a given schematic_hash, group warnings_emitted by warning_type.
+Within each group, sort by call timestamp.
+For each pair (W_i, W_j) where i < j:
+  if set(W_i.affected_refs) ∩ set(W_j.affected_refs) is non-empty:
+    count W_j as a re-emission of W_i.
+A given W_j may be counted as the re-emission of at most one earlier W_i
+(the most recent one with overlap). This avoids triple-counting in long
+chains.
+```
+
+The `convergence_stats` query uses this to compute the `warnings_reemitted` field. Future v2 may add an explicit `reemits_warning_id` column with the relationship computed at write time, if query-time computation becomes expensive (unlikely at expected volumes — a few thousand rows per schematic).
+
+## Abandonment rules
+
+Pending warnings get marked `abandoned` when:
+
+1. **Age cutoff.** 7 days since `timestamp` of the call that emitted the warning, with no resolution.
+2. **Fresh-state reset.** A subsequent call on the same `schematic_hash` has `is_fresh_state=True`. Caller has effectively started over and lost the iteration thread.
+
+Sweep runs opportunistically inside `record_call` — if more than 1 hour has elapsed since last sweep, run it before inserting. The "last sweep" timestamp is stored in a single-row `sweep_state` table.
+
+## Read API
+
+One new MCP tool: `analyze_placement_telemetry`.
+
+```python
+@mcp.tool()
+def analyze_placement_telemetry(
+    query: str,                             # see query types below
+    filters: dict | None = None,            # query-specific filter dict
+    verbosity: str = "minimal",             # "minimal" | "full"
+) -> dict:
+    """Read telemetry data. Always returns {"status": "ok", "rows": [...]} or
+    {"error": "..."}. Verbose mode includes raw call_ids, sample warnings, etc."""
+```
+
+### v1 query types
+
+**`"calibration_table"`** — per (warning_type, confidence bucket), the action rate.
+
+**Confidence buckets** (5, equal width): `[0.0, 0.2)`, `[0.2, 0.4)`, `[0.4, 0.6)`, `[0.6, 0.8)`, `[0.8, 1.0]`. The top bucket is closed on both ends so `confidence=1.0` lands somewhere. Warnings with no associated confidence (most types) land in a special bucket `"none"`.
+
+**Confidence source**: for each warning, the confidence is read from the most recent cluster_decision for any of its `affected_cluster_ids`. If none exists (warning fired without a cluster context), bucket is `"none"`.
+
+**Action rate formula**: `addressed / (addressed + abandoned)`. Excludes `pending` so the metric stays stable as new warnings get attribution. If `addressed + abandoned == 0`, action_rate is `null` (insufficient data).
+
+```json
+{
+  "rows": [
+    {"warning_type": "bus_bridge_suspected", "confidence_bucket": "0.0-0.2",
+     "emitted": 12, "addressed": 8, "abandoned": 1, "pending": 3, "action_rate": 0.89},
+    {"warning_type": "bus_bridge_suspected", "confidence_bucket": "0.8-1.0",
+     "emitted": 5, "addressed": 1, "abandoned": 0, "pending": 4, "action_rate": 1.0},
+    {"warning_type": "singleton_orphan", "confidence_bucket": "none",
+     "emitted": 23, "addressed": 2, "abandoned": 18, "pending": 3, "action_rate": 0.10},
+    ...
+  ]
+}
+```
+
+Interpretation: a high action rate at high confidence = honest signal. A high action rate at low confidence = false alarms (algorithm is hedging when it shouldn't). A low action rate anywhere = noise candidate (the warning isn't useful).
+
+**`"convergence_stats"`** — per schematic, iteration counts and repeat metrics.
+
+```json
+{
+  "rows": [
+    {"schematic_hash": "abc123", "iterations": 7,
+     "warnings_emitted": 23, "warnings_reemitted": 5,
+     "first_call_at": "2026-05-27T...", "last_call_at": "2026-05-27T..."},
+    ...
+  ]
+}
+```
+
+`warnings_reemitted` is the count of warnings whose `warning_type` + `affected_refs` overlap repeated within the schematic — the algorithm fired, caller saw it, and it kept happening.
+
+**`"system_events"`** — recent events from the `system_events` table for review.
+
+```json
+{
+  "rows": [
+    {"event_id": 47, "timestamp": "2026-05-27T14:32:11Z",
+     "severity": "error", "code": "telemetry_write_failed",
+     "message": "database is locked", "seen": false,
+     "context": {"table": "warnings_emitted", "call_id": 102}},
+    ...
+  ]
+}
+```
+
+Each event returned by this query has its `seen` flag flipped to `1`, so a follow-up `unseen_only=True` query naturally shows only what's new since last review. Errors are returned regardless of `seen` state unless `seen` is explicitly filtered.
+
+### Filter dict (per query type)
+
+For `calibration_table`: `{"warning_type": "...", "since": "ISO-8601"}` — both optional.
+
+For `convergence_stats`: `{"schematic_hash": "...", "since": "ISO-8601"}` — both optional.
+
+For `system_events`: `{"severity": "info" | "warn" | "error", "unseen_only": true, "since": "ISO-8601", "limit": int}` — all optional. Default `limit=100`.
+
+### Empty-result behavior
+
+All queries return `{"status": "ok", "rows": []}` when no data matches — never an error. A fresh install with no calls yet, or `KICAD_MCP_NO_TELEMETRY=1` flipped on at first use, returns empty rows from any query without complaint. The schema is migrated on first read even when writes are disabled, so the tables exist and queries don't fail.
+
+### Verbosity
+
+`"minimal"` (default): just the aggregated rows.
+`"full"`: includes a `sample_warnings` array per row with up to 3 example warning_ids and their call_ids, for drilling in.
+
+## Opt-out
+
+`KICAD_MCP_NO_TELEMETRY=1` short-circuits all write paths (`record_*`, `attribute_pending_warnings`, `sweep_abandoned`) to no-ops. Reads still function. Schema migration still runs on first read (creates empty tables) so analyze tool doesn't error on a fresh disable-then-read sequence.
+
+The env var is checked once at module load; toggling requires process restart. (Acceptable: kicad-mcp is a per-session subprocess.)
+
+## v1 scope
+
+Ship:
+- Schema (four tables + version table + sweep_state table) + migration v1
+- `record_call`, `record_cluster_decision`, `record_warning` write functions (with `record_warning` validation rejecting empty-target warnings)
+- `attribute_pending_warnings` with `hints` / `cluster_assignments` / `fixed_positions` matching, including cluster-ID-drift fallback
+- `sweep_abandoned` with the 7-day + fresh-state-reset rules, throttled by `sweep_state.last_sweep_at` to once per hour
+- Lazy migration on first DB connection per process; migration events persisted to `system_events`
+- `analyze_placement_telemetry` tool (standalone, not behind a router) with three queries: `calibration_table`, `convergence_stats`, `system_events`
+- Integration with the OOB events subsystem for failure surfacing (write failures, schema migration outcomes, sweep summaries)
+- `KICAD_MCP_NO_TELEMETRY` opt-out (writes skipped; reads still work)
+- Tests using synthetic fixtures (no real `suggest_placement` needed)
+
+**Prerequisite:** the `mcp-events` package exists at `/Volumes/Files/claude/mcp-events/` (per [`SPEC_OOB_Events.md`](SPEC_OOB_Events.md), implemented 2026-05-27, 47 tests passing). The telemetry PR adds it as a dependency:
+
+```toml
+# kicad-mcp/pyproject.toml additions
+[project]
+dependencies = [
+    "mcp-events>=0.1.0",
+    # ... existing deps ...
+]
+
+[tool.uv.sources]
+mcp-events = { path = "/Volumes/Files/claude/mcp-events", editable = true }
+```
+
+**Important: PyPI publication blocker.** kicad-mcp's CI uses `uv sync --frozen`, which fails on local-path-only dependencies. The telemetry PR cannot merge until `mcp-events 0.1.0` is published to PyPI. The `[tool.uv.sources]` block above is for local dev; CI resolves `mcp-events>=0.1.0` from PyPI. Coordinate the PyPI publication of `mcp-events` BEFORE opening the telemetry PR.
+
+Don't reinvent OOB inside the telemetry module — that would defeat the point of having it factored out.
+
+## Deferred from v1
+
+- `move_component` hook for surgical-fix attribution (`addressed_how='surgical_move'`)
+- `merge_clusters` / `split_cluster` action attribution
+- Explicit re-emission linking (`reemits_warning_id` column)
+- Cross-tool telemetry beyond placement (other tools can adopt the same primitives later)
+- Pre-computed aggregate caches (compute on demand for now; not a bottleneck at expected volumes)
+- Scheduled-review pattern (à la the dep-audit-automation) for weekly telemetry summaries
+
+## Testing strategy
+
+Tests live in `tests/test_telemetry.py`. No KiCad installation needed; no `suggest_placement` needed.
+
+### Synthetic fixtures
+
+Use an in-memory SQLite (`sqlite3.connect(":memory:")`) with the schema migrated, then drive sequences of fake `record_call` + `record_warning` + `attribute_pending_warnings` to exercise the attribution logic.
+
+### Test cases
+
+- **Attribution: hint matches affected_ref** → warning becomes `addressed`, `addressed_how='hint'`
+- **Attribution: hint matches unrelated ref** → warning stays `pending`
+- **Attribution: cluster_assignment whose value list overlaps affected_refs** → `cluster_assignment` match
+- **Attribution: fixed_position on affected ref** → `fixed_position` match
+- **Attribution: multiple potential matches** → first match (in hints/cluster_assignments/fixed_positions order) wins
+- **Cluster ID drift: fresh-state next call, ref still appears in cluster_assignments** → matches anyway via ref-only fallback
+- **Abandonment: 7-day age cutoff** → warning → `abandoned`
+- **Abandonment: fresh-state reset** → warning → `abandoned`
+- **Sweep idempotency** → running sweep twice doesn't double-mark
+- **Calibration table query** → counts and rates compute correctly for a known fixture; action_rate excludes pending; null when (addressed+abandoned)==0
+- **Confidence buckets** → 0.0 lands in bucket [0.0, 0.2); 0.2 lands in [0.2, 0.4); 1.0 lands in [0.8, 1.0]; missing confidence lands in "none"
+- **Convergence stats query** → iteration count and reemission count correct for a known fixture
+- **Re-emission detection at query time** → same warning_type + overlapping refs in later call counted as reemission; chain of three doesn't triple-count
+- **System events query** → returns events; flips `seen` flag on returned rows; `unseen_only=true` excludes already-seen
+- **Empty-result behavior** → all queries return `rows: []` on fresh DB; never error
+- **Migration on first read** → fresh DB triggers schema migration even when writes are disabled
+- **Empty-targets warning rejection** → `record_warning` with both arrays empty emits a soft_failure and does not insert
+- **Opt-out** → with `KICAD_MCP_NO_TELEMETRY=1`, write functions no-op; reads still work
+
+### Boundary tests (per project CLAUDE.md threshold-testing rule)
+
+- Abandonment age cutoff: warning at exactly 7 days → `abandoned`. 6.99 days → still `pending`. 7.01 days → `abandoned`.
+- Sweep interval: `record_call` invoked at last_sweep + 59 min → no sweep. At + 60 min exactly → sweep runs (`>=` semantics). At + 61 min → sweep runs.
+- Empty inputs (`inputs_summary` with all zero counts): no attribution attempts, no errors.
+- Empty-target warning at emit: `record_warning` with both arrays empty → rejected; no row inserted; soft_failure event emitted.
+- Confidence bucket edges: `confidence=0.2` lands in [0.2, 0.4) not [0.0, 0.2). `confidence=1.0` lands in [0.8, 1.0]. `confidence=None` lands in "none" bucket.
+- Action rate formula: with addressed=0, abandoned=0, pending=5 → action_rate is `null` not `0` (insufficient data marker).
+
+## Implementation notes
+
+### Module structure
+```
+src/kicad_mcp/utils/
+  telemetry.py            # write API, attribution, sweep
+  telemetry_schema.sql    # DDL, applied on first import
+src/kicad_mcp/tools/
+  telemetry_analyze.py    # the analyze_placement_telemetry tool
+tests/
+  test_telemetry.py
+```
+
+### Database path
+
+`~/.cache/kicad-mcp/telemetry.db` — same parent directory as `library_index.db`. Use `Path.home() / ".cache" / "kicad-mcp"` (with parents created if missing). Honor `XDG_CACHE_HOME` if set.
+
+### Concurrency
+
+Each kicad-mcp invocation is a per-session subprocess; the common case is single-writer. Multi-writer is possible if the user opens multiple Claude sessions in different terminals, each with kicad-mcp loaded. SQLite handles this with its default file locking — no extra coordination needed at this volume. Use WAL mode (`PRAGMA journal_mode=WAL`) for slightly better concurrent-read behavior; no other tuning required.
+
+Connection per call (cheap; the file is on local SSD). Don't hold long-lived connections across tool boundaries.
+
+### Tool registration
+
+`analyze_placement_telemetry` is registered as a **standalone** `@mcp.tool()` — not behind a router. The router pattern (`pcb`, `schematic`, etc.) is for domain-specific operations on KiCad files; telemetry is meta-operational and belongs at the top level alongside `search`, `audit_all`, etc.
+
+If kicad-mcp ever grows additional analyze tools (e.g., `analyze_external_interfaces` for the [external interface verification](../docs/) project), a future router might collapse them — but with one analyze tool today, standalone is right.
+
+### Performance expectations
+
+`attribute_pending_warnings` is `O(pending × inputs)`. At expected scale (≤100 pending warnings per schematic, ≤20 input items per call), this is microseconds. Don't optimize. If it becomes hot, add an index on `(schematic_hash, status)` — currently covered by the index on `(status, call_id)` plus the `calls.schematic_hash` join.
+
+Read queries scan the relevant table fully (no pre-aggregation). At expected scale (≤100k rows), SQLite GROUP BY is sub-millisecond. Pre-aggregation is a complexity smell at this scale; revisit only if a real query crosses 100 ms.
+
+### Tool-name vs router-operation handling
+
+Today's only writer is the standalone `suggest_schematic_placement` tool, so `tool_name="suggest_schematic_placement"` is unambiguous. If future tools live behind routers (e.g., `pcb(operation="suggest_placement", ...)`), the convention is:
+
+- `tool_name="pcb.suggest_placement"` — dotted form, router + operation
+- No separate `operation` column. The dotted form keeps queries simple (`WHERE tool_name LIKE 'pcb.%'` is enough).
+
+This is documented here rather than enforced at the schema level because no v1 consumer needs it. The first router-hosted writer is the one that has to commit to this convention.
+
+### Hashes
+
+### Hashes
+
+- `schematic_hash`: SHA-256 of the schematic file's bytes at call time, truncated to 16 hex chars (64 bits, comfortably collision-free at expected volumes).
+- `netlist_schema_hash`: SHA-256 of a sorted list of element/attribute names appearing in the kicad-cli netlist XML output, truncated to 8 hex chars. Used for correlation with the external-interface-verification project (see `project_external_interface_verification.md` in memory); if not computable, NULL is fine.
+
+### Tool-count cost
+
+Adds 1 tool (`analyze_placement_telemetry`). Current count is 13; this brings it to 14. The placement project will add `suggest_schematic_placement` and `apply_schematic_placement` separately. Stay well under the meaningful caps.
+
+### Test count
+
+Estimated 25-35 new tests. Current main: 651. After this PR: ~680-690.
+
+## Open questions (resolved during spec session — documented for posterity)
+
+- **Q**: One tool with `query=` discriminator vs. multiple analyze tools? **A**: One tool, dispatched by `query=` string. Keeps tool count down (context frugality) and the analysis surface is small enough that a single dispatch tool stays legible.
+- **Q**: Pre-aggregate calibration metrics or compute on demand? **A**: Compute on demand. SQLite handles GROUP BY on a few thousand rows in microseconds; pre-aggregation is a complexity smell at this scale.
+- **Q**: Daemon for backfill vs. inline at call boundary? **A**: Inline. See `synchronous-at-call-boundary` feedback memory.
+- **Q**: Server-side state cache scope — same SPEC or separate? **A**: Separate — the cached `PlacementState` lives in the placement project's scope, not the telemetry project's. They reference each other via `state_id` but don't share storage. Keep them decoupled.
+
+## Hand-off summary
+
+For an implementer picking this up cold:
+
+1. Read this SPEC end-to-end.
+2. **Verify the `mcp-events` package exists** at `/Volumes/Files/claude/mcp-events/` (per [`SPEC_OOB_Events.md`](SPEC_OOB_Events.md), authored 2026-05-27 alongside this SPEC). If not, this PR blocks on that one — do NOT inline-reimplement OOB.
+3. Add `mcp-events>=0.1.0` to `pyproject.toml` dependencies and the `[tool.uv.sources]` block pointing to the local path. Run `uv sync`.
+4. Read the design-philosophy feedback memories: `feedback_context_frugality.md`, `feedback_synchronous_at_call_boundary.md`, `feedback_prefer_packaging_over_vendoring.md`.
+5. Read `project_schematic_placement.md` for first-consumer context (placement itself is still in design, not implemented — your tests use synthetic fixtures, not real placement output).
+6. Implement against the v1 scope above. Defer everything in "Deferred from v1."
+7. The test suite is the acceptance criterion. All test cases in the Testing section must pass. Tests run in the existing `uv run pytest` invocation with no KiCad installation required.
+8. Update `MEMORY.md` and `project_feedback_infrastructure.md` to mark this as **implemented** when the PR merges; note any deviations from spec.
+
+The placement project will integrate against `record_call` / `record_cluster_decision` / `record_warning` / `attribute_pending_warnings` when it ships; for now those functions just need to exist with the right shapes.
+
+Tool count after this PR: 13 → 14 (`analyze_placement_telemetry` added). Test count target: 651 → ~680-690.

--- a/docs/SPEC_OOB_Events.md
+++ b/docs/SPEC_OOB_Events.md
@@ -1,0 +1,426 @@
+# SPEC — Out-of-Band Events Subsystem
+
+**Status:** Approved for implementation
+**Author:** Brian + Claude
+**Date:** 2026-05-27
+**Targets:** A shared `mcp_events.py` module vendored into MCP server projects; per-MCP integration patterns. First adopters: kicad-mcp and freecad-mcp.
+**Informed by:** Audit of freecad-mcp's existing error handling (`/Volumes/Files/claude/freecad-mcp/`, 2026-05-27).
+
+## Motivation
+
+A coherent channel for events that don't belong in a tool's main response but also can't be silently swallowed — errors that the caller LLM should see, warnings that surface a degradation, info-level signals that need to survive between calls.
+
+The freecad-mcp audit found three patterns of out-of-band handling that need a unified channel:
+
+1. **Silent-pass sites.** `except Exception: pass` blocks that discard real failures — file `base.py:178-179` (`save_before_risky_op` silently fails), `spreadsheet_ops.py:348/361/376` (multiple fallback paths silently swallow errors), `base.py:291-294` (per-geometry-element failures).
+2. **Visibility loss to the LLM.** `boolean_ops.py:36` writes a complexity warning to `FreeCAD.Console.PrintWarning()` — invisible to the calling LLM. The warning is constructed and immediately discarded from the MCP channel.
+3. **Inconsistent error envelopes.** Some tools return `{"result": "Error doing X: e"}` (error embedded in success envelope as string); others return `{"error": "...", "error_id": "..."}` (structured dict). The LLM can't reliably parse status across the tool surface.
+
+Same patterns will appear in kicad-mcp as it grows — telemetry write failures (the immediate need from the [Feedback Infrastructure SPEC](SPEC_Feedback_Infrastructure.md)), schema-drift warnings, stale jlcparts-snapshot warnings (from the upcoming component-intelligence work), and similar.
+
+Without a coherent channel:
+- Errors get swallowed → never fixed
+- Warnings buried where the LLM can't see → never acted on
+- Inconsistent envelopes → LLM can't reliably parse status
+
+This SPEC defines that channel.
+
+## Non-goals
+
+- **Not a general-purpose logging framework.** Use Python's `logging` for debug/info messages that don't need to surface to the LLM. This subsystem is for events that the *calling LLM* should see or that need to *persist between calls*.
+- **Not a metrics or tracing platform.** No counters, no timers, no distributed-trace IDs.
+- **Not a persistence layer.** The shared module accumulates events in-process and flushes them to the response envelope. Persistence (durable storage of events between sessions) is each MCP's local concern, layered on top.
+- **Not a published PyPI release yet** (until ~0.1.0 stabilizes). But it IS a proper Python package from day one — installed via editable path-dependency in the workspace; published to PyPI once stable. **Copy-paste vendoring was considered and rejected**: in a single-maintainer multi-repo workspace, copy-paste drift is a real, predictable failure mode that proper packaging eliminates. See the "Distribution" section below.
+
+## Design principles
+
+- **Synchronous at call boundary.** Event accumulation happens inline during a tool call. No daemon, no background thread, no async write queue. See `feedback_synchronous_at_call_boundary.md` in memory.
+- **Context-frugal.** The default response envelope omits `events` entirely when nothing notable happened. Warnings and errors are included; info-level events are accumulated but not surfaced by default (caller can opt in). See `feedback_context_frugality.md`.
+- **Never silent.** Every recorded event has a path to surface. If no event context is active when something is recorded, the event falls back to stderr (visible at process level) rather than being dropped.
+- **Same API surface across MCPs.** Copying the file should "just work." No project-specific configuration, no class hierarchies to subclass.
+
+## Architecture
+
+### The shared module: `mcp-events` (Python package, module name `mcp_events`)
+
+A small Python package, roughly 150-200 lines of code plus tests. No external dependencies beyond the Python standard library. Lives in its own repo / directory so both consumers depend on a single source of truth.
+
+### Location
+
+```
+/Volumes/Files/claude/
+├── kicad-mcp/         ← consumer; depends on mcp-events
+├── freecad-mcp/       ← consumer; depends on mcp-events
+└── mcp-events/        ← canonical package (separate directory, eventually its own git repo)
+    ├── pyproject.toml
+    ├── src/mcp_events/
+    │   ├── __init__.py    # the public API
+    │   └── _impl.py       # implementation if it grows; v1 can be one file
+    └── tests/
+        └── test_mcp_events.py
+```
+
+Eventual GitHub home: `blwfish/mcp-events` (not in scope for this SPEC — local dir works for v1).
+
+### Consumer integration
+
+Each consuming MCP adds `mcp-events` as a normal Python dependency. In dev, the path source overrides PyPI:
+
+```toml
+# kicad-mcp/pyproject.toml (and freecad-mcp/pyproject.toml, identical pattern)
+[project]
+dependencies = [
+    "mcp-events>=0.1.0",   # PyPI version for downstream users
+    # ... other deps ...
+]
+
+[tool.uv.sources]
+mcp-events = { path = "../mcp-events", editable = true }
+```
+
+The `[tool.uv.sources]` block tells uv (in dev) to install from the local path rather than PyPI. Downstream users installing kicad-mcp per `AGENT-INSTALL.md` run `uv sync` against the cloned repo; their sync resolves `mcp-events>=0.1.0` from PyPI (the path source resolution applies only when the local path exists, which it does for Brian and not for them). Note: kicad-mcp itself is NOT distributed via PyPI (per [`feedback_ai_first_distribution.md`](../../../../Users/blw/.claude/projects/-Volumes-Files-claude-kicad-mcp/memory/feedback_ai_first_distribution.md)) — it uses `AGENT-INSTALL.md` as the distribution model. `mcp-events` is the exception because it's a library dependency that package managers must resolve.
+
+Editable install means a fix in `/Volumes/Files/claude/mcp-events/src/mcp_events/__init__.py` is immediately visible to both consumers. No copy, no sync, no drift.
+
+### Versioning policy
+
+- Aggressive bumping while early: 0.1.0 → 0.1.1 → 0.1.2 as the API settles
+- Consumers pin to `>=0.1.0,<0.2.0` (or similar tight range) until 0.1 stabilizes
+- 0.2 onward = stable API; consumers can use `>=0.2.0` and benefit from patches without version pinning
+- 1.0 once it's been stable for ~6 months and there's no foreseeable need for breaking changes
+
+### Publication to PyPI
+
+Publish `mcp-events` to PyPI BEFORE merging any kicad-mcp PR that depends on it. kicad-mcp's CI uses `uv sync --frozen` and the lockfile must resolve `mcp-events>=0.1.0` from PyPI — a local-path-only resolution would fail in CI and fail for downstream users following `AGENT-INSTALL.md`. (Note: kicad-mcp itself is NOT published to PyPI — `AGENT-INSTALL.md` is its distribution model. `mcp-events` is the exception because it's a runtime library dependency.)
+
+### Public API
+
+```python
+# Event data
+@dataclass
+class Event:
+    severity: str       # "info" | "warn" | "error"
+    code: str           # short stable identifier, e.g. "stale_cache_fallback"
+    message: str        # human-readable
+    context: dict       # optional structured data; default {}
+
+# The accumulator — one per tool call
+class EventAccumulator:
+    def emit(self, severity: str, code: str, message: str, context: dict | None = None) -> None: ...
+    def info(self, code: str, message: str, context: dict | None = None) -> None: ...
+    def warn(self, code: str, message: str, context: dict | None = None) -> None: ...
+    def error(self, code: str, message: str, context: dict | None = None) -> None: ...
+    def soft_failure(self, code: str, message: str, context: dict | None = None) -> None:
+        # Convenience: alias for warn() with the soft-failure semantic.
+        # Use this at sites that were previously `except Exception: pass`.
+        ...
+    def has_any(self, min_severity: str = "info") -> bool: ...
+    def to_envelope(self, min_severity: str = "warn") -> list[dict]:
+        # Render as the JSON-serializable envelope shape.
+        # Default threshold "warn" excludes info events; pass min_severity="info"
+        # to include them.
+        ...
+    @property
+    def events(self) -> list[Event]:
+        # Read-only access to all collected events (any severity).
+        # For local persistence layers to iterate.
+        ...
+
+# Context management
+class event_context:
+    """Context manager establishing an EventAccumulator for the current call.
+    Use at the top of each tool:
+
+        @mcp.tool()
+        def my_tool(args):
+            with event_context() as events:
+                # ... tool logic ...
+                response = {"status": "ok", "data": ...}
+                if events.has_any("warn"):
+                    response["events"] = events.to_envelope()
+                return response
+    """
+    def __enter__(self) -> EventAccumulator: ...
+    def __exit__(self, *exc) -> bool: ...
+
+def get_current() -> EventAccumulator | None:
+    """Returns the active EventAccumulator if inside an event_context, else None.
+    Used by helper functions that don't receive the accumulator directly."""
+    ...
+
+# Top-level shortcuts (find the current accumulator via ContextVar)
+def soft_failure(code: str, message: str, context: dict | None = None) -> None: ...
+def emit_event(severity: str, code: str, message: str, context: dict | None = None) -> None: ...
+
+# Decorator convenience
+def with_events(min_severity: str = "warn"):
+    """Decorator that wraps a tool function with an event_context and auto-
+    augments the response with the envelope.
+
+        @with_events()
+        @mcp.tool()
+        def my_tool(args):
+            soft_failure("foo", "bar")  # automatically captured
+            return {"status": "ok", "data": ...}
+    """
+    ...
+```
+
+### Internals (informational)
+
+The current accumulator is tracked via a Python `ContextVar`. This means:
+- Each tool call sees its own accumulator
+- Async tools that yield don't lose context (ContextVar propagates correctly under asyncio)
+- Nested calls (tool calls helper that calls another helper) all share the outer accumulator
+
+The fallback when no context is active: write to stderr in a structured prefix (`[mcp_events] {severity}: {code}: {message}`). This means events are never lost, even if a tool forgets to use `event_context`. The stderr output isn't pretty but it's visible at the process level.
+
+### Response envelope contract
+
+Every tool's response follows this envelope (or uses `with_events` to construct it automatically):
+
+```json
+{
+    "status": "ok",                       // required: "ok" | "error"
+    "data": {...},                        // optional, tool-specific success payload
+    "error": "...",                       // required if status=="error"; optional otherwise
+    "events": [                           // optional; present when warn/error events accumulated
+        {
+            "level": "warn",              // "info" | "warn" | "error"
+            "code": "stale_cache_fallback",  // short identifier; for programmatic handling
+            "message": "Using cached jlcparts snapshot from 5 days ago",  // human-readable
+            "context": {"snapshot_age_days": 5, "source_url": "..."}  // optional structured data
+        }
+    ]
+}
+```
+
+Rules:
+- `events` is omitted entirely when empty. Don't include `"events": []`.
+- `events` is always an array, even with one element.
+- Each event must have `level`, `code`, `message`. `context` is optional.
+- `code` should be short, lowercase, snake_case, and stable across releases (LLMs may pattern-match on it).
+- `message` is for humans; can change without breaking anything.
+- Tools at `status: "error"` still include events that accumulated before the error occurred.
+
+### Severity policy
+
+| Severity | Surfaced in `events` envelope by default | Typical persistence (per-MCP) | Example |
+|---|---|---|---|
+| `info` | No (collected but excluded from envelope unless caller lowers threshold) | Yes | "Schema migration applied", "Sweep completed: 12 warnings abandoned" |
+| `warn` | Yes | Yes | "Stale cache used as fallback", "kicad-cli netlist schema hash changed", "Soft failure: spreadsheet alias query fell back" |
+| `error` | Yes (always — including when otherwise hidden by threshold) | Yes | "Telemetry write failed", "FreeCAD pre-crash save failed" |
+
+The asymmetry is intentional: errors are unconditional (the LLM must see them); info is opt-in (most callers don't want noise). Warn is the default-visible middle ground.
+
+## Per-MCP integration
+
+The shared module handles in-call accumulation. Each project decides what to do with the accumulated events at the end of each call.
+
+### kicad-mcp integration
+
+- **Dependency**: `mcp-events>=0.1.0` in `pyproject.toml`; `[tool.uv.sources]` points to `../mcp-events` for dev.
+- **Import**: `from mcp_events import event_context, soft_failure, emit_event, with_events`.
+- **Persistence**: events with severity `warn`/`error` (and optionally `info`) are written to the `system_events` table in the telemetry DB. See `SPEC_Feedback_Infrastructure.md`. The persistence layer iterates `accumulator.events` at end of call and inserts each.
+- **Migration target**: every tool should be wrapped with `with_events()`. Start with the heaviest call sites: `suggest_schematic_placement` (when it ships), `run_drc_check`, `analyze_placement_telemetry`. Roll out to the rest as touched.
+- **The `analyze_placement_telemetry` system_events query** is the durable view of accumulated events (see the Feedback Infrastructure SPEC).
+
+### freecad-mcp integration
+
+- **Dependency**: same — `mcp-events>=0.1.0` in `pyproject.toml`, path source for dev.
+- **Persistence**: freecad-mcp already has fragmented infrastructure (`freecad_debug.py`, `freecad_crash_report.py`, `_last_tracebacks`). Recommendation for v1: don't unify those yet. Just add a write-through to `freecad_debug.py`'s existing jsonl file for `warn`+`error` events.
+- **Migration target — known silent-pass sites to retrofit (from the audit)**:
+  - `base.py:178-179` (`save_before_risky_op`): replace `except Exception: pass` with `except Exception as e: soft_failure("save_before_risky_op_failed", str(e), {"path": ...})`
+  - `boolean_ops.py:34-36` (complexity warning): replace `FreeCAD.Console.PrintWarning(msg)` with `emit_event("warn", "boolean_op_complex", msg, {"face_count": ...})`
+  - `spreadsheet_ops.py:348-349, 361-362, 376-377` (XML/dimension/alias fallback): replace each silent `pass` with `soft_failure(...)` plus the existing fallback behavior
+  - `base.py:291-294` (per-geometry-element failures): same pattern — capture each one as `info`-severity at minimum so they're not invisible
+- **Envelope cleanup**: tools currently inconsistent in error shape. Standardize on the envelope above. Likely a separate PR; not blocking for OOB adoption.
+
+### Future MCPs
+
+Any new MCP adds `mcp-events>=0.1.0` (or whatever current version) to `pyproject.toml` and imports normally. The package is project-agnostic — no kicad-mcp-specific or freecad-mcp-specific code in it.
+
+## Distribution strategy
+
+Standard Python package, distributed via PyPI when ready, consumed via editable path-dependency in the workspace until then. **Copy-paste vendoring is explicitly rejected** for this project because the failure mode (drift between two repos maintained by the same person) is predictable and avoidable.
+
+### Why a package, not copy-paste
+
+The argument for copy-paste vendoring ("API will change as both adopters validate it") applies when two independent teams might disagree on the abstraction. That's not our situation: one maintainer (Brian) owns both consumers and the workspace is the source of truth. Drift between copies is just a foot-gun with no upside in this configuration.
+
+The package approach addresses the "API stability" concern via standard mechanisms — version-pinned dependencies in the consumers, aggressive bumping while early. Same outcome (controlled rollout of changes) with stronger guarantees (impossible to forget to sync).
+
+### What goes in `mcp_events` (the package) vs. per-MCP
+
+In `mcp_events` (shared, lives in `mcp-events/`):
+- `Event`, `EventAccumulator`
+- `event_context`, `get_current`
+- Top-level `soft_failure`, `emit_event`
+- `with_events` decorator
+- Test suite (one canonical, runs in the `mcp-events` repo)
+
+Per-MCP (local):
+- Persistence (system_events table, jsonl file, whatever each project does)
+- Hooks that fire on each event (if used)
+- The actual `@mcp.tool()` wrapping
+- Project-specific codes (`stale_cache_fallback` is kicad-mcp's code for jlcparts; freecad-mcp's equivalent has a different code)
+
+### Drift detection
+
+There's nothing to drift between — both consumers import from the same installed package. The only drift risk is between local `[tool.uv.sources]` path-dependency and the version pinned for downstream users. Run `uv sync` periodically to confirm the path version satisfies the pinned constraint.
+
+## Migration guidance
+
+For retrofitting existing silent-pass sites:
+
+```python
+# Before
+try:
+    risky_thing()
+except Exception:
+    pass
+
+# After
+try:
+    risky_thing()
+except Exception as e:
+    soft_failure("risky_thing_failed", str(e), {"context": ...})
+    # Continue with fallback behavior here, unchanged.
+```
+
+For surfacing previously-buried warnings:
+
+```python
+# Before
+FreeCAD.Console.PrintWarning(f"Complex geometry: {n} faces")
+# Caller LLM never sees this.
+
+# After
+emit_event("warn", "complex_geometry", f"Complex geometry: {n} faces", {"face_count": n})
+# Appears in the tool response's events field.
+```
+
+For wrapping a tool:
+
+```python
+# Before
+@mcp.tool()
+def my_tool(args):
+    # ... work ...
+    return {"status": "ok", "data": result}
+
+# After (option 1: decorator)
+@with_events()
+@mcp.tool()
+def my_tool(args):
+    # Now any soft_failure / emit_event inside this call surfaces automatically.
+    return {"status": "ok", "data": result}
+
+# After (option 2: explicit)
+@mcp.tool()
+def my_tool(args):
+    with event_context() as events:
+        response = {"status": "ok", "data": ...}
+        if events.has_any("warn"):
+            response["events"] = events.to_envelope()
+        return response
+```
+
+Either works; decorator is less verbose and harder to forget. Use the decorator unless there's a specific reason not to (e.g., the tool needs to inspect events during processing).
+
+## Testing strategy
+
+Tests live ONCE, in the `mcp-events` package itself (`mcp-events/tests/test_mcp_events.py`). Consumers don't re-test the shared module — they just trust it because the package is versioned.
+
+### Test cases (canonical suite)
+
+- **Basic accumulation**: emit info/warn/error → `events` contains all three; `to_envelope("warn")` excludes info
+- **`has_any` thresholds**: `has_any("warn")` returns True with only warn, False with only info
+- **Context isolation**: nested `event_context` blocks each get their own accumulator (or: confirm they share, depending on design choice — see Open Questions)
+- **`soft_failure` shortcut**: equivalent to `warn` with the same arguments
+- **Decorator wrapping**: tool wrapped with `@with_events()` automatically includes `events` field when warns occur
+- **Decorator omits events when empty**: no warn/error → `events` field absent from response
+- **Stderr fallback**: `soft_failure` called outside any context → writes to stderr (capture with capsys), does not raise
+- **Async-safety**: under `asyncio.run`, an async tool with `with event_context()` correctly isolates events per coroutine
+- **Envelope shape**: every emitted event renders to the documented JSON shape
+- **Boundary**: empty string for `code` or `message` — rejected? accepted? Spec choice: accepted (sometimes you have a vague error and want at least a record); but `code=""` and `message=""` together logs a stderr meta-warning
+
+### Boundary tests
+
+- Threshold: `to_envelope("warn")` includes a warn-level event; `to_envelope("error")` excludes it
+- `to_envelope()` default is `"warn"`, not `"info"` (check the default)
+- `events` array is always a list, never None; absent when no events meet threshold
+- `Event.context` defaults to `{}`, not `None`
+
+## v1 scope
+
+Ship the `mcp-events` package:
+- Create the directory structure at `/Volumes/Files/claude/mcp-events/`
+- `pyproject.toml` with `name = "mcp-events"`, `version = "0.1.0"`, no runtime dependencies
+- `src/mcp_events/__init__.py` exporting the public API: `Event`, `EventAccumulator`, `event_context`, `soft_failure`, `emit_event`, `with_events`, `get_current`
+- ContextVar-based current-accumulator tracking
+- Stderr fallback for events emitted outside any context
+- `tests/test_mcp_events.py` with the canonical test suite
+- A README explaining the API and the distribution model
+- Initialize a git repo in the directory (target: eventual push to `blwfish/mcp-events`)
+
+Concretely for kicad-mcp (same PR or follow-up):
+- Add `mcp-events>=0.1.0` to `pyproject.toml` dependencies
+- Add `[tool.uv.sources] mcp-events = { path = "../mcp-events", editable = true }` for dev
+- Run `uv sync` to update `uv.lock`
+- Wire `@with_events()` into `analyze_placement_telemetry` when that tool exists (it doesn't yet; this can wait for the telemetry implementation PR)
+
+Concretely for freecad-mcp (follow-up PR, separate session):
+- Same dependency + path-source setup
+- Retrofit the named silent-pass sites
+- Standardize envelope shape across tools
+
+PyPI publication: ship `mcp-events 0.1.0` to PyPI before merging any kicad-mcp PR that adds `mcp-events` as a dependency (so CI's `uv sync --frozen` resolves it, and so users following `AGENT-INSTALL.md` can `uv sync` successfully). kicad-mcp itself stays off PyPI per [`feedback_ai_first_distribution.md`](../../../../Users/blw/.claude/projects/-Volumes-Files-claude-kicad-mcp/memory/feedback_ai_first_distribution.md).
+
+## Deferred from v1
+
+- **Hooks/observers** (`accumulator.add_hook(callable)`). Useful for tee-ing events to persistence in real time. Not needed in v1 because iterating `accumulator.events` at end of call is simple enough.
+- **Tag/category metadata** beyond `code`. If we want hierarchical categorization later, add it.
+- **Async-safe stderr fallback**. v1 uses `print(file=sys.stderr)` which is fine in practice. If we hit lock contention under heavy async, switch to a queue.
+- **Pip-package promotion.** Revisit after 6+ months of use across kicad-mcp and freecad-mcp.
+- **Cross-process event aggregation** (one session's events visible in another). Out of scope; per-MCP persistence layers can do this themselves if needed.
+- **Structured `context` schemas.** v1 treats `context` as opaque JSON. v2 could define schemas per `code`.
+- **Drift-detection tooling** for vendored copies. Manual sync is fine for v1; automate if drift becomes a recurring problem.
+
+## Open questions (decisions to make at implementation time)
+
+1. **Nested `event_context` semantics.** If a tool wrapped with `@with_events()` calls a helper that also uses `with event_context()`, do the helper's events accumulate into the outer context, or are they isolated? **Proposal: nested contexts accumulate into the outer** (so deeply-nested helpers don't lose their events). The inner context is a no-op if an outer is active. Confirm at implementation.
+2. **Event ordering.** Are events emitted in chronological order in the envelope? **Proposal: yes**, list order = emission order. Trivial to maintain.
+3. **Decorator + sync-vs-async tools.** FastMCP supports both. `@with_events()` needs to work on both. **Proposal: detect at decoration time** via `asyncio.iscoroutinefunction`; produce a sync or async wrapper accordingly.
+4. **`Event` JSON shape stability.** The shape documented above is the wire contract. Adding fields is allowed; renaming/removing is breaking. **Proposal: document this in the file header.**
+
+## Hand-off summary
+
+For an implementer picking this up cold:
+
+1. Read this SPEC end-to-end.
+2. Read the two feedback memories (`feedback_context_frugality.md`, `feedback_synchronous_at_call_boundary.md`) for design philosophy.
+3. **Create the `mcp-events` package** at `/Volumes/Files/claude/mcp-events/`:
+   - `pyproject.toml` with hatchling or uv-build backend; package name `mcp-events`; module name `mcp_events`; version `0.1.0`; no runtime deps; Python `>=3.11`
+   - `src/mcp_events/__init__.py` with the full public API per this SPEC
+   - `tests/test_mcp_events.py` with the canonical test suite
+   - `README.md` explaining what the package is, the API, and the distribution model
+   - `git init`, initial commit; ready to push to `blwfish/mcp-events` when the GitHub repo is created (out of scope here)
+4. **Wire into kicad-mcp** (same PR or a follow-up, your call):
+   - Add `mcp-events>=0.1.0` to `pyproject.toml` dependencies
+   - Add the `[tool.uv.sources]` block pointing to the local path with `editable = true`
+   - Run `uv sync` to update the lockfile
+   - Do NOT wire `@with_events()` into any specific tool yet — telemetry is the first consumer and it doesn't exist yet
+5. Do NOT touch freecad-mcp in this PR. That's a follow-up after the canonical package lands.
+6. Update `MEMORY.md` and `project_oob_events.md` to mark this implemented when the PR merges; note any deviations.
+
+Tool count after this PR: no change (it's a dependency, not a new tool). Test count target in `mcp-events` repo: ~15-20 tests. kicad-mcp's test count is unchanged.
+
+Implementation order beyond this SPEC:
+
+```
+1. OOB Events Subsystem        ← this SPEC
+2. Feedback Infrastructure     ← SPEC_Feedback_Infrastructure.md (ready)
+3. Component Intelligence      ← memory file's spec needs revision based on jlcparts findings
+4. Schematic Auto-Placement    ← spec session ongoing; not started
+```

--- a/docs/SPEC_Schematic_Placement.md
+++ b/docs/SPEC_Schematic_Placement.md
@@ -1,0 +1,478 @@
+# SPEC — Schematic Auto-Placement
+
+**Status:** Approved for implementation (pending the ground-truth fixture set, see Open Questions)
+**Author:** Brian + Claude
+**Date:** 2026-05-27
+**Target:** Topology-aware automatic placement of components in a KiCad schematic. Produces a structured state object that a calling LLM iterates against.
+**Trigger:** [GitHub issue #11](https://github.com/blwfish/kicad-mcp/issues/11) — external user asked whether AI-generated schematics always need manual reorganization. Baseline today: yes; this SPEC's goal is "first draft is usable in 70-85% of cases."
+
+## Motivation
+
+AI-generated schematics today have every coordinate supplied by the LLM's imagination — no spatial awareness, no signal-flow convention, no component-size awareness, no collision detection. The result is unusable without manual reorganization for anything more than a handful of components. Issue #11 surfaced this as a real pain point for external users.
+
+The quick wins from the same session (grid snap, `add_wire_between_pins`) addressed labels and wire elbows but did not address placement itself. This SPEC defines the placement tool.
+
+### Quality target
+
+**70-85% of small-to-medium AI-generated schematics produce a layout that the calling LLM can finalize via a few iterations and minor tweaks**, vs. today's baseline of "essentially 0%" usable without manual reorganization. The estimate is structural — until ground-truth fixtures exist, we don't have measurement.
+
+We're not competing with Altium's auto-placer or a human designer. We're competing with "raw LLM coordinates."
+
+## Non-goals
+
+- **Not human-grade layout.** The 70-85% bar is "good first draft," not "polished final."
+- **Not for non-LLM consumers.** The iteration loop assumes Claude (or another AI assistant) is the caller. Manual usage works but isn't optimized for.
+- **Not autorouting** — that's `autoroute_pcb`, a separate concern.
+- **Not PCB placement** — see [the existing `suggest_placement` PCB tool](../src/kicad_mcp/tools/pcb_planning.py). Schematic placement is a distinct problem (more semantic, less geometric) and diverges intentionally; see "Divergence from PCB placement" below.
+- **Not hierarchical sheets in v1.** Flat schematics only. Multi-sheet support deferred (see Deferred section).
+- **Not wire re-routing.** Placement output is coordinates only; existing wires aren't auto-reflowed. See "Precondition: un-wired or accept-stale-wires" below.
+
+## Dependencies
+
+This SPEC depends on:
+
+- **`mcp-events` package** (per [`SPEC_OOB_Events.md`](SPEC_OOB_Events.md), implemented 2026-05-27) — for surfacing warnings (bus-bridge detection, low-confidence labels, etc.)
+- **Feedback Infrastructure** (per [`SPEC_Feedback_Infrastructure.md`](SPEC_Feedback_Infrastructure.md)) — for telemetry-driven calibration of the algorithm
+- **Component Intelligence (LCSC)** (per [`SPEC_Component_Intelligence_LCSC.md`](SPEC_Component_Intelligence_LCSC.md)) — *optional* but strongly enhances Layer 3 (resolved-part labeling). The tool degrades gracefully when no LCSC data is assigned.
+- **Existing kicad-cli netlist export** with `pintype` extraction (already happens silently in `extract_netlist_via_cli`; this SPEC formalizes its use)
+- **Existing `pattern_recognition.py`** — but demoted from cluster-driver to labeling-layer (see Layer 2 below)
+
+**Implementation order**: all three named SPECs above must land first. This is the capstone.
+
+## Design principles
+
+1. **Layered understanding, with each layer optional.** Topology is the foundation; pattern recognition, resolved-part data, and caller hints layer in additional richness without being required. Quality scales with available information.
+2. **Calibration over coverage.** The algorithm should be *honestly uncertain* when uncertain. A confidently-wrong label is worse than an honestly-uncertain one because Claude trusts the label.
+3. **State machine, not magic function.** The tool returns a structured `PlacementState`. The calling LLM iterates against this state via overrides, hints, frozen regions. Each call is a state-machine transition, not a one-shot RPC.
+4. **Context-frugal.** Default `verbosity="minimal"`. Stateful (server-cached) mode for iteration on context-constrained callers. See `feedback_context_frugality.md`.
+5. **Synchronous at call boundary.** All telemetry recording and attribution is inline; no daemons. See `feedback_synchronous_at_call_boundary.md`.
+
+## The 4-layer architecture
+
+Each layer adds semantic richness when its inputs are present; the next layer down is fallback.
+
+### Layer 1 — Topology (always present)
+
+Community-detection clustering on the signal-net graph.
+
+- **Graph construction**: nodes are components; edges are signal-net connections (power nets filtered via `pintype in {"power_in", "power_out"}` exclusion). Edges are weighted by net multiplicity (a component pair sharing multiple non-power nets has higher weight).
+- **Clustering**: Louvain community detection (modularity maximization). Produces a partition of components into clusters with no labels yet.
+- **Output**: `cluster_id` per component; `members` and `louvain_modularity` per cluster.
+
+Failure modes (and how the algorithm reports them):
+- **Bus bridges** (SPI/I2C connecting two functional blocks heavily enough to merge them) → emit `bus_bridge_suspected` warning when two pre-merge sub-clusters had high internal modularity
+- **Singletons** (components with no signal edges after power filtering — TVS diodes, fuses, ferrite beads) → emit `singleton_orphan` warning; placed but unclustered
+- **Sparse clusters** (3 or fewer members) → emit `sparse_cluster` info-level event; may indicate misgrouping
+
+### Layer 2 — Pattern recognition labeling (when applicable)
+
+Uses the existing `pattern_recognition.py` module, but demoted to a *labeling* role with confidence scores.
+
+For each cluster from Layer 1:
+- Run `identify_microcontrollers`, `identify_power_supplies`, `identify_amplifiers`, etc. on the cluster's components
+- If exactly one identifier matches with high confidence → label the cluster (e.g., `"mcu"`, `"ldo"`, `"op_amp_circuit"`) with `label_source="pattern_recognition"` and `label_confidence ∈ [0.5, 1.0]`
+- If multiple identifiers match (collision) → emit `pattern_recognition_collision` warning; label with lower confidence
+- If none match → label = `"unclassified"`, `label_confidence=0.0`, `label_source="topology_only"`
+
+**Coverage**: the 2026-05-27 audit found `pattern_recognition.py` classifies ~33% of components on a representative IoT fixture. The known false-positives (`MCP\d+` collision, RC-filter false positive on I²C pull-ups) must be fixed before this layer ships — but expanding coverage is NOT in scope. Calibrated honesty (33% covered, 67% honestly unclassified) is more valuable than expanded coverage with the existing bugs.
+
+### Layer 3 — Resolved-part labeling (when LCSC data present)
+
+When components have LCSC part numbers assigned (via the Component Intelligence tool), the supplier-provided category dominates pattern_recognition.
+
+- For each component with an LCSC `Value` and `LCSC` property: look up the part in the jlcparts SQLite, read its category (`firstSortName`, `secondSortName`)
+- Map category → cluster label (e.g., `"Power Management (PMIC) > Voltage Regulators - Linear, Low Drop Out (LDO)"` → `"ldo"`)
+- When a cluster's anchor component has a confident resolved-part label, that label wins over pattern_recognition's guess
+- `label_source="resolved_part"`, `label_confidence ∈ [0.8, 1.0]` (high because we *asked* the supplier)
+
+This is the highest-quality labeling layer when data is available, but doesn't require all components to be resolved — it dominates per-cluster based on what's known.
+
+### Layer 4 — Caller hints (override)
+
+The calling LLM can pass explicit semantic information:
+
+```python
+hints = {
+    "U1": "mcu",                # cluster anchor type
+    "C3": "decoupling_for(U1)", # role within cluster
+    "J1": "edge_connector",     # placement convention hint
+}
+```
+
+Hints override all lower layers for the referenced components. `label_source="caller_hint"`, `label_confidence=1.0` (trust the caller).
+
+## The 3-phase algorithm
+
+Layered understanding feeds a 3-phase layout algorithm.
+
+### Phase 1 — Cluster
+
+Run Layer 1 (topology) → Layer 2 (labels) → Layer 3 (resolved-part) → Layer 4 (hints, applied first if present). Output: cluster assignments + labels + confidence per cluster.
+
+### Phase 2 — Rank (signal flow → column tiers)
+
+Directed BFS on the signal-net graph using `pintype`:
+
+- Build directed edges: pin `output`/`power_out` → pin `input`/`power_in` on the same net (within a non-power net)
+- For `bidirectional` pins: add soft edges in both directions (weighted lower than directed edges)
+- For `passive` pins: propagate direction transitively (a resistor between MCU output and LED input forwards the direction)
+- Identify source nodes: clusters whose anchor component has no signal inputs (connectors, regulators, oscillators)
+- BFS from source nodes; assign each cluster a tier (column index, 0 = leftmost = sources)
+- Within a tier, secondary sort by cluster size (larger clusters more central)
+
+Output: tier per cluster.
+
+Failure modes:
+- **Cycle in the directed graph**: emit `signal_flow_cycle` warning; break the cycle at the lowest-confidence edge
+- **No clear source node**: emit `no_signal_source` warning; pick the cluster with the most outgoing edges as origin
+
+### Phase 3 — Pack (coordinates + conventions)
+
+Within each tier, lay components out left-to-right or top-to-bottom:
+
+- **Order within tier**: barycentric heuristic (sort components by average position of their connected components in adjacent tiers). Reduces crossings.
+- **Coordinate assignment**: `x_mm = tier * column_pitch_mm`, `y_mm = row_index * row_pitch_mm`. Defaults: `column_pitch_mm=25.4`, `row_pitch_mm=12.7` (1 inch / 0.5 inch on the KiCad grid).
+- **Cluster bounding box**: each cluster gets a bbox; sub-conventions place components within the bbox.
+
+Convention rules applied within each cluster (when label permits):
+
+| Cluster label | Convention |
+|---|---|
+| Any IC with decap (cap connected only to power) | Decap below IC, snapped to grid |
+| Regulator | VIN-side passives left; VOUT-side passives right |
+| MCU | Crystal close to OSC pins (if pin functions identifiable); power pins ungrouped from signal pins |
+| Op-amp circuit | Inverting input on top, non-inverting on bottom |
+| Connector (anchor only) | Push to left or right edge of board (input vs output direction) |
+
+The convention set is **explicitly v1-minimal**. Failure to apply a convention is not an error; it emits an info-level event so we can see (via telemetry) which conventions are most often skipped and why.
+
+Output: `x_mm`, `y_mm`, `rotation`, `mirror_x` per component.
+
+## `PlacementState` schema
+
+The structured output that Claude reads. Same shape returned by every call.
+
+```python
+{
+    "schematic_path": str,
+    "algorithm_version": str,
+    "computed_at": iso8601_str,
+
+    "components": {
+        "<ref>": {
+            "x_mm": float,
+            "y_mm": float,
+            "rotation": 0 | 90 | 180 | 270,
+            "mirror_x": bool,
+            "cluster_id": str,
+            "fixed_by": "caller" | "tool" | None,
+        },
+        # ...
+    },
+
+    "clusters": {
+        "<cluster_id>": {
+            "members": [ref, ...],
+            "anchor": ref | None,
+            "label": "mcu" | "ldo" | "i2c_bus" | "unclassified" | ...,
+            "label_confidence": 0.0 - 1.0,
+            "label_source": "pattern_recognition" | "resolved_part" |
+                            "caller_hint" | "topology_only",
+            "tier": int | None,
+            "bbox_mm": {"x": float, "y": float, "w": float, "h": float},
+        },
+        # ...
+    },
+
+    "tiers": { tier_index: [cluster_id, ...] },
+
+    "events": [Event, ...],  # surfaced via mcp-events (warnings, info, errors)
+
+    "inputs_honored": {
+        "hints_applied": [ref, ...],
+        "fixed_positions": [ref, ...],
+        "redo_scope": [cluster_id, ...] | None,
+    },
+
+    "state_id": str,  # opaque ID for stateful iteration mode
+}
+```
+
+### Verbosity modes
+
+- `verbosity="minimal"` (default): coordinates + cluster_id + cluster anchor + label + label_confidence. ~50 bytes/component, ~30 bytes/cluster. A 200-component schematic returns ~12 KB.
+- `verbosity="full"`: everything — provenance, decisions log, all warnings detail, bounding boxes, algorithm metadata. ~5-10× larger.
+
+Sparse encoding: omit fields equal to defaults (`rotation: 0`, `mirror_x: false`, `fixed_by: None`, etc.).
+
+### Stateful vs stateless modes
+
+**Stateless** (caller has runway): caller passes full state in via `state` param; tool returns full state. Auditable, self-contained.
+
+**Stateful** (caller is context-constrained): caller holds only `state_id`; tool persists state server-side at `~/.cache/kicad-mcp/placement_states/<state_id>.json` and returns only deltas. Last 5 states per schematic kept; 30-day expiry.
+
+Both modes accept the same input parameters; the difference is what gets returned and what the caller has to track.
+
+## Tool API
+
+A new router `schematic_layout` with three operations.
+
+### `schematic_layout(operation="suggest", ...)`
+
+```python
+schematic_layout(
+    operation="suggest",
+    schematic_path: str | None = None,    # defaults to currently-loaded schematic
+
+    # Iteration: pass previous state OR state_id
+    state: PlacementState | None = None,
+    state_id: str | None = None,
+
+    # Caller-supplied semantic information (Layer 4)
+    hints: dict[ref, str] = {},
+
+    # Explicit cluster overrides (for when topology gets it wrong)
+    cluster_assignments: dict[cluster_id, list[ref]] = {},
+
+    # Positional constraints
+    fixed_positions: dict[ref, dict] = {},
+        # {"U1": {"x_mm": 50, "y_mm": 30, "rotation": 0}}
+
+    # Cluster surgery
+    merge_clusters: list[list[cluster_id]] = [],
+    split_cluster: dict[cluster_id, list[list[ref]]] = {},
+
+    # Scope of recomputation
+    redo_scope: list[cluster_id] | None = None,
+        # None = full redo; [c0, c2] = recompute only those; rest preserved
+
+    # Algorithm knobs
+    column_pitch_mm: float = 25.4,
+    row_pitch_mm: float = 12.7,
+    confidence_threshold: float = 0.5,
+
+    # Output controls
+    verbosity: str = "minimal",  # "minimal" | "full"
+)
+-> {
+    "status": "ok",
+    "state": PlacementState,   # full in stateless mode; delta in stateful mode
+    "state_id": str,
+    "events": [...],
+}
+```
+
+Returns a placement state without mutating the schematic. Read-only.
+
+### `schematic_layout(operation="apply", ...)`
+
+```python
+schematic_layout(
+    operation="apply",
+    state_id: str | None = None,           # use most-recent if None
+    state: PlacementState | None = None,   # alternatively, pass full state
+    refs: list[ref] | None = None,         # None = apply all; or partial
+    schematic_path: str | None = None,
+)
+-> {
+    "status": "ok",
+    "applied": int,                        # count of components moved
+    "errors": [...],                       # refs that couldn't be moved
+    "events": [...],
+}
+```
+
+"Dumb apply" semantics: walks `state.components` and calls `move_component` for each. Drift detection via `state.schematic_hash` recomputed at apply time — if it changed since suggest, emit a `placement_state_stale` warning (don't fail; caller decides).
+
+### `schematic_layout(operation="clear_cache", ...)`
+
+```python
+schematic_layout(
+    operation="clear_cache",
+    schematic_path: str | None = None,     # None = all schematics
+)
+-> {"status": "ok", "cleared_count": int}
+```
+
+Manual cache eviction. Useful for testing and when the user wants a clean slate.
+
+## Iteration loop
+
+**Default workflow** (Claude is orchestrator):
+
+1. Claude builds schematic (`add_component`, `add_wire`, ...)
+2. Calls `schematic_layout(operation="suggest", schematic_path="foo.kicad_sch")` → first draft
+3. Reads the `state` and `events`. Identifies any cluster with `bus_bridge_suspected` or `label_confidence < 0.5`
+4. If needed, re-calls `schematic_layout` with `cluster_assignments` / `hints` / `fixed_positions` to fix specific issues. Each call cheap (~ms in stateful mode, full state returned in stateless)
+5. Calls `schematic_layout(operation="apply", state_id=last_state_id)` → applies to schematic
+6. Optional: opens schematic visually for user review or screenshots; user-fed feedback drives another iteration
+
+**Iteration cost**: in stateful mode, each call ships only a delta — typically <1 KB even for large schematics. Caller context grows by deltas, not by full-state snapshots.
+
+## Divergence from PCB `suggest_placement`
+
+The PCB version returns a flat `{ref: {"x_mm", "y_mm", "mirror"}}` dict. Schematic placement returns rich state.
+
+Reasons for divergence:
+- PCB placement has fewer "what is this" decisions (schematic-level grouping is already done)
+- PCB consumer use case is "smart starting position"; schematic consumer is "iterate with Claude"
+- PCB tool ships today; retrofitting is real work; not justified preemptively
+
+When/if PCB placement also needs iteration UX (the calibration loop showing frequent overrides on the PCB side), retrofit at that point. Documented as deliberate divergence; not technical debt.
+
+## Telemetry integration
+
+Per the Feedback Infrastructure SPEC:
+
+- Every `schematic_layout` call records to the `calls` table with `tool_name="schematic_layout.suggest"` (or `.apply`, `.clear_cache`)
+- Every cluster decision recorded to `cluster_decisions` (member_count, anchor, label, label_confidence, label_source, tier, louvain_modularity)
+- Every emitted warning recorded to `warnings_emitted`
+- Action attribution runs synchronously at suggest entry (per `feedback_synchronous_at_call_boundary.md`)
+
+`output_summary` fields for placement:
+```json
+{
+  "cluster_count": 7,
+  "tier_count": 3,
+  "label_source_breakdown": {"pattern_recognition": 3, "resolved_part": 1, "caller_hint": 2, "topology_only": 1},
+  "low_confidence_cluster_count": 2,
+  "warnings_emitted_count": 4,
+  "lcsc_resolved_component_count": 5,
+  "verbosity": "minimal"
+}
+```
+
+## Convention rules (v1 set)
+
+Minimal v1 set. Each is implemented as a function that takes a labeled cluster and outputs constrained positions; if no rule matches, the cluster gets generic placement (anchor centered, peripherals around).
+
+| Rule code | Trigger | Effect |
+|---|---|---|
+| `decap_below_ic` | Cluster has 1 IC + ≥1 cap connected only to power nets shared with the IC | Caps placed in row below IC, x-aligned to IC center |
+| `regulator_input_left` | Cluster labeled `"ldo"` or `"regulator"` | VIN pin's net on left, VOUT pin's net on right (uses `pintype` + `pinfunction`) |
+| `mcu_crystal_proximate` | Cluster labeled `"mcu"` + cluster member labeled `"crystal"` | Crystal placed within `column_pitch_mm` of MCU, on the side with the OSC pins |
+| `connector_edge` | Cluster anchor labeled `"connector"` or `"edge_connector"` | Push to tier 0 (left edge) or last tier (right edge) based on signal direction |
+| `power_symbols_top_bottom` | Power-flag symbols (`+3V3`, `+5V`, `GND`, etc.) | Placed at top of cluster (positive rails) or bottom (ground) |
+
+When a rule is applied, emit info-level event `convention_applied` with the rule code and refs affected. When a rule fails to apply (e.g., couldn't identify VIN pin), emit info-level event `convention_skipped`. Telemetry uses these to surface frequent skip reasons.
+
+## v1 scope
+
+Ship:
+- `schematic_layout` router with operations `suggest`, `apply`, `clear_cache`
+- 4-layer architecture (topology + pattern_recognition + resolved-part + hints)
+- 3-phase algorithm (cluster → rank → pack)
+- v1 convention rules (5 rules above)
+- `PlacementState` schema with verbosity modes
+- Stateful (server-cached) and stateless modes
+- Telemetry integration per the Feedback Infrastructure SPEC
+- OOB event surfacing for warnings/errors
+- Cache management at `~/.cache/kicad-mcp/placement_states/`
+- Pre-flight fixes to `pattern_recognition.py`: the `MCP\d+` collision and RC-filter false-positive on I²C pull-ups (these are blockers for honest calibration)
+- Tests: unit tests for clustering, ranking, packing, conventions; integration tests against 3-5 ground-truth schematics (see Open Questions)
+
+### Tool count after this PR
+
+14 → 15 (`schematic_layout` router).
+
+### Test count target
+
+Approximately +60-80 tests. The algorithm has many decision points; boundary coverage per project's threshold-testing rule.
+
+### Estimated wall-clock
+
+2-3 weeks of pairing-mode work. Longer than the other specs in this session because: (a) the algorithm has more inherent complexity, (b) heuristic tuning against real fixtures is iterative, (c) the 3-5 ground-truth fixtures must be picked before quality measurement is possible.
+
+## Deferred from v1
+
+- **Hierarchical schematic sheets.** Flat-only in v1. Sub-sheet support requires either (a) flattening then re-splitting, or (b) running the algorithm per-sheet with cross-sheet edge accounting. Significant scope addition; defer until a real use case emerges.
+- **Convention rules beyond the v1 set.** Future candidates: bus grouping, differential pair placement, RF guard rings (probably out of scope ever — RF needs PCB layout), audio signal-path conventions, high-current trace allowances.
+- **Manual iteration UX.** External users without an AI orchestrator (no Claude) get a usable first draft from `suggest`, then they tweak in KiCad GUI. No interactive cluster-clicking UI in v1.
+- **Sub-second incremental updates.** v1 recomputes the entire algorithm on each `suggest` call (within `redo_scope` if specified). Truly-incremental "I just added one component" updates are deferred.
+- **Cross-schematic layout consistency.** v1 treats each schematic independently. Multi-board projects with conventions (e.g., always-MCU-bottom-left) need a separate layer (defer).
+- **Convention rule overrides per caller.** v1 has a fixed rule set. Caller-specifiable rules (e.g., "for this schematic, regulator goes on the right") deferred.
+- **A11y / readability scoring.** Quantifying "does this look like a readable schematic" beyond crossing count and convention application. Real challenge; defer to a future v2.
+
+## Open questions
+
+These are decisions Brian needs to weigh in on before implementation begins:
+
+1. **The 3-5 ground-truth test fixtures.** Without these, the 70-85% quality estimate is structural-not-measured. The fixtures should be representative AI-built schematics (MCU + peripherals, power supply, analog filter, sensor breakout, mixed-signal). Brian needs to pick (or draft) these — they're his contribution. They live at `tests/fixtures/schematic_placement/`.
+
+2. **The wire-reflow precondition.** Three options:
+   - (a) **Un-wired only**: `schematic_layout` requires the schematic to have no existing wires (caller deletes wires before placement, redraws after). Cleanest but most restrictive.
+   - (b) **Accept stale wires**: tool emits a `wires_will_be_stale` warning if existing wires would no longer match component positions, but proceeds anyway. Caller decides whether to re-wire.
+   - (c) **Re-wire after placement**: tool also reflows wires using `add_wire_between_pins`. Larger scope; less of a chance to ship v1 soon.
+   - **Recommended: (b) for v1**, with `wires_will_be_stale` surfaced via `mcp-events`. Re-wire as v2.
+
+3. **Whether the v1 convention rule set is the right cut.** I picked 5 rules I'm confident matter. Brian may want to add/remove based on what schematics he actually builds.
+
+4. **The `role` field on components (deferred from earlier in this session).** Currently I'm using a 3-value enum: `"anchor" | "peripheral" | "passive"`. Brian deferred more granular options (`decoupling_cap`, `pull_up`, etc.); when telemetry shows callers wanting finer roles, expand.
+
+5. **Pattern recognition fixes scope.** The `MCP\d+` collision and RC-filter false-positive are blockers (without fixing them, labeling has confidently-wrong outputs that poison the iteration loop). But what about the broader coverage limitations? Recommended: fix only the collisions/false-positives in this PR. Coverage expansion (handling voltage refs, level shifters, motor drivers, etc.) is its own project.
+
+## Testing strategy
+
+### Unit tests (synthetic, no KiCad)
+
+- **Layer 1 (topology)**: synthetic netlist fixtures with known cluster structure; verify Louvain finds them; verify bus-bridge detection on synthetic merge scenarios
+- **Layer 2 (pattern recognition)**: verify the `MCP\d+` collision is fixed (TLV70 / MCP6002 / MCP23017 / MCP2200 all correctly classified, not misidentified as "voltage_sensor"); RC-filter detector excludes pull-ups (R to VCC, not R to signal source)
+- **Layer 3 (resolved-part)**: synthetic jlcparts SQLite fixture; verify category → label mapping; verify resolved-part dominates pattern_recognition when both present
+- **Layer 4 (hints)**: caller hints override all lower layers; absent hints don't crash anything
+- **Phase 2 (rank/BFS)**: synthetic netlist with known signal flow; verify tier assignment; verify cycle handling
+- **Phase 3 (pack)**: barycentric ordering reduces crossings on synthetic test cases; convention rules apply correctly
+- **PlacementState verbosity**: `minimal` and `full` differ in expected ways; sparse encoding omits default fields
+- **Stateful/stateless modes**: state_id round-trips; cached state is loadable; cache cleanup works
+- **Cluster ID stability**: re-running with `state=previous` preserves cluster_ids when membership unchanged; new clusters get new IDs
+- **Iteration**: `redo_scope` recomputes only the named clusters; others preserved
+
+### Boundary tests (per project CLAUDE.md threshold-testing rule)
+
+- Confidence threshold: `confidence=0.5` (the default) — label retained; `0.499` — label becomes `"unclassified"`
+- Cluster size boundary: 3 members (sparse warning); 4 members (no warning)
+- Bus-bridge detection threshold: define exact edge count that triggers warning; test at boundary
+- `column_pitch_mm` boundary: very small value (0.1mm) produces collisions; very large value (1000mm) is technically valid
+- Empty schematic: `suggest` returns empty state, no errors
+- Single-component schematic: places at origin, single-cluster, no warnings
+
+### Integration tests (KiCad required, marked)
+
+- Real schematics from `tests/fixtures/schematic_placement/`: run `suggest` → `apply` → verify no DRC violations; verify components are at expected approximate positions
+- Round-trip: build a known schematic via tools, run placement, save, re-load, verify state survives
+
+### Quality benchmark (the 70-85% measurement)
+
+Not a unit test but an ongoing measurement:
+- For each fixture, baseline: position-randomized layout (random within bounding box)
+- For each fixture, candidate: `schematic_layout(operation="suggest")` first call output
+- Score: human evaluator (Brian) rates each layout on a scale (e.g., 1-5) for readability and convention compliance
+- Target: candidate scores ≥ 3.5 on 70-85% of fixtures
+- Telemetry instruments the algorithm so we can identify which fixtures score below and why
+
+## Hand-off summary
+
+For an implementer picking this up cold:
+
+1. Read this SPEC end-to-end.
+2. Read the design-philosophy memories: `feedback_context_frugality.md`, `feedback_synchronous_at_call_boundary.md`, `feedback_prefer_packaging_over_vendoring.md`.
+3. **Verify the prerequisite chain is implemented**:
+   - `mcp-events` package (published to PyPI, integrated into kicad-mcp)
+   - Feedback Infrastructure (per `SPEC_Feedback_Infrastructure.md`)
+   - Component Intelligence (per `SPEC_Component_Intelligence_LCSC.md`) — *optional but enhances Layer 3*
+4. **Confirm the ground-truth fixtures exist** at `tests/fixtures/schematic_placement/`. If not, this PR can begin but quality-benchmarking is blocked on Brian providing them.
+5. Pre-flight fixes to `pattern_recognition.py`: fix the `MCP\d+` collision and RC-filter false-positive. These are tracked as their own commits within the same PR.
+6. Implement against the v1 scope. Defer everything in "Deferred from v1."
+7. The test suite is the acceptance criterion. Unit tests run in `uv run pytest` without KiCad. Integration tests require KiCad and are marked appropriately.
+8. Update `MEMORY.md` and `project_schematic_placement.md` to mark this implemented when the PR merges; note any deviations.
+
+Tool count after this PR: 14 → 15. Test count target: +60-80.
+
+Implementation order recap:
+
+```
+✅ OOB Events Subsystem        (mcp-events package implemented)
+⏳ mcp-events PyPI publication (blocker)
+→  Feedback Infrastructure     (spec ready)
+→  Component Intelligence      (spec ready)
+→  Schematic Auto-Placement    (this spec — capstone)
+```


### PR DESCRIPTION
## Summary

Adds four design SPECs targeting v0.11. Docs-only — no source changes, no tests changed, no dependencies added.

- **[SPEC_OOB_Events.md](docs/SPEC_OOB_Events.md)** — shared mcp-events Python package (already implemented at /Volumes/Files/claude/mcp-events/) for in-call event surfacing across MCP servers
- **[SPEC_Feedback_Infrastructure.md](docs/SPEC_Feedback_Infrastructure.md)** — local telemetry + action-attribution for tools (implementation pending on a separate branch)
- **[SPEC_Component_Intelligence_LCSC.md](docs/SPEC_Component_Intelligence_LCSC.md)** — LCSC/JLCPCB part search + KiCad symbol/footprint resolution (replaces the Chrome-extension kludge)
- **[SPEC_Schematic_Placement.md](docs/SPEC_Schematic_Placement.md)** — 4-layer topology-aware schematic auto-layout (the capstone)

The SPECs cross-reference each other and reflect the implementation order: OOB Events → Feedback Infrastructure → Component Intelligence → Schematic Placement. Landing these on main first lets implementation work proceed in parallel sessions without each branch carrying duplicate copies of the design docs.

## Test plan

- [x] 969/969 existing tests still pass — no behavior change
- [x] mypy clean
- [x] No new files outside docs/; no source modifications