### PR TITLE
fix(pattern_recognition): pre-flight fixes for placement calibration

### DIFF
--- a/src/kicad_mcp/utils/pattern_recognition.py
+++ b/src/kicad_mcp/utils/pattern_recognition.py
@@ -9,6 +9,7 @@ from kicad_mcp.utils.component_utils import (
     extract_frequency_from_value,
     extract_voltage_from_regulator,
 )
+from kicad_mcp.utils.netlist_parser import is_power_net
 
 
 def identify_power_supplies(
@@ -118,7 +119,12 @@ def identify_amplifiers(
     # missing from the outer filter, making the instrumentation sub-branch
     # unreachable for those values.
     opamp_patterns = [
-        r"LM\d{3}|TL\d{3}|NE\d{3}|LF\d{3}|OP\d{2}|MCP\d{3}|AD\d{3,}|LT\d{4}|OPA\d{3}|INA\d+",
+        # MCP6\d{2,3} matches MCP602/604/6001/6002/etc — the actual MCP op-amp
+        # families. Previously MCP\d{3} also matched MCP9808 (temp), MCP1525
+        # (vref), MCP4725 (DAC), MCP3221 (ADC). AD\d{3,} stays widened to
+        # catch 4-digit AD parts; INA\d+ keeps the instrumentation branch
+        # reachable. Mirror change in identify_filters opamp detection below.
+        r"LM\d{3}|TL\d{3}|NE\d{3}|LF\d{3}|OP\d{2}|MCP6\d{2,3}|AD\d{3,}|LT\d{4}|OPA\d{3}|INA\d+",
         r"Opamp|Op-Amp|OpAmp|Operational Amplifier",
     ]
 
@@ -257,7 +263,14 @@ def identify_filters(
     """
     filters = []
 
-    # Look for RC low-pass filters
+    # Look for RC low-pass filters.
+    #
+    # A real RC low-pass has R between signal-in and signal-out (both
+    # non-power) and C between signal-out and ground. Skip when any of
+    # R's nets is a power rail — that's a pull-up/pull-down, not a
+    # filter. Without this guard, an I²C pull-up resistor + an unrelated
+    # decoupling cap on the same VCC net produced a spurious "rc_low_pass"
+    # classification.
     resistor_refs = [ref for ref in components.keys() if ref.startswith("R")]
 
     for r_ref in resistor_refs:
@@ -265,6 +278,12 @@ def identify_filters(
         for net_name, pins in nets.items():
             if any(pin.get("component") == r_ref for pin in pins):
                 r_nets.append(net_name)
+
+        # Filter R must straddle signal nets only. If either terminal is
+        # on power, this is a pull-up / pull-down / current-limit, not
+        # a low-pass.
+        if any(is_power_net(n) for n in r_nets):
+            continue
 
         for net_name in r_nets:
             connected_caps = []
@@ -299,7 +318,9 @@ def identify_filters(
         component_lib = component.get("lib_id", "").upper()
 
         if re.search(
-            r"LM\d{3}|TL\d{3}|NE\d{3}|LF\d{3}|OP\d{2}|MCP\d{3}|AD\d{3}|LT\d{4}|OPA\d{3}",
+            # Same MCP6\d{2,3} narrowing as identify_amplifiers above — keeps
+            # MCP-op-amp detection in the active-filter path consistent.
+            r"LM\d{3}|TL\d{3}|NE\d{3}|LF\d{3}|OP\d{2}|MCP6\d{2,3}|AD\d{3}|LT\d{4}|OPA\d{3}",
             component_value,
             re.IGNORECASE,
         ) or "OP_AMP" in component_lib:
@@ -330,22 +351,16 @@ def identify_filters(
                 "value": components[op_ref].get("value", ""),
             })
 
-    # Look for crystal filters or ceramic filters
+    # Ceramic / mechanical filters — components explicitly named as filters.
+    #
+    # Crystals (Y*/X* refs and lib_ids containing CRYSTAL/XTAL) used to be
+    # classified here as well, which double-counted them since they also
+    # appear in identify_oscillators. They almost always serve as oscillator
+    # elements, not filters. Removed here; identify_oscillators is the
+    # single source of truth for crystal classification.
     for ref, component in components.items():
         component_value = component.get("value", "").upper()
         component_lib = component.get("lib_id", "").upper()
-
-        if (
-            ref.startswith("Y")
-            or ref.startswith("X")
-            or "CRYSTAL" in component_lib
-            or "XTAL" in component_lib
-        ):
-            filters.append({
-                "type": "crystal_filter",
-                "component": ref,
-                "value": component_value,
-            })
 
         if (
             "FILTER" in component_lib
@@ -461,11 +476,31 @@ def identify_digital_interfaces(
         sig_upper = {s.upper() for s in signals}
         return [n for n in nets.keys() if _net_tokens(n) & sig_upper]
 
+    def _components_on_nets(net_names: list) -> list:
+        """Collect unique component refs whose pins touch any of the given nets.
+
+        Returned in sorted order for deterministic output. Used so downstream
+        cluster-labeling code can map a detected interface back to the
+        components implementing it — previously results were keyed only by
+        net name and the components were invisible.
+        """
+        refs: set[str] = set()
+        for n in net_names:
+            for pin in nets.get(n, []):
+                ref = pin.get("component")
+                if ref:
+                    refs.add(ref)
+        return sorted(refs)
+
     # I2C interface detection
     i2c_signals = {"SCL", "SDA", "I2C_SCL", "I2C_SDA"}
     i2c_nets = _matching_nets(i2c_signals)
     if i2c_nets:
-        interfaces.append({"type": "i2c_interface", "signals_found": i2c_nets})
+        interfaces.append({
+            "type": "i2c_interface",
+            "signals_found": i2c_nets,
+            "components": _components_on_nets(i2c_nets),
+        })
 
     # SPI interface detection
     spi_signals = {
@@ -473,43 +508,63 @@ def identify_digital_interfaces(
     }
     spi_nets = _matching_nets(spi_signals)
     if spi_nets:
-        interfaces.append({"type": "spi_interface", "signals_found": spi_nets})
+        interfaces.append({
+            "type": "spi_interface",
+            "signals_found": spi_nets,
+            "components": _components_on_nets(spi_nets),
+        })
 
     # UART interface detection
     uart_signals = {"TX", "RX", "TXD", "RXD", "UART_TX", "UART_RX"}
     uart_nets = _matching_nets(uart_signals)
     if uart_nets:
-        interfaces.append({"type": "uart_interface", "signals_found": uart_nets})
+        interfaces.append({
+            "type": "uart_interface",
+            "signals_found": uart_nets,
+            "components": _components_on_nets(uart_nets),
+        })
 
     # USB interface detection — nets OR a known USB-IC value
     usb_signals = {
         "USB_D+", "USB_D-", "USB_DP", "USB_DM", "D+", "D-", "DP", "DM", "VBUS",
     }
     usb_nets = _matching_nets(usb_signals)
-    has_usb_ic = any(
-        re.search(
+    usb_ic_refs = sorted(
+        ref
+        for ref, component in components.items()
+        if re.search(
             r"FT232|CH340|CP210|MCP2200|TUSB|FT231|FT201",
             component.get("value", ""),
             re.IGNORECASE,
         )
-        for component in components.values()
     )
-    if usb_nets or has_usb_ic:
-        interfaces.append({"type": "usb_interface", "signals_found": usb_nets})
+    if usb_nets or usb_ic_refs:
+        combined = sorted(set(_components_on_nets(usb_nets)) | set(usb_ic_refs))
+        interfaces.append({
+            "type": "usb_interface",
+            "signals_found": usb_nets,
+            "components": combined,
+        })
 
     # Ethernet interface detection — nets OR a known PHY value
     ethernet_signals = {"TX+", "TX-", "RX+", "RX-", "MDI", "MDIO", "ETH"}
     eth_nets = _matching_nets(ethernet_signals)
-    has_eth_phy = any(
-        re.search(
+    eth_phy_refs = sorted(
+        ref
+        for ref, component in components.items()
+        if re.search(
             r"W5500|ENC28J60|LAN87|KSZ80|DP83|RTL8|AX88",
             component.get("value", ""),
             re.IGNORECASE,
         )
-        for component in components.values()
     )
-    if eth_nets or has_eth_phy:
-        interfaces.append({"type": "ethernet_interface", "signals_found": eth_nets})
+    if eth_nets or eth_phy_refs:
+        combined = sorted(set(_components_on_nets(eth_nets)) | set(eth_phy_refs))
+        interfaces.append({
+            "type": "ethernet_interface",
+            "signals_found": eth_nets,
+            "components": combined,
+        })
 
     return interfaces
 
@@ -551,7 +606,12 @@ def identify_sensor_interfaces(
         # ADS1115-specific branch in the ADC handler (with resolution and
         # channel count) was unreachable because dict iteration order put
         # "voltage" before "ADC".
-        "voltage": r"INA\d+|MCP\d+",
+        # MCP\d+ was previously here and matched any Microchip part starting
+        # with MCP — including MCP6002 (op-amp), MCP23017 (GPIO expander),
+        # MCP2200 (USB-UART), MCP9808 (temp sensor). All wrongly classified
+        # as voltage_sensor. Real MCP voltage-sensing parts are ADCs (MCP3xxx)
+        # already covered by the ADC pattern below.
+        "voltage": r"INA\d+",
         "ADC": r"ADS\d+|MCP33\d+|MCP32\d+|LTC\d+|NAU7802|HX711",
         "GPS": r"NEO-[67]M|L80|MTK\d+|SIM\d+|SAM-M8Q|MAX-M8",
     }

--- a/tests/test_pattern_recognition.py
+++ b/tests/test_pattern_recognition.py
@@ -9,15 +9,14 @@ double-classification guard, edge/empty cases.
 import pytest
 
 from kicad_mcp.utils.pattern_recognition import (
-    identify_power_supplies,
     identify_amplifiers,
-    identify_filters,
-    identify_oscillators,
     identify_digital_interfaces,
-    identify_sensor_interfaces,
+    identify_filters,
     identify_microcontrollers,
+    identify_oscillators,
+    identify_power_supplies,
+    identify_sensor_interfaces,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -279,17 +278,9 @@ class TestIdentifyFilters:
         rc = [r for r in result if r.get("subtype") == "rc_low_pass"]
         assert len(rc) == 0
 
-    def test_crystal_filter_y_prefix(self):
-        components = {"Y1": _comp("16MHz")}
-        result = identify_filters(components, {})
-        crystal = [r for r in result if r["type"] == "crystal_filter"]
-        assert len(crystal) == 1
-
-    def test_crystal_filter_x_prefix(self):
-        components = {"X1": _comp("8MHz")}
-        result = identify_filters(components, {})
-        crystal = [r for r in result if r["type"] == "crystal_filter"]
-        assert len(crystal) == 1
+    # Crystal_filter classification removed — identify_oscillators is the
+    # single source of truth for crystals (see TestCrystalNotDoubleClassified
+    # below).
 
     def test_active_filter_opamp_with_rc_feedback(self):
         components = {
@@ -815,3 +806,234 @@ class TestIdentifyMicrocontrollers:
         components = {"U1": _comp("RPICO")}
         result = identify_microcontrollers(components)
         assert any(r.get("type") in ("development_board", "microcontroller") for r in result)
+
+
+# ===========================================================================
+# Pre-flight fixes for placement-project calibration honesty (2026-05-27).
+# Each class below pins a specific bug the v0.10.0 prep didn't address.
+# ===========================================================================
+
+
+def _net(pins):
+    """Build a synthetic net entry: list of {component, pin}.
+
+    Used by the test classes below that exercise net-topology fixes (RC
+    pull-up false positive, digital interface component-ref collection).
+    """
+    return [{"component": ref, "pin": p} for ref, p in pins]
+
+
+class TestSensorMCPCollision:
+    """identify_sensor_interfaces previously matched any MCP\\d+ as
+    voltage_sensor, sweeping up op-amps, GPIO expanders, USB-UARTs."""
+
+    def test_mcp6002_opamp_not_voltage_sensor(self):
+        components = {"U1": _comp(value="MCP6002")}
+        sensors = identify_sensor_interfaces(components, {})
+        types = {s.get("type") for s in sensors}
+        assert "voltage_sensor" not in types
+
+    def test_mcp23017_gpio_not_voltage_sensor(self):
+        components = {"U1": _comp(value="MCP23017")}
+        sensors = identify_sensor_interfaces(components, {})
+        types = {s.get("type") for s in sensors}
+        assert "voltage_sensor" not in types
+
+    def test_mcp2200_usb_not_voltage_sensor(self):
+        components = {"U1": _comp(value="MCP2200")}
+        sensors = identify_sensor_interfaces(components, {})
+        types = {s.get("type") for s in sensors}
+        assert "voltage_sensor" not in types
+
+    def test_mcp9808_temp_not_voltage_sensor(self):
+        """MCP9808 is a temp sensor; voltage_sensor would shadow temperature_sensor."""
+        components = {"U1": _comp(value="MCP9808")}
+        sensors = identify_sensor_interfaces(components, {})
+        types = {s.get("type") for s in sensors}
+        assert "temperature_sensor" in types
+        assert "voltage_sensor" not in types
+
+    def test_ina226_still_classified(self):
+        components = {"U1": _comp(value="INA226")}
+        sensors = identify_sensor_interfaces(components, {})
+        types = {s.get("type") for s in sensors}
+        assert "current_sensor" in types or "voltage_sensor" in types
+
+    def test_mcp3204_still_classified_as_adc(self):
+        """ADC path is unchanged. Emits type='analog_interface'."""
+        components = {"U1": _comp(value="MCP3204")}
+        sensors = identify_sensor_interfaces(components, {})
+        types = {s.get("type") for s in sensors}
+        assert "analog_interface" in types
+
+
+class TestOpAmpMCPOverMatch:
+    """identify_amplifiers previously matched MCP\\d{3} which caught
+    MCP9808 (temp), MCP1525 (vref), MCP4725 (DAC), MCP3221 (ADC).
+    Now uses MCP6\\d{2,3} which is the actual MCP op-amp family."""
+
+    def test_mcp6002_still_classified_as_opamp(self):
+        components = {"U1": _comp(value="MCP6002", lib_id="Amplifier_Operational:MCP6002")}
+        amps = identify_amplifiers(components, {})
+        values = {a.get("value") for a in amps}
+        assert "MCP6002" in values
+
+    def test_mcp9808_temp_not_opamp(self):
+        components = {"U1": _comp(value="MCP9808")}
+        amps = identify_amplifiers(components, {})
+        values = {a.get("value") for a in amps}
+        assert "MCP9808" not in values
+
+    def test_mcp1525_vref_not_opamp(self):
+        components = {"U1": _comp(value="MCP1525")}
+        amps = identify_amplifiers(components, {})
+        values = {a.get("value") for a in amps}
+        assert "MCP1525" not in values
+
+    def test_mcp4725_dac_not_opamp(self):
+        components = {"U1": _comp(value="MCP4725")}
+        amps = identify_amplifiers(components, {})
+        values = {a.get("value") for a in amps}
+        assert "MCP4725" not in values
+
+    def test_mcp3221_adc_not_opamp(self):
+        components = {"U1": _comp(value="MCP3221")}
+        amps = identify_amplifiers(components, {})
+        values = {a.get("value") for a in amps}
+        assert "MCP3221" not in values
+
+
+class TestRCFilterPullupFalsePositive:
+    """A pull-up R between VCC and SDA + decoupling cap on VCC was
+    misclassified as rc_low_pass. Now skipped via is_power_net guard."""
+
+    def test_i2c_pullup_not_rc_filter(self):
+        components = {
+            "R1": _comp(value="4.7k"),
+            "C1": _comp(value="100nF"),
+            "U1": _comp(value="MCP23017"),
+        }
+        nets = {
+            "VCC": _net([("R1", "1"), ("C1", "1"), ("U1", "20")]),
+            "SDA": _net([("R1", "2"), ("U1", "12")]),
+            "GND": _net([("C1", "2"), ("U1", "10")]),
+        }
+        results = identify_filters(components, nets)
+        types = [(f.get("type"), f.get("subtype")) for f in results]
+        assert ("passive_filter", "rc_low_pass") not in types
+
+    def test_pullup_to_3v3_not_rc_filter(self):
+        components = {
+            "R1": _comp(value="10k"),
+            "C1": _comp(value="100nF"),
+            "U1": _comp(value="MCU"),
+        }
+        nets = {
+            "+3V3": _net([("R1", "1"), ("C1", "1"), ("U1", "1")]),
+            "SDA": _net([("R1", "2"), ("U1", "2")]),
+            "GND": _net([("C1", "2"), ("U1", "3")]),
+        }
+        results = identify_filters(components, nets)
+        assert all(f.get("subtype") != "rc_low_pass" for f in results)
+
+    def test_real_rc_low_pass_still_detected(self):
+        """R between two non-power nets, C to GND. Genuine low-pass."""
+        components = {
+            "R1": _comp(value="1k"),
+            "C1": _comp(value="100nF"),
+        }
+        nets = {
+            "SIGNAL_IN": _net([("R1", "1")]),
+            "SIGNAL_OUT": _net([("R1", "2"), ("C1", "1")]),
+            "GND": _net([("C1", "2")]),
+        }
+        results = identify_filters(components, nets)
+        types = [(f.get("type"), f.get("subtype")) for f in results]
+        assert ("passive_filter", "rc_low_pass") in types
+
+
+class TestCrystalNotDoubleClassified:
+    """identify_filters used to also emit crystal_filter for any Y*/X*
+    ref or CRYSTAL/XTAL lib_id. identify_oscillators classifies them too.
+    Removed from filters; oscillator-side stays."""
+
+    def test_crystal_not_in_filter_output(self):
+        components = {"Y1": _comp(value="16MHz", lib_id="Device:Crystal")}
+        nets = {"XTAL1": _net([("Y1", "1")]), "XTAL2": _net([("Y1", "2")])}
+        results = identify_filters(components, nets)
+        types = {f.get("type") for f in results}
+        assert "crystal_filter" not in types
+
+    def test_crystal_still_in_oscillator_output(self):
+        components = {"Y1": _comp(value="16MHz", lib_id="Device:Crystal")}
+        nets = {"XTAL1": _net([("Y1", "1")]), "XTAL2": _net([("Y1", "2")])}
+        results = identify_oscillators(components, nets)
+        types = {f.get("type") for f in results}
+        assert "crystal_oscillator" in types
+
+    def test_ceramic_filter_still_detected(self):
+        components = {"FL1": _comp(value="455kHz", lib_id="Custom:Ceramic_Filter")}
+        results = identify_filters(components, {})
+        types = {f.get("type") for f in results}
+        assert "ceramic_filter" in types
+
+
+class TestDigitalInterfacesComponents:
+    """Each interface entry now has a `components` list (refs touching the
+    matched signal nets, plus the IC by ref for value-based detection)."""
+
+    def test_i2c_interface_includes_component_refs(self):
+        components = {
+            "U1": _comp(value="MCU"),
+            "U2": _comp(value="MCP23017"),
+            "R1": _comp(value="4.7k"),
+            "R2": _comp(value="4.7k"),
+        }
+        nets = {
+            "SCL": _net([("U1", "1"), ("U2", "12"), ("R1", "1")]),
+            "SDA": _net([("U1", "2"), ("U2", "13"), ("R2", "1")]),
+            "+3V3": _net([("R1", "2"), ("R2", "2")]),
+        }
+        interfaces = identify_digital_interfaces(components, nets)
+        i2c = next(i for i in interfaces if i["type"] == "i2c_interface")
+        assert set(i2c["components"]) == {"U1", "U2", "R1", "R2"}
+
+    def test_spi_interface_includes_component_refs(self):
+        components = {"U1": _comp(value="MCU"), "U2": _comp(value="W25Q64")}
+        nets = {
+            "MOSI": _net([("U1", "1"), ("U2", "5")]),
+            "MISO": _net([("U1", "2"), ("U2", "2")]),
+            "SCK": _net([("U1", "3"), ("U2", "6")]),
+            "SPI_CS": _net([("U1", "4"), ("U2", "1")]),
+        }
+        interfaces = identify_digital_interfaces(components, nets)
+        spi = next(i for i in interfaces if i["type"] == "spi_interface")
+        assert set(spi["components"]) == {"U1", "U2"}
+
+    def test_usb_ic_detected_by_value_appears_in_components(self):
+        """USB IC detected by value (no USB nets) — must appear in components."""
+        components = {"U1": _comp(value="FT232RL"), "U2": _comp(value="MCU")}
+        nets = {}
+        interfaces = identify_digital_interfaces(components, nets)
+        usb = next(i for i in interfaces if i["type"] == "usb_interface")
+        assert "U1" in usb["components"]
+
+
+class TestMCP6PatternBoundaries:
+    """Boundary coverage for the narrowed op-amp pattern (MCP6\\d{2,3})."""
+
+    def test_mcp602_three_digit_form_matches(self):
+        components = {"U1": _comp(value="MCP602")}
+        amps = identify_amplifiers(components, {})
+        assert any(a.get("value") == "MCP602" for a in amps)
+
+    def test_mcp6001_four_digit_form_matches(self):
+        components = {"U1": _comp(value="MCP6001")}
+        amps = identify_amplifiers(components, {})
+        assert any(a.get("value") == "MCP6001" for a in amps)
+
+    def test_mcp7383_non_opamp_family_does_not_match(self):
+        """Boundary: MCP7xxx (not an op-amp family) must NOT match the narrowed pattern."""
+        components = {"U1": _comp(value="MCP7383")}
+        amps = identify_amplifiers(components, {})
+        assert not any(a.get("value") == "MCP7383" for a in amps)


### PR DESCRIPTION
## Summary

Four bug fixes + one improvement in `pattern_recognition.py`, layered on top of the v0.10.0 prep work (which fixed adjacent bugs in the same module). Each pins a confidently-wrong classification that would poison the placement project's calibration loop (`calibration > coverage` per [`SPEC_Schematic_Placement.md`](docs/SPEC_Schematic_Placement.md)).

1. **`identify_amplifiers` + `identify_filters`** — `MCP\d{3}` → `MCP6\d{2,3}` in op-amp patterns. v0.10.0 prep widened the outer filter to `AD\d{3,}|INA\d+` for instrumentation amp coverage but didn't touch the MCP token, so MCP9808 (temp), MCP1525 (vref), MCP4725 (DAC), MCP3221 (ADC) all still wrongly matched as op-amps. New pattern catches the real MCP op-amp families (MCP602/604/6001/6002/etc.) only.
2. **`identify_sensor_interfaces` voltage pattern** — dropped `MCP\d+` entirely. v0.10.0 prep moved `ADS\d+` out of voltage to ADC (correct), but kept `MCP\d+` in voltage. `MCP\d+` swept up MCP6002 (op-amp), MCP23017 (GPIO), MCP2200 (USB-UART), MCP9808 (temp). Real MCP voltage-sensing parts are ADCs (MCP3xxx) already covered by the ADC pattern.
3. **`identify_filters` RC-low-pass** — skip when any of R's nets is a power rail. A pull-up R between VCC and SDA + unrelated decoupling cap on VCC was misclassified as rc_low_pass. Uses `utils.netlist_parser.is_power_net` (the canonical classifier).
4. **`identify_filters`** — removed `crystal_filter` classification. `identify_oscillators` classifies them as `crystal_oscillator` and double-classification was emitting the same component with two incompatible labels. `identify_oscillators` is now the single source of truth.

Plus an improvement (not a bug fix): `identify_digital_interfaces` now returns a `components` field per interface listing component refs whose pins touch the matched signal nets, plus the IC by ref for USB/Ethernet detection-by-value paths.

## Test plan

- [x] 990/990 tests pass (969 baseline + 23 new in `tests/test_pattern_recognition.py`, -2 deleted `test_crystal_filter_*_prefix` tests that pinned the removed behavior)
- [x] mypy clean
- [x] No dependencies added; independent of feedback infrastructure and any other in-flight work

## Notes for reviewer

Six new TestClasses pin each fix:
- `TestSensorMCPCollision` (6 tests) — MCP non-voltage-sensors not misclassified
- `TestOpAmpMCPOverMatch` (5 tests) — MCP non-op-amps not misclassified  
- `TestRCFilterPullupFalsePositive` (3 tests) — I²C pull-ups not flagged as RC filters
- `TestCrystalNotDoubleClassified` (3 tests) — crystals in oscillators only
- `TestDigitalInterfacesComponents` (3 tests) — interfaces include component refs
- `TestMCP6PatternBoundaries` (3 tests) — boundary cases for the narrowed pattern