### PR TITLE
feat(telemetry): implement feedback infrastructure

### DIFF
--- a/AGENT-INSTALL.md
+++ b/AGENT-INSTALL.md
@@ -4,7 +4,7 @@ This file is for you, the AI agent. It tells you what needs to be true on this s
 
 ## What This Is
 
-kicad-mcp is a Model Context Protocol (MCP) server providing 89 tools for KiCad electronic design automation — schematic capture, PCB layout, autorouting, DRC, and more. Once installed and registered, these tools appear in your tool list and you can design circuit boards conversationally.
+kicad-mcp is a Model Context Protocol (MCP) server providing 90 tools for KiCad electronic design automation — schematic capture, PCB layout, autorouting, DRC, and more. Once installed and registered, these tools appear in your tool list and you can design circuit boards conversationally.
 
 **Origin:** Built by one person for personal use, on a Mac, with Claude Code. Other platforms *should* work (the code handles macOS, Windows, and Linux) but are untested. PRs for other agents and platforms will be considered.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This tool enables your AI agent to use [KiCad](https://www.kicad.org/) — the i
 
 ## What This Does
 
-You describe what you need — "design a board for this ESP32 circuit" or "here's the schematic, lay out the PCB" — and your AI agent does the rest: drawing the schematic, choosing components, placing them on the board, routing traces, checking for errors, and producing manufacturing-ready files. All using the same KiCad that professional engineers use, with 89 tools covering the full design workflow.
+You describe what you need — "design a board for this ESP32 circuit" or "here's the schematic, lay out the PCB" — and your AI agent does the rest: drawing the schematic, choosing components, placing them on the board, routing traces, checking for errors, and producing manufacturing-ready files. All using the same KiCad that professional engineers use, with 90 tools covering the full design workflow.
 
 You don't need to know KiCad. You don't need to know what a PCB layout tool does. You just need an AI agent (like [Claude](https://claude.ai/)).
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1,5 +1,5 @@
 # Tool Summary
 
-This MCP server exposes 89 MCP tools for KiCad EDA.
+This MCP server exposes 90 MCP tools for KiCad EDA.
 
 See [README.md](README.md) for the full tool list and usage guide.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,14 @@ dependencies = [
     "pyyaml>=6.0.3",
     "defusedxml>=0.7.1",
     "python-multipart>=0.0.29",
+    "mcp-events>=0.1.0",
 ]
+
+[tool.uv.sources]
+# Local dev: use the workspace copy of mcp-events. CI / downstream users
+# resolve from PyPI per the version constraint above. kicad-mcp itself is
+# distributed via AGENT-INSTALL.md, not PyPI.
+mcp-events = { path = "/Volumes/Files/claude/mcp-events", editable = true }
 
 [project.scripts]
 kicad-mcp = "kicad_mcp.server:main"
@@ -103,4 +110,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["pandas", "defusedxml.*", "sexpdata"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# mcp-events 0.1.0 doesn't ship a py.typed marker yet. Remove this override
+# when the upstream package adds typing markers.
+module = ["mcp_events"]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,12 +36,6 @@ dependencies = [
     "mcp-events>=0.1.0",
 ]
 
-[tool.uv.sources]
-# Local dev: use the workspace copy of mcp-events. CI / downstream users
-# resolve from PyPI per the version constraint above. kicad-mcp itself is
-# distributed via AGENT-INSTALL.md, not PyPI.
-mcp-events = { path = "/Volumes/Files/claude/mcp-events", editable = true }
-
 [project.scripts]
 kicad-mcp = "kicad_mcp.server:main"
 

--- a/src/kicad_mcp/server.py
+++ b/src/kicad_mcp/server.py
@@ -60,6 +60,11 @@ def create_server() -> FastMCP:
 
     register_schematic_tools(mcp)
 
+    # Telemetry analyze tool (read-only access to feedback infrastructure)
+    from kicad_mcp.tools.telemetry_analyze import register_telemetry_analyze_tools
+
+    register_telemetry_analyze_tools(mcp)
+
     logger.info("KiCad MCP server initialized with all tool modules")
     return mcp
 

--- a/src/kicad_mcp/tools/telemetry_analyze.py
+++ b/src/kicad_mcp/tools/telemetry_analyze.py
@@ -1,0 +1,96 @@
+"""`analyze_placement_telemetry` MCP tool.
+
+Per `docs/SPEC_Feedback_Infrastructure.md`. Reads from the local telemetry DB
+populated by `kicad_mcp.utils.telemetry`. Read-only; does not write.
+
+Standalone tool (not behind a router). Telemetry is meta-operational and
+belongs at the top level alongside other utility tools.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastmcp import Context, FastMCP
+
+from kicad_mcp.utils import telemetry
+
+logger = logging.getLogger(__name__)
+
+
+_SUPPORTED_QUERIES = ("calibration_table", "convergence_stats", "system_events")
+
+
+def register_telemetry_analyze_tools(mcp: FastMCP) -> None:
+    """Register the `analyze_placement_telemetry` tool."""
+
+    @mcp.tool()
+    async def analyze_placement_telemetry(
+        query: str,
+        filters: dict[str, Any] | None = None,
+        verbosity: str = "minimal",
+        ctx: Context | None = None,
+    ) -> dict[str, Any]:
+        """Read telemetry data for calibration and convergence analysis.
+
+        Args:
+            query: One of `calibration_table`, `convergence_stats`, `system_events`.
+            filters: Query-specific filter dict (see below). All filters optional.
+            verbosity: `minimal` (default) for terse rows, `full` for additional
+                provenance fields.
+
+        Filter shapes per query:
+            calibration_table: {"warning_type": str, "since": ISO-8601}
+            convergence_stats: {"schematic_hash": str, "since": ISO-8601}
+            system_events:     {"severity": "info"|"warn"|"error", "unseen_only": bool,
+                                "since": ISO-8601, "limit": int}
+
+        Returns: {"status": "ok", "rows": [...]} or {"status": "error", "error": "..."}.
+        On a fresh install with no data, returns rows=[] (never errors).
+        """
+        if query not in _SUPPORTED_QUERIES:
+            return {
+                "status": "error",
+                "error": f"Unknown query {query!r}; supported: {list(_SUPPORTED_QUERIES)}",
+            }
+
+        if verbosity not in ("minimal", "full"):
+            return {
+                "status": "error",
+                "error": f"Unknown verbosity {verbosity!r}; supported: minimal, full",
+            }
+
+        f = filters or {}
+
+        try:
+            if query == "calibration_table":
+                rows = telemetry.query_calibration_table(
+                    warning_type=f.get("warning_type"),
+                    since=f.get("since"),
+                    include_samples=(verbosity == "full"),
+                )
+            elif query == "convergence_stats":
+                rows = telemetry.query_convergence_stats(
+                    schematic_hash=f.get("schematic_hash"),
+                    since=f.get("since"),
+                )
+            else:  # system_events
+                rows = telemetry.query_system_events(
+                    severity=f.get("severity"),
+                    unseen_only=bool(f.get("unseen_only", False)),
+                    since=f.get("since"),
+                    limit=int(f.get("limit", 100)),
+                )
+        except Exception as e:
+            logger.warning(f"analyze_placement_telemetry({query=}) failed: {e}")
+            if ctx:
+                await ctx.info(f"Query {query!r} failed: {e}")
+            return {"status": "error", "error": str(e)}
+
+        result: dict[str, Any] = {"status": "ok", "rows": rows}
+        if verbosity == "full":
+            result["query"] = query
+            result["filters_applied"] = f
+            result["row_count"] = len(rows)
+        return result

--- a/src/kicad_mcp/utils/telemetry.py
+++ b/src/kicad_mcp/utils/telemetry.py
@@ -1,0 +1,974 @@
+"""Telemetry persistence for kicad-mcp tools.
+
+Per `docs/SPEC_Feedback_Infrastructure.md`. Action-attribution + calibration
+measurement persisted to a local SQLite. Synchronous at call boundary; no
+daemon; safe under multi-process concurrency via SQLite file locking.
+
+Telemetry write failures are surfaced via `mcp_events.soft_failure` but never
+propagated to the calling tool's main behavior.
+
+Opt-out: set `KICAD_MCP_NO_TELEMETRY=1` to short-circuit all writes. Reads still
+work; the analyze tool returns empty rows on a fresh disable-then-read sequence.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+from collections.abc import Iterable
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from mcp_events import emit_event, soft_failure
+
+# --------------------------------------------------------------------------
+# Constants
+# --------------------------------------------------------------------------
+
+_SCHEMA_VERSION = 1
+_SCHEMA_SQL_PATH = Path(__file__).parent / "telemetry_schema.sql"
+_SWEEP_THROTTLE_SECONDS = 3600  # 1 hour
+_DEFAULT_MAX_AGE_DAYS = 7
+
+# --------------------------------------------------------------------------
+# Module-level state (paths and initialization tracking)
+# --------------------------------------------------------------------------
+
+_db_path_override: Path | None = None
+_init_lock = threading.Lock()
+_initialized_paths: set[Path] = set()
+
+
+# --------------------------------------------------------------------------
+# Opt-out and path resolution
+# --------------------------------------------------------------------------
+
+
+def _telemetry_disabled() -> bool:
+    """Check env var for opt-out. Cheap; checked on each write."""
+    return os.environ.get("KICAD_MCP_NO_TELEMETRY", "") == "1"
+
+
+def _resolve_db_path() -> Path:
+    """Resolve the telemetry DB path.
+
+    Test override (via `_reset_for_tests`) takes precedence; then `XDG_CACHE_HOME`;
+    then `~/.cache/kicad-mcp/telemetry.db`.
+    """
+    if _db_path_override is not None:
+        return _db_path_override
+
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".cache"
+    return base / "kicad-mcp" / "telemetry.db"
+
+
+# --------------------------------------------------------------------------
+# Connection management and schema migration
+# --------------------------------------------------------------------------
+
+
+def _connect_raw(db_path: Path) -> sqlite3.Connection:
+    """Open a raw connection without ensuring initialization."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _apply_schema(conn: sqlite3.Connection) -> None:
+    """Apply the schema SQL (idempotent via CREATE TABLE IF NOT EXISTS)."""
+    schema_sql = _SCHEMA_SQL_PATH.read_text()
+    conn.executescript(schema_sql)
+
+
+def _migrate_if_needed(conn: sqlite3.Connection) -> None:
+    """Apply migrations forward to `_SCHEMA_VERSION`. Idempotent."""
+    cur = conn.execute("SELECT MAX(version) FROM schema_version")
+    row = cur.fetchone()
+    current = row[0] if row and row[0] is not None else 0
+
+    if current >= _SCHEMA_VERSION:
+        return
+
+    # v0 → v1: initial schema; tables already created by _apply_schema.
+    # Just record the version.
+    if current == 0:
+        now_iso = _now_iso()
+        message = "Telemetry schema initialized at v1"
+        context = {"from_version": 0, "to_version": 1}
+        conn.execute(
+            "INSERT INTO schema_version (version, applied_at) VALUES (?, ?)",
+            (1, now_iso),
+        )
+        # Persist to system_events directly (inside the init's open conn — calling
+        # the fresh-conn persist helper here would deadlock on _init_lock).
+        conn.execute(
+            """INSERT INTO system_events (timestamp, severity, code, message, context)
+               VALUES (?, ?, ?, ?, ?)""",
+            (now_iso, "info", "telemetry_schema_migrated", message, json.dumps(context)),
+        )
+        conn.commit()
+        emit_event("info", "telemetry_schema_migrated", message, context)
+    # Future versions: add elif branches here as the schema evolves.
+
+
+def _ensure_initialized(db_path: Path) -> bool:
+    """Ensure the schema is applied for this path. Returns True on success."""
+    if db_path in _initialized_paths:
+        return True
+
+    with _init_lock:
+        if db_path in _initialized_paths:
+            return True
+
+        try:
+            db_path.parent.mkdir(parents=True, exist_ok=True)
+            conn = _connect_raw(db_path)
+            try:
+                _apply_schema(conn)
+                _migrate_if_needed(conn)
+            finally:
+                conn.close()
+            _initialized_paths.add(db_path)
+            return True
+        except Exception as e:
+            soft_failure(
+                "telemetry_init_failed",
+                f"Failed to initialize telemetry DB at {db_path}: {e}",
+                {"db_path": str(db_path)},
+            )
+            return False
+
+
+def _connect() -> sqlite3.Connection | None:
+    """Open a connection to the initialized DB. Returns None on failure or opt-out."""
+    if _telemetry_disabled():
+        return None
+    db_path = _resolve_db_path()
+    if not _ensure_initialized(db_path):
+        return None
+    try:
+        return _connect_raw(db_path)
+    except Exception as e:
+        soft_failure(
+            "telemetry_connect_failed",
+            f"Failed to connect to telemetry DB: {e}",
+            {"db_path": str(db_path)},
+        )
+        return None
+
+
+def _connect_for_read() -> sqlite3.Connection | None:
+    """Open a connection for read-only operations.
+
+    Unlike `_connect`, this ignores the opt-out env var — reads still work
+    even when writes are disabled. Schema is still migrated on first read.
+    """
+    db_path = _resolve_db_path()
+    if not _ensure_initialized(db_path):
+        return None
+    try:
+        return _connect_raw(db_path)
+    except Exception as e:
+        soft_failure(
+            "telemetry_connect_failed",
+            f"Failed to connect to telemetry DB for read: {e}",
+            {"db_path": str(db_path)},
+        )
+        return None
+
+
+# --------------------------------------------------------------------------
+# Time helper
+# --------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    """ISO-8601 timestamp in UTC."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+# --------------------------------------------------------------------------
+# Event persistence helper (system_events table)
+# --------------------------------------------------------------------------
+
+
+def _persist_event(
+    severity: str, code: str, message: str, context: dict[str, Any] | None = None
+) -> None:
+    """Best-effort write of an event to the `system_events` table.
+
+    Opens a fresh connection. Skipped when:
+    - Telemetry is disabled (opt-out)
+    - The DB isn't initialized yet (avoids recursion through `_ensure_initialized`)
+    - Any exception (best-effort; never raises)
+
+    Used by `_emit_soft_failure` to persist warn events. Migration and sweep
+    events persist directly via their own open connections (no fresh-conn
+    helper) to stay inside the existing init/sweep transaction.
+    """
+    if _telemetry_disabled():
+        return
+    db_path = _resolve_db_path()
+    if db_path not in _initialized_paths:
+        return
+    try:
+        conn = _connect_raw(db_path)
+        try:
+            with conn:
+                conn.execute(
+                    """INSERT INTO system_events
+                       (timestamp, severity, code, message, context)
+                       VALUES (?, ?, ?, ?, ?)""",
+                    (
+                        _now_iso(),
+                        severity,
+                        code,
+                        message,
+                        json.dumps(context) if context else None,
+                    ),
+                )
+        finally:
+            conn.close()
+    except Exception:
+        pass
+
+
+def _emit_soft_failure(
+    code: str, message: str, context: dict[str, Any] | None = None
+) -> None:
+    """Emit a warn-severity event via both mcp_events AND `system_events` persistence.
+
+    Use this for telemetry's own failures during normal operation (write paths,
+    read paths). Do NOT use during init — `_ensure_initialized` should use
+    plain `soft_failure` because the DB might not exist yet.
+    """
+    soft_failure(code, message, context)
+    _persist_event("warn", code, message, context)
+
+
+# --------------------------------------------------------------------------
+# Public write API
+# --------------------------------------------------------------------------
+
+
+def record_call(
+    tool_name: str,
+    schematic_hash: str,
+    inputs_summary: dict[str, Any],
+    output_summary: dict[str, Any] | None = None,
+    elapsed_ms: int = 0,
+    phase_breakdown_ms: dict[str, int] | None = None,
+    state_id: str | None = None,
+    is_fresh_state: bool = True,
+    kicad_cli_version: str | None = None,
+    netlist_schema_hash: str | None = None,
+) -> int | None:
+    """Record one call. Returns the new `call_id`, or None on failure/opt-out.
+
+    `iteration_index` is auto-computed by counting prior calls on this `schematic_hash`.
+    Opportunistic sweep runs if the throttle interval has elapsed.
+    """
+    conn = _connect()
+    if conn is None:
+        return None
+
+    try:
+        with conn:
+            cur = conn.execute(
+                "SELECT COUNT(*) FROM calls WHERE schematic_hash = ?",
+                (schematic_hash,),
+            )
+            row = cur.fetchone()
+            iteration_index = row[0] if row else 0
+
+            cur = conn.execute(
+                """INSERT INTO calls
+                   (tool_name, schematic_hash, timestamp, iteration_index,
+                    state_id, is_fresh_state, inputs_summary, output_summary,
+                    elapsed_ms, phase_breakdown_ms, kicad_cli_version,
+                    netlist_schema_hash)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    tool_name,
+                    schematic_hash,
+                    _now_iso(),
+                    iteration_index,
+                    state_id,
+                    1 if is_fresh_state else 0,
+                    json.dumps(inputs_summary, sort_keys=True),
+                    json.dumps(output_summary, sort_keys=True) if output_summary else None,
+                    elapsed_ms,
+                    json.dumps(phase_breakdown_ms, sort_keys=True)
+                    if phase_breakdown_ms
+                    else None,
+                    kicad_cli_version,
+                    netlist_schema_hash,
+                ),
+            )
+            call_id = cur.lastrowid
+
+            _maybe_sweep(conn)
+
+            return call_id
+    except Exception as e:
+        _emit_soft_failure(
+            "telemetry_write_failed",
+            f"record_call failed: {e}",
+            {"tool_name": tool_name, "schematic_hash": schematic_hash},
+        )
+        return None
+    finally:
+        conn.close()
+
+
+def record_cluster_decision(
+    call_id: int,
+    cluster_id: str,
+    member_count: int,
+    anchor_ref: str | None,
+    label: str | None,
+    label_confidence: float | None,
+    label_source: str,
+    tier: int | None,
+    louvain_modularity: float | None,
+) -> None:
+    """Record a cluster decision for the given call."""
+    conn = _connect()
+    if conn is None:
+        return
+
+    try:
+        with conn:
+            conn.execute(
+                """INSERT INTO cluster_decisions
+                   (call_id, cluster_id, member_count, anchor_ref, label,
+                    label_confidence, label_source, tier, louvain_modularity)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    call_id,
+                    cluster_id,
+                    member_count,
+                    anchor_ref,
+                    label,
+                    label_confidence,
+                    label_source,
+                    tier,
+                    louvain_modularity,
+                ),
+            )
+    except Exception as e:
+        _emit_soft_failure(
+            "telemetry_write_failed",
+            f"record_cluster_decision failed: {e}",
+            {"call_id": call_id, "cluster_id": cluster_id},
+        )
+    finally:
+        conn.close()
+
+
+def record_warning(
+    call_id: int,
+    warning_type: str,
+    severity: str,
+    affected_refs: list[str],
+    affected_cluster_ids: list[str],
+) -> None:
+    """Record a warning emitted during a call.
+
+    Validation: at least one of `affected_refs` or `affected_cluster_ids` must
+    be non-empty. A warning with no targets has no way to be matched against
+    caller actions. If both are empty, the function emits a `soft_failure`
+    event (code `warning_emit_invalid`) and skips the insert — catches bad
+    emitter code at the source.
+    """
+    if not affected_refs and not affected_cluster_ids:
+        _emit_soft_failure(
+            "warning_emit_invalid",
+            (
+                f"record_warning rejected: no affected refs or clusters for "
+                f"warning_type={warning_type!r}"
+            ),
+            {"call_id": call_id, "warning_type": warning_type},
+        )
+        return
+
+    conn = _connect()
+    if conn is None:
+        return
+
+    try:
+        with conn:
+            conn.execute(
+                """INSERT INTO warnings_emitted
+                   (call_id, warning_type, severity, affected_refs,
+                    affected_cluster_ids, status)
+                   VALUES (?, ?, ?, ?, ?, 'pending')""",
+                (
+                    call_id,
+                    warning_type,
+                    severity,
+                    json.dumps(affected_refs),
+                    json.dumps(affected_cluster_ids),
+                ),
+            )
+    except Exception as e:
+        _emit_soft_failure(
+            "telemetry_write_failed",
+            f"record_warning failed: {e}",
+            {"call_id": call_id, "warning_type": warning_type},
+        )
+    finally:
+        conn.close()
+
+
+# --------------------------------------------------------------------------
+# Action attribution
+# --------------------------------------------------------------------------
+
+
+def attribute_pending_warnings(
+    schematic_hash: str,
+    new_call_id: int,
+    inputs: dict[str, Any],
+) -> int:
+    """Match pending warnings on this schematic to actions in the call's inputs.
+
+    `inputs` is the RAW caller payload (the kwargs passed to suggest_placement),
+    NOT the inputs_summary. The matching logic walks the actual structure of
+    hints / cluster_assignments / fixed_positions to compare against
+    affected_refs.
+
+    Returns count of newly-addressed warnings. 0 if telemetry disabled or
+    DB unavailable.
+    """
+    conn = _connect()
+    if conn is None:
+        return 0
+
+    try:
+        with conn:
+            cur = conn.execute(
+                """SELECT w.warning_id, w.affected_refs, w.affected_cluster_ids
+                   FROM warnings_emitted w
+                   JOIN calls c ON w.call_id = c.call_id
+                   WHERE c.schematic_hash = ?
+                     AND w.status = 'pending'""",
+                (schematic_hash,),
+            )
+            pending = cur.fetchall()
+
+            count = 0
+            now = _now_iso()
+            for row in pending:
+                refs = set(json.loads(row["affected_refs"]))
+                cluster_ids = set(json.loads(row["affected_cluster_ids"]))
+
+                how = _match_attribution(refs, cluster_ids, inputs)
+                if how is not None:
+                    conn.execute(
+                        """UPDATE warnings_emitted
+                           SET status = 'addressed',
+                               addressed_in_call_id = ?,
+                               addressed_how = ?,
+                               addressed_at = ?
+                           WHERE warning_id = ?""",
+                        (new_call_id, how, now, row["warning_id"]),
+                    )
+                    count += 1
+            return count
+    except Exception as e:
+        _emit_soft_failure(
+            "telemetry_write_failed",
+            f"attribute_pending_warnings failed: {e}",
+            {"schematic_hash": schematic_hash, "new_call_id": new_call_id},
+        )
+        return 0
+    finally:
+        conn.close()
+
+
+def _match_attribution(
+    affected_refs: set[str],
+    affected_cluster_ids: set[str],
+    inputs: dict[str, Any],
+) -> str | None:
+    """Return the `addressed_how` value if inputs address the warning, else None.
+
+    First-match-wins in this priority order:
+      1. hints (most direct semantic signal)
+      2. cluster_assignments (structural override)
+      3. fixed_positions (positional override)
+
+    Note: cluster_ids match falls back to ref-membership because cluster_ids
+    may drift across fresh-state calls.
+    """
+    hints = inputs.get("hints") or {}
+    if isinstance(hints, dict) and any(ref in affected_refs for ref in hints):
+        return "hint"
+
+    cluster_assignments = inputs.get("cluster_assignments") or {}
+    if isinstance(cluster_assignments, dict):
+        assigned_refs: set[str] = set()
+        for refs_list in cluster_assignments.values():
+            if isinstance(refs_list, (list, tuple, set)):
+                assigned_refs.update(refs_list)
+        if affected_refs & assigned_refs:
+            return "cluster_assignment"
+
+    fixed_positions = inputs.get("fixed_positions") or {}
+    if isinstance(fixed_positions, dict) and any(
+        ref in affected_refs for ref in fixed_positions
+    ):
+        return "fixed_position"
+
+    return None
+
+
+# --------------------------------------------------------------------------
+# Abandonment sweep
+# --------------------------------------------------------------------------
+
+
+def sweep_abandoned(max_age_days: int = _DEFAULT_MAX_AGE_DAYS) -> int:
+    """Mark pending warnings older than `max_age_days` as 'abandoned'.
+
+    Also abandons warnings whose schematic had a subsequent fresh-state call.
+    Returns count of newly-abandoned warnings.
+    """
+    conn = _connect()
+    if conn is None:
+        return 0
+
+    try:
+        with conn:
+            return _do_sweep(conn, max_age_days)
+    except Exception as e:
+        _emit_soft_failure(
+            "telemetry_write_failed",
+            f"sweep_abandoned failed: {e}",
+            {},
+        )
+        return 0
+    finally:
+        conn.close()
+
+
+def _do_sweep(conn: sqlite3.Connection, max_age_days: int) -> int:
+    """Sweep implementation; runs inline on the given connection."""
+    now = datetime.now(timezone.utc)
+    now_iso = now.isoformat()
+    cutoff_iso = (now - timedelta(days=max_age_days)).isoformat()
+
+    # Age cutoff: non-strict (warning at exactly max_age_days → abandoned,
+    # matching the SPEC's boundary semantics).
+    cur = conn.execute(
+        """UPDATE warnings_emitted
+           SET status = 'abandoned', addressed_at = ?
+           WHERE status = 'pending'
+             AND call_id IN (
+               SELECT call_id FROM calls WHERE timestamp <= ?
+             )""",
+        (now_iso, cutoff_iso),
+    )
+    count_age = cur.rowcount
+
+    # Fresh-state reset
+    cur = conn.execute(
+        """UPDATE warnings_emitted
+           SET status = 'abandoned', addressed_at = ?
+           WHERE status = 'pending'
+             AND warning_id IN (
+               SELECT w.warning_id
+               FROM warnings_emitted w
+               JOIN calls c_emit ON w.call_id = c_emit.call_id
+               JOIN calls c_later ON c_later.schematic_hash = c_emit.schematic_hash
+                                  AND c_later.timestamp > c_emit.timestamp
+                                  AND c_later.is_fresh_state = 1
+             )""",
+        (now_iso,),
+    )
+    count_reset = cur.rowcount
+
+    # Update sweep state
+    conn.execute(
+        """INSERT OR REPLACE INTO sweep_state (id, last_sweep_at)
+           VALUES (1, ?)""",
+        (now_iso,),
+    )
+
+    total = count_age + count_reset
+    if total > 0:
+        message = (
+            f"Abandoned {total} pending warnings "
+            f"({count_age} aged out, {count_reset} fresh-state reset)"
+        )
+        context = {"aged_out": count_age, "fresh_state_reset": count_reset}
+        # Persist via the open conn (no fresh-conn helper here — same reason
+        # as _migrate_if_needed: stay in the existing transaction).
+        conn.execute(
+            """INSERT INTO system_events (timestamp, severity, code, message, context)
+               VALUES (?, ?, ?, ?, ?)""",
+            (now_iso, "info", "telemetry_sweep_completed", message, json.dumps(context)),
+        )
+        emit_event("info", "telemetry_sweep_completed", message, context)
+    return total
+
+
+def _maybe_sweep(conn: sqlite3.Connection) -> None:
+    """Opportunistic sweep called inline from `record_call`.
+
+    Throttled by `_SWEEP_THROTTLE_SECONDS`. Runs in the same connection (no
+    extra lock contention). Failures are swallowed — sweep is best-effort.
+    """
+    try:
+        cur = conn.execute("SELECT last_sweep_at FROM sweep_state WHERE id = 1")
+        row = cur.fetchone()
+        now = datetime.now(timezone.utc)
+
+        if row is None:
+            # Initialize sweep_state; no warnings to sweep on first call.
+            conn.execute(
+                "INSERT INTO sweep_state (id, last_sweep_at) VALUES (1, ?)",
+                (now.isoformat(),),
+            )
+            return
+
+        last_iso = row[0]
+        if not last_iso:
+            return
+
+        last = datetime.fromisoformat(last_iso)
+        if (now - last).total_seconds() < _SWEEP_THROTTLE_SECONDS:
+            return
+
+        _do_sweep(conn, _DEFAULT_MAX_AGE_DAYS)
+    except Exception:
+        # Sweep is opportunistic; never propagate.
+        pass
+
+
+# --------------------------------------------------------------------------
+# Public read API (used by analyze_placement_telemetry tool)
+# --------------------------------------------------------------------------
+
+
+def query_calibration_table(
+    warning_type: str | None = None,
+    since: str | None = None,
+    include_samples: bool = False,
+) -> list[dict[str, Any]]:
+    """Return per (warning_type, confidence_bucket) action-rate rows.
+
+    Buckets: [0.0, 0.2), [0.2, 0.4), [0.4, 0.6), [0.6, 0.8), [0.8, 1.0],
+    plus "none" for warnings whose affected clusters had no confidence recorded.
+
+    `action_rate = addressed / (addressed + abandoned)`; null if denominator is 0.
+
+    When `include_samples=True`, each row gains a `sample_warnings` list of up
+    to 3 `{"warning_id", "call_id"}` entries for drilling in. Used by the
+    analyze tool when `verbosity="full"`.
+    """
+    conn = _connect_for_read()
+    if conn is None:
+        return []
+
+    try:
+        # Collect all warnings with their best-available confidence
+        # (max label_confidence across affected_cluster_ids in the same call,
+        # else "none").
+        sql = """
+        SELECT
+          w.warning_id,
+          w.warning_type,
+          w.status,
+          w.affected_cluster_ids,
+          w.call_id,
+          (SELECT MAX(cd.label_confidence)
+             FROM cluster_decisions cd
+             WHERE cd.call_id = w.call_id
+               AND cd.cluster_id IN (
+                 SELECT value FROM json_each(w.affected_cluster_ids)
+               )) AS confidence
+        FROM warnings_emitted w
+        WHERE 1=1
+        """
+        params: list[Any] = []
+        if warning_type:
+            sql += " AND w.warning_type = ?"
+            params.append(warning_type)
+        if since:
+            sql += " AND w.call_id IN (SELECT call_id FROM calls WHERE timestamp >= ?)"
+            params.append(since)
+
+        cur = conn.execute(sql, params)
+        rows = cur.fetchall()
+
+        # Bucket the warnings
+        buckets: dict[tuple[str, str], dict[str, Any]] = {}
+        for r in rows:
+            bucket = _confidence_bucket(r["confidence"])
+            key = (r["warning_type"], bucket)
+            if key not in buckets:
+                buckets[key] = {
+                    "emitted": 0,
+                    "addressed": 0,
+                    "abandoned": 0,
+                    "pending": 0,
+                    "samples": [],
+                }
+            buckets[key]["emitted"] += 1
+            status = r["status"]
+            if status in buckets[key]:
+                buckets[key][status] += 1
+            samples = buckets[key]["samples"]
+            if len(samples) < 3:
+                samples.append({"warning_id": r["warning_id"], "call_id": r["call_id"]})
+
+        # Format output
+        out: list[dict[str, Any]] = []
+        for (wt, bucket), counts in sorted(buckets.items()):
+            terminal = counts["addressed"] + counts["abandoned"]
+            action_rate: float | None
+            action_rate = (counts["addressed"] / terminal) if terminal > 0 else None
+            row: dict[str, Any] = {
+                "warning_type": wt,
+                "confidence_bucket": bucket,
+                "emitted": counts["emitted"],
+                "addressed": counts["addressed"],
+                "abandoned": counts["abandoned"],
+                "pending": counts["pending"],
+                "action_rate": action_rate,
+            }
+            if include_samples:
+                row["sample_warnings"] = counts["samples"]
+            out.append(row)
+        return out
+    except Exception as e:
+        _emit_soft_failure(
+            "telemetry_read_failed",
+            f"query_calibration_table failed: {e}",
+            {},
+        )
+        return []
+    finally:
+        conn.close()
+
+
+def _confidence_bucket(confidence: float | None) -> str:
+    """Map a confidence value to a bucket label."""
+    if confidence is None:
+        return "none"
+    if confidence < 0.2:
+        return "0.0-0.2"
+    if confidence < 0.4:
+        return "0.2-0.4"
+    if confidence < 0.6:
+        return "0.4-0.6"
+    if confidence < 0.8:
+        return "0.6-0.8"
+    return "0.8-1.0"
+
+
+def query_convergence_stats(
+    schematic_hash: str | None = None,
+    since: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return per-schematic convergence stats: iterations, warnings, reemissions."""
+    conn = _connect_for_read()
+    if conn is None:
+        return []
+
+    try:
+        sql = """
+        SELECT
+          schematic_hash,
+          COUNT(*) AS iterations,
+          MIN(timestamp) AS first_call_at,
+          MAX(timestamp) AS last_call_at
+        FROM calls
+        WHERE 1=1
+        """
+        params: list[Any] = []
+        if schematic_hash:
+            sql += " AND schematic_hash = ?"
+            params.append(schematic_hash)
+        if since:
+            sql += " AND timestamp >= ?"
+            params.append(since)
+        sql += " GROUP BY schematic_hash ORDER BY last_call_at DESC"
+
+        cur = conn.execute(sql, params)
+        schematics = cur.fetchall()
+
+        out: list[dict[str, Any]] = []
+        for s in schematics:
+            sh = s["schematic_hash"]
+            # Count emitted warnings on this schematic
+            cur = conn.execute(
+                """SELECT COUNT(*) FROM warnings_emitted w
+                   JOIN calls c ON w.call_id = c.call_id
+                   WHERE c.schematic_hash = ?""",
+                (sh,),
+            )
+            row = cur.fetchone()
+            warnings_emitted_count = row[0] if row else 0
+
+            # Count reemissions: same warning_type appearing in multiple calls
+            # with overlapping affected_refs.
+            reemits = _count_reemissions_for_schematic(conn, sh)
+
+            out.append(
+                {
+                    "schematic_hash": sh,
+                    "iterations": s["iterations"],
+                    "warnings_emitted": warnings_emitted_count,
+                    "warnings_reemitted": reemits,
+                    "first_call_at": s["first_call_at"],
+                    "last_call_at": s["last_call_at"],
+                }
+            )
+        return out
+    except Exception as e:
+        _emit_soft_failure(
+            "telemetry_read_failed",
+            f"query_convergence_stats failed: {e}",
+            {},
+        )
+        return []
+    finally:
+        conn.close()
+
+
+def _count_reemissions(warning_chains: Iterable[tuple[str, set[str]]]) -> int:
+    """Count re-emissions from a chain of (warning_type, affected_refs) tuples.
+
+    Pure function — no DB dependency, directly unit-testable. The input must
+    be ordered by emission time within each `warning_type`. A warning is a
+    re-emission if it shares ≥1 affected_ref with the most-recent earlier
+    warning of the same type; each row counted at most once.
+
+    For a chain of three overlapping warnings W1=[U1,U2], W2=[U2,U3], W3=[U3,U4]:
+    W2 reemits W1, W3 reemits W2 → result is 2, not 3 (W1 is not double-counted).
+    """
+    count = 0
+    last_refs_by_type: dict[str, set[str]] = {}
+    for wt, refs in warning_chains:
+        prev = last_refs_by_type.get(wt)
+        if prev is not None and refs & prev:
+            count += 1
+        last_refs_by_type[wt] = refs
+    return count
+
+
+def _count_reemissions_for_schematic(conn: sqlite3.Connection, schematic_hash: str) -> int:
+    """Fetch the warning chain for a schematic and count re-emissions.
+
+    Thin DB wrapper around the pure `_count_reemissions` helper.
+    """
+    cur = conn.execute(
+        """SELECT w.warning_type, w.affected_refs
+           FROM warnings_emitted w
+           JOIN calls c ON w.call_id = c.call_id
+           WHERE c.schematic_hash = ?
+           ORDER BY w.warning_type, c.timestamp""",
+        (schematic_hash,),
+    )
+    chains = (
+        (r["warning_type"], set(json.loads(r["affected_refs"]))) for r in cur.fetchall()
+    )
+    return _count_reemissions(chains)
+
+
+def query_system_events(
+    severity: str | None = None,
+    unseen_only: bool = False,
+    since: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Return recent system events, flipping `seen=1` on returned rows.
+
+    Errors are returned regardless of `seen` unless the caller explicitly filters.
+    """
+    conn = _connect_for_read()
+    if conn is None:
+        return []
+
+    try:
+        sql = "SELECT * FROM system_events WHERE 1=1"
+        params: list[Any] = []
+        if severity:
+            sql += " AND severity = ?"
+            params.append(severity)
+        if unseen_only:
+            sql += " AND (seen = 0 OR severity = 'error')"
+        if since:
+            sql += " AND timestamp >= ?"
+            params.append(since)
+        sql += " ORDER BY timestamp DESC LIMIT ?"
+        params.append(int(limit))
+
+        cur = conn.execute(sql, params)
+        rows = cur.fetchall()
+
+        out: list[dict[str, Any]] = []
+        ids_to_mark: list[int] = []
+        for r in rows:
+            out.append(
+                {
+                    "event_id": r["event_id"],
+                    "timestamp": r["timestamp"],
+                    "severity": r["severity"],
+                    "code": r["code"],
+                    "message": r["message"],
+                    "context": json.loads(r["context"]) if r["context"] else None,
+                    "seen": bool(r["seen"]),
+                }
+            )
+            if not r["seen"]:
+                ids_to_mark.append(r["event_id"])
+
+        # Flip seen=1 for newly-returned rows
+        if ids_to_mark:
+            try:
+                with conn:
+                    placeholders = ",".join("?" * len(ids_to_mark))
+                    conn.execute(
+                        f"UPDATE system_events SET seen = 1 WHERE event_id IN ({placeholders})",
+                        ids_to_mark,
+                    )
+            except Exception:
+                # Mark-as-seen is best-effort; don't fail the read
+                pass
+
+        return out
+    except Exception as e:
+        _emit_soft_failure(
+            "telemetry_read_failed",
+            f"query_system_events failed: {e}",
+            {},
+        )
+        return []
+    finally:
+        conn.close()
+
+
+# --------------------------------------------------------------------------
+# Test helpers (not part of public API surface, but importable for tests)
+# --------------------------------------------------------------------------
+
+
+def _reset_for_tests(db_path_override: Path | None = None) -> None:
+    """Reset module state for clean test isolation.
+
+    Pass a `db_path_override` (e.g. a tmp_path Path) to redirect the DB
+    location. Clears the initialized-paths cache so the override takes effect.
+    """
+    global _db_path_override
+    _db_path_override = db_path_override
+    _initialized_paths.clear()

--- a/src/kicad_mcp/utils/telemetry_schema.sql
+++ b/src/kicad_mcp/utils/telemetry_schema.sql
@@ -1,0 +1,96 @@
+-- Telemetry schema v1 — see docs/SPEC_Feedback_Infrastructure.md
+-- Applied lazily on first DB connection per process.
+
+CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER PRIMARY KEY,
+    applied_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS calls (
+    call_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tool_name TEXT NOT NULL,
+    schematic_hash TEXT NOT NULL,
+    timestamp TEXT NOT NULL,
+
+    -- Iteration tracking (within a schematic)
+    iteration_index INTEGER NOT NULL,
+    state_id TEXT,
+    is_fresh_state INTEGER NOT NULL,
+
+    -- Inputs (terse summary, not full payload)
+    inputs_summary TEXT NOT NULL,
+    output_summary TEXT,
+
+    -- Performance
+    elapsed_ms INTEGER NOT NULL,
+    phase_breakdown_ms TEXT,
+
+    -- Environment
+    kicad_cli_version TEXT,
+    netlist_schema_hash TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_calls_schematic ON calls(schematic_hash, timestamp);
+CREATE INDEX IF NOT EXISTS idx_calls_tool ON calls(tool_name, timestamp);
+
+CREATE TABLE IF NOT EXISTS cluster_decisions (
+    decision_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    call_id INTEGER NOT NULL REFERENCES calls(call_id),
+    cluster_id TEXT NOT NULL,
+
+    member_count INTEGER NOT NULL,
+    anchor_ref TEXT,
+
+    label TEXT,
+    label_confidence REAL,
+    label_source TEXT,
+
+    tier INTEGER,
+    louvain_modularity REAL
+);
+
+CREATE INDEX IF NOT EXISTS idx_cluster_call ON cluster_decisions(call_id);
+
+CREATE TABLE IF NOT EXISTS warnings_emitted (
+    warning_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    call_id INTEGER NOT NULL REFERENCES calls(call_id),
+
+    warning_type TEXT NOT NULL,
+    severity TEXT NOT NULL,
+    affected_refs TEXT NOT NULL,
+    affected_cluster_ids TEXT NOT NULL,
+
+    -- Action attribution (synchronously updated)
+    status TEXT NOT NULL DEFAULT 'pending',
+    addressed_in_call_id INTEGER REFERENCES calls(call_id),
+    addressed_how TEXT,
+    addressed_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_warnings_pending
+    ON warnings_emitted(status, call_id)
+    WHERE status = 'pending';
+CREATE INDEX IF NOT EXISTS idx_warnings_type
+    ON warnings_emitted(warning_type, status);
+
+CREATE TABLE IF NOT EXISTS system_events (
+    event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TEXT NOT NULL,
+    severity TEXT NOT NULL,
+    code TEXT NOT NULL,
+    message TEXT NOT NULL,
+    context TEXT,
+    seen INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_system_events_unseen
+    ON system_events(seen, timestamp);
+CREATE INDEX IF NOT EXISTS idx_system_events_severity
+    ON system_events(severity, timestamp);
+
+CREATE TABLE IF NOT EXISTS sweep_state (
+    -- Single-row table holding the timestamp of the last sweep_abandoned run.
+    -- Used to throttle sweep frequency.
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    last_sweep_at TEXT
+);

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -33,8 +33,8 @@ class TestCreateServer:
         Target: 14 tools. Current count tracks the in-progress migration.
         """
         tools = asyncio.run(mcp_server.list_tools())
-        assert len(tools) == 89, (
-            f"Expected 89 tools, got {len(tools)}. "
+        assert len(tools) == 90, (
+            f"Expected 90 tools, got {len(tools)}. "
             "Update this test if tools were intentionally added or removed."
         )
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,1037 @@
+"""Tests for the telemetry persistence module.
+
+Per docs/SPEC_Feedback_Infrastructure.md "Testing strategy" section.
+No KiCad installation required; all tests use synthetic fixtures and a
+per-test SQLite DB via the tmp_path fixture.
+
+Style follows tests/test_geometry.py: one TestClass per logical area,
+descriptive method names, docstrings for non-obvious assertions.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from kicad_mcp.utils import telemetry
+from kicad_mcp.utils.telemetry import (
+    _confidence_bucket,
+    _count_reemissions,
+    attribute_pending_warnings,
+    query_calibration_table,
+    query_convergence_stats,
+    query_system_events,
+    record_call,
+    record_cluster_decision,
+    record_warning,
+    sweep_abandoned,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Redirect the telemetry DB to a fresh tmp_path for each test.
+
+    autouse=True so every test in this module gets isolation without
+    having to declare the fixture explicitly.  Clears the env var so
+    opt-out tests can flip it on without leaking state.
+    """
+    db = tmp_path / "telemetry.db"
+    monkeypatch.delenv("KICAD_MCP_NO_TELEMETRY", raising=False)
+    telemetry._reset_for_tests(db_path_override=db)
+    yield db
+    # Ensure the override is cleared even if the test raises
+    telemetry._reset_for_tests(db_path_override=None)
+
+
+def _make_call(
+    schematic_hash: str = "abc123",
+    tool_name: str = "suggest_schematic_placement",
+    inputs_summary: dict | None = None,
+    is_fresh_state: bool = True,
+) -> int:
+    """Convenience wrapper: record a synthetic call and return its call_id."""
+    call_id = record_call(
+        tool_name=tool_name,
+        schematic_hash=schematic_hash,
+        inputs_summary=inputs_summary or {"hints": {"count": 0}},
+        is_fresh_state=is_fresh_state,
+    )
+    assert call_id is not None, "record_call returned None — telemetry may be disabled"
+    return call_id
+
+
+def _set_call_timestamp(db: Path, call_id: int, ts: str) -> None:
+    """Directly rewrite a call's timestamp for sweep-age tests."""
+    conn = sqlite3.connect(str(db))
+    conn.execute("UPDATE calls SET timestamp = ? WHERE call_id = ?", (ts, call_id))
+    conn.commit()
+    conn.close()
+
+
+def _set_last_sweep(db: Path, ts: str) -> None:
+    """Directly rewrite sweep_state.last_sweep_at for throttle-boundary tests."""
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "INSERT OR REPLACE INTO sweep_state (id, last_sweep_at) VALUES (1, ?)", (ts,)
+    )
+    conn.commit()
+    conn.close()
+
+
+def _query_warning_status(db: Path, warning_id: int) -> str:
+    conn = sqlite3.connect(str(db))
+    row = conn.execute(
+        "SELECT status FROM warnings_emitted WHERE warning_id = ?", (warning_id,)
+    ).fetchone()
+    conn.close()
+    return row[0] if row else "NOT_FOUND"
+
+
+def _count_warnings(db: Path) -> int:
+    conn = sqlite3.connect(str(db))
+    row = conn.execute("SELECT COUNT(*) FROM warnings_emitted").fetchone()
+    conn.close()
+    return row[0] if row else 0
+
+
+def _now_minus(days: float = 0, hours: float = 0, minutes: float = 0, seconds: float = 0) -> str:
+    """Return an ISO-8601 timestamp offset back from now."""
+    delta = timedelta(days=days, hours=hours, minutes=minutes, seconds=seconds)
+    return (datetime.now(timezone.utc) - delta).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# TestAttribution
+# ---------------------------------------------------------------------------
+
+
+class TestAttribution:
+    def test_hint_matches_affected_ref_marks_addressed(self, isolated_db: Path):
+        """A hint whose key is in affected_refs → status='addressed', how='hint'."""
+        call_id = _make_call("h1")
+        record_warning(call_id, "orphan", "warn", ["U1", "U2"], [])
+
+        call_id2 = _make_call("h1", is_fresh_state=False)
+        inputs = {"hints": {"U1": {"region": "top"}}}
+        addressed = attribute_pending_warnings("h1", call_id2, inputs)
+
+        assert addressed == 1
+        conn = sqlite3.connect(str(isolated_db))
+        row = conn.execute(
+            "SELECT status, addressed_how FROM warnings_emitted"
+        ).fetchone()
+        conn.close()
+        assert row[0] == "addressed"
+        assert row[1] == "hint"
+
+    def test_hint_on_unrelated_ref_stays_pending(self, isolated_db: Path):
+        """A hint whose key does NOT appear in affected_refs → warning stays pending."""
+        call_id = _make_call("h2")
+        record_warning(call_id, "orphan", "warn", ["U3"], [])
+
+        call_id2 = _make_call("h2", is_fresh_state=False)
+        inputs = {"hints": {"R1": {}}}  # R1 not in affected_refs
+        addressed = attribute_pending_warnings("h2", call_id2, inputs)
+
+        assert addressed == 0
+        conn = sqlite3.connect(str(isolated_db))
+        row = conn.execute("SELECT status FROM warnings_emitted").fetchone()
+        conn.close()
+        assert row[0] == "pending"
+
+    def test_cluster_assignment_overlapping_refs_matches(self, isolated_db: Path):
+        """cluster_assignments whose value list overlaps affected_refs → 'cluster_assignment'."""
+        call_id = _make_call("h3")
+        record_warning(call_id, "bus_bridge", "warn", ["U4", "U5"], ["c0"])
+
+        call_id2 = _make_call("h3", is_fresh_state=False)
+        # U4 appears in cluster_assignments value list
+        inputs = {"cluster_assignments": {"c0": ["U4", "R10"]}}
+        addressed = attribute_pending_warnings("h3", call_id2, inputs)
+
+        assert addressed == 1
+        conn = sqlite3.connect(str(isolated_db))
+        row = conn.execute("SELECT addressed_how FROM warnings_emitted").fetchone()
+        conn.close()
+        assert row[0] == "cluster_assignment"
+
+    def test_fixed_position_on_affected_ref_matches(self, isolated_db: Path):
+        """fixed_positions whose key appears in affected_refs → 'fixed_position'."""
+        call_id = _make_call("h4")
+        record_warning(call_id, "singleton_orphan", "info", ["C1"], [])
+
+        call_id2 = _make_call("h4", is_fresh_state=False)
+        inputs = {"fixed_positions": {"C1": {"x": 10, "y": 20}}}
+        addressed = attribute_pending_warnings("h4", call_id2, inputs)
+
+        assert addressed == 1
+        conn = sqlite3.connect(str(isolated_db))
+        row = conn.execute("SELECT addressed_how FROM warnings_emitted").fetchone()
+        conn.close()
+        assert row[0] == "fixed_position"
+
+    def test_priority_order_hint_beats_cluster_and_fixed(self, isolated_db: Path):
+        """When hints, cluster_assignments, AND fixed_positions all match, hint wins."""
+        call_id = _make_call("h5")
+        record_warning(call_id, "orphan", "warn", ["U6"], ["c1"])
+
+        call_id2 = _make_call("h5", is_fresh_state=False)
+        inputs = {
+            "hints": {"U6": {}},
+            "cluster_assignments": {"c1": ["U6"]},
+            "fixed_positions": {"U6": {"x": 0, "y": 0}},
+        }
+        attribute_pending_warnings("h5", call_id2, inputs)
+
+        conn = sqlite3.connect(str(isolated_db))
+        row = conn.execute("SELECT addressed_how FROM warnings_emitted").fetchone()
+        conn.close()
+        assert row[0] == "hint"
+
+    def test_priority_order_cluster_beats_fixed(self, isolated_db: Path):
+        """When cluster_assignments and fixed_positions both match, cluster_assignment wins."""
+        call_id = _make_call("h6")
+        record_warning(call_id, "orphan", "warn", ["U7"], [])
+
+        call_id2 = _make_call("h6", is_fresh_state=False)
+        inputs = {
+            "cluster_assignments": {"c0": ["U7"]},
+            "fixed_positions": {"U7": {"x": 0, "y": 0}},
+        }
+        attribute_pending_warnings("h6", call_id2, inputs)
+
+        conn = sqlite3.connect(str(isolated_db))
+        row = conn.execute("SELECT addressed_how FROM warnings_emitted").fetchone()
+        conn.close()
+        assert row[0] == "cluster_assignment"
+
+    def test_cluster_id_drift_ref_only_fallback_matches(self, isolated_db: Path):
+        """Fresh-state next call: cluster IDs may drift; ref-only fallback in cluster_assignments still matches."""
+        call_id = _make_call("h7", is_fresh_state=True)
+        record_warning(call_id, "bridge", "warn", ["U8"], ["old_cluster_id"])
+
+        # Fresh-state call — cluster IDs won't match, but ref U8 IS in assignments
+        call_id2 = _make_call("h7", is_fresh_state=True)
+        inputs = {
+            "cluster_assignments": {"new_cluster_id": ["U8", "R5"]}  # different cluster id
+        }
+        addressed = attribute_pending_warnings("h7", call_id2, inputs)
+
+        # The first warning was for the FIRST call. After fresh-state call it should
+        # still be matchable if not yet swept.
+        # The sweep in _maybe_sweep would mark the first warning abandoned since there's
+        # a fresh_state call after it. Let's check what actually happens.
+        # If sweep ran, count=0; if not swept yet, count=1.
+        # record_call initializes sweep_state on first call, so no sweep on first call.
+        # Second call: sweep_state exists, < 1h since last_sweep → no sweep.
+        # So the warning is still pending and should be matched.
+        assert addressed == 1
+        conn = sqlite3.connect(str(isolated_db))
+        row = conn.execute("SELECT addressed_how FROM warnings_emitted WHERE call_id=?",
+                           (call_id,)).fetchone()
+        conn.close()
+        assert row[0] == "cluster_assignment"
+
+    def test_empty_inputs_no_attribution_attempts(self, isolated_db: Path):
+        """All-zero inputs_summary with empty hint/cluster/fixed dicts → no attribution, no error."""
+        call_id = _make_call("h8")
+        record_warning(call_id, "orphan", "warn", ["U9"], [])
+
+        call_id2 = _make_call("h8", is_fresh_state=False)
+        inputs: dict = {}  # no hints, no cluster_assignments, no fixed_positions
+        addressed = attribute_pending_warnings("h8", call_id2, inputs)
+
+        assert addressed == 0
+        conn = sqlite3.connect(str(isolated_db))
+        row = conn.execute("SELECT status FROM warnings_emitted WHERE call_id=?",
+                           (call_id,)).fetchone()
+        conn.close()
+        assert row[0] == "pending"
+
+
+# ---------------------------------------------------------------------------
+# TestAbandonment
+# ---------------------------------------------------------------------------
+
+
+class TestAbandonment:
+    def test_age_cutoff_7_days_marks_abandoned(self, isolated_db: Path):
+        """A call older than 7 days is swept to abandoned."""
+        call_id = _make_call("s1")
+        record_warning(call_id, "orphan", "warn", ["U1"], [])
+        _set_call_timestamp(isolated_db, call_id, _now_minus(days=8))
+
+        count = sweep_abandoned(max_age_days=7)
+        assert count == 1
+        assert _query_warning_status(isolated_db, 1) == "abandoned"
+
+    def test_age_boundary_below_7_days_stays_pending(self, isolated_db: Path):
+        """A call 6 hours under 7 days (6 days 18 hours) → stays pending."""
+        call_id = _make_call("s2")
+        record_warning(call_id, "orphan", "warn", ["U1"], [])
+        # 6 days and 23 hours — definitely less than 7 days
+        _set_call_timestamp(isolated_db, call_id, _now_minus(days=6, hours=23))
+
+        count = sweep_abandoned(max_age_days=7)
+        assert count == 0
+        assert _query_warning_status(isolated_db, 1) == "pending"
+
+    def test_age_boundary_above_7_days_marks_abandoned(self, isolated_db: Path):
+        """A call 1 hour over 7 days (7 days 1 hour) → abandoned."""
+        call_id = _make_call("s3")
+        record_warning(call_id, "orphan", "warn", ["U1"], [])
+        _set_call_timestamp(isolated_db, call_id, _now_minus(days=7, hours=1))
+
+        count = sweep_abandoned(max_age_days=7)
+        assert count == 1
+        assert _query_warning_status(isolated_db, 1) == "abandoned"
+
+    def test_fresh_state_reset_marks_warning_abandoned(self, isolated_db: Path):
+        """A subsequent fresh-state call on the same schematic abandons prior pending warnings."""
+        call_id1 = _make_call("s4", is_fresh_state=True)
+        record_warning(call_id1, "orphan", "warn", ["U2"], [])
+
+        # Fresh-state call comes after
+        _make_call("s4", is_fresh_state=True)
+
+        count = sweep_abandoned(max_age_days=7)
+        assert count == 1
+        assert _query_warning_status(isolated_db, 1) == "abandoned"
+
+    def test_sweep_idempotency_does_not_double_count(self, isolated_db: Path):
+        """Running sweep_abandoned twice doesn't mark already-abandoned warnings again."""
+        call_id = _make_call("s5")
+        record_warning(call_id, "orphan", "warn", ["U3"], [])
+        _set_call_timestamp(isolated_db, call_id, _now_minus(days=8))
+
+        count1 = sweep_abandoned(max_age_days=7)
+        count2 = sweep_abandoned(max_age_days=7)
+
+        assert count1 == 1
+        assert count2 == 0, "Second sweep should find nothing new to abandon"
+
+    def test_sweep_interval_at_59min_no_sweep(self, isolated_db: Path):
+        """record_call at last_sweep + 59 min → _maybe_sweep does NOT run."""
+        call_id = _make_call("s6")
+        record_warning(call_id, "orphan", "warn", ["U4"], [])
+        _set_call_timestamp(isolated_db, call_id, _now_minus(days=8))
+
+        # Set last_sweep_at to 59 minutes ago — below the 60-minute throttle
+        _set_last_sweep(isolated_db, _now_minus(minutes=59))
+
+        # Another record_call triggers _maybe_sweep
+        _make_call("s6", is_fresh_state=False)
+
+        # Warning should still be pending (sweep was suppressed)
+        assert _query_warning_status(isolated_db, 1) == "pending"
+
+    def test_sweep_interval_at_60min_exactly_triggers_sweep(self, isolated_db: Path):
+        """record_call at last_sweep + 60 min exactly → _maybe_sweep runs (non-strict >=)."""
+        call_id = _make_call("s7")
+        record_warning(call_id, "orphan", "warn", ["U5"], [])
+        _set_call_timestamp(isolated_db, call_id, _now_minus(days=8))
+
+        # Set last_sweep_at to exactly 60 minutes ago — at the threshold
+        _set_last_sweep(isolated_db, _now_minus(hours=1))
+
+        _make_call("s7", is_fresh_state=False)
+
+        # Warning should be abandoned (sweep ran)
+        assert _query_warning_status(isolated_db, 1) == "abandoned"
+
+    def test_sweep_interval_at_61min_triggers_sweep(self, isolated_db: Path):
+        """record_call at last_sweep + 61 min → _maybe_sweep runs."""
+        call_id = _make_call("s8")
+        record_warning(call_id, "orphan", "warn", ["U6"], [])
+        _set_call_timestamp(isolated_db, call_id, _now_minus(days=8))
+
+        _set_last_sweep(isolated_db, _now_minus(hours=1, minutes=1))
+
+        _make_call("s8", is_fresh_state=False)
+
+        assert _query_warning_status(isolated_db, 1) == "abandoned"
+
+
+# ---------------------------------------------------------------------------
+# TestQueries
+# ---------------------------------------------------------------------------
+
+
+class TestQueries:
+    def _setup_calibration_fixture(self, db: Path) -> None:
+        """Insert a known fixture: 3 addressed, 1 abandoned, 2 pending for type=orphan."""
+        call_id = _make_call("q1")
+        # addressed ×3
+        for ref in [["A1"], ["A2"], ["A3"]]:
+            record_warning(call_id, "orphan", "warn", ref, [])
+        # abandoned ×1 (inject directly — sweep_abandoned would need old timestamp)
+        record_warning(call_id, "orphan", "warn", ["B1"], [])
+        # pending ×2
+        record_warning(call_id, "orphan", "warn", ["C1"], [])
+        record_warning(call_id, "orphan", "warn", ["C2"], [])
+
+        conn = sqlite3.connect(str(db))
+        # Mark first 3 as addressed
+        rows = conn.execute(
+            "SELECT warning_id FROM warnings_emitted WHERE warning_type='orphan' LIMIT 3"
+        ).fetchall()
+        for r in rows:
+            conn.execute(
+                "UPDATE warnings_emitted SET status='addressed', addressed_how='hint' WHERE warning_id=?",
+                (r[0],),
+            )
+        # Mark 4th as abandoned
+        rows4 = conn.execute(
+            "SELECT warning_id FROM warnings_emitted WHERE warning_type='orphan' LIMIT 1 OFFSET 3"
+        ).fetchall()
+        for r in rows4:
+            conn.execute(
+                "UPDATE warnings_emitted SET status='abandoned' WHERE warning_id=?",
+                (r[0],),
+            )
+        conn.commit()
+        conn.close()
+
+    def test_calibration_counts_and_rates_correct(self, isolated_db: Path):
+        """Calibration table returns accurate emitted/addressed/abandoned/pending counts."""
+        self._setup_calibration_fixture(isolated_db)
+
+        rows = query_calibration_table(warning_type="orphan")
+        assert len(rows) == 1
+        r = rows[0]
+        assert r["warning_type"] == "orphan"
+        assert r["emitted"] == 6
+        assert r["addressed"] == 3
+        assert r["abandoned"] == 1
+        assert r["pending"] == 2
+
+    def test_calibration_action_rate_excludes_pending(self, isolated_db: Path):
+        """action_rate = addressed / (addressed + abandoned); pending is excluded from denominator."""
+        self._setup_calibration_fixture(isolated_db)
+
+        rows = query_calibration_table(warning_type="orphan")
+        r = rows[0]
+        # addressed=3, abandoned=1 → 3/4 = 0.75
+        assert r["action_rate"] == pytest.approx(0.75)
+
+    def test_calibration_action_rate_null_when_no_terminal(self, isolated_db: Path):
+        """action_rate is None when addressed=0 and abandoned=0 (only pending rows)."""
+        call_id = _make_call("q2")
+        record_warning(call_id, "noise", "info", ["U1"], [])
+        record_warning(call_id, "noise", "info", ["U2"], [])
+
+        rows = query_calibration_table(warning_type="noise")
+        assert len(rows) == 1
+        assert rows[0]["action_rate"] is None, (
+            "Denominator is 0 (no addressed or abandoned) — action_rate must be null"
+        )
+        assert rows[0]["pending"] == 2
+
+    def test_calibration_empty_db_returns_no_rows(self, isolated_db: Path):
+        """On a fresh DB with no calls, calibration_table returns empty list."""
+        rows = query_calibration_table()
+        assert rows == []
+
+    def test_convergence_stats_iteration_count_correct(self, isolated_db: Path):
+        """iterations = number of calls on the schematic."""
+        for _ in range(4):
+            _make_call("q3", is_fresh_state=False)
+
+        rows = query_convergence_stats(schematic_hash="q3")
+        assert len(rows) == 1
+        assert rows[0]["iterations"] == 4
+
+    def test_convergence_stats_reemission_count_correct(self, isolated_db: Path):
+        """warnings_reemitted counts overlapping-ref re-emissions within a schematic."""
+        # Call 1: emit warning for U1 + U2
+        c1 = _make_call("q4", is_fresh_state=False)
+        record_warning(c1, "bus_bridge", "warn", ["U1", "U2"], [])
+        # Call 2: same type, overlapping ref (U2) → reemission
+        c2 = _make_call("q4", is_fresh_state=False)
+        record_warning(c2, "bus_bridge", "warn", ["U2", "U3"], [])
+        # Call 3: same type, overlapping ref (U3) → reemission
+        c3 = _make_call("q4", is_fresh_state=False)
+        record_warning(c3, "bus_bridge", "warn", ["U3", "U4"], [])
+
+        rows = query_convergence_stats(schematic_hash="q4")
+        assert len(rows) == 1
+        assert rows[0]["warnings_reemitted"] == 2
+
+    def test_reemission_chain_of_three_does_not_triple_count(self, isolated_db: Path):
+        """A chain of 3 overlapping warnings yields reemitted=2, not 3.
+
+        W1=[U1,U2], W2=[U2,U3], W3=[U3,U4]: W2 reemits W1, W3 reemits W2.
+        Total reemissions = 2, not 3 (W1 is not double-counted as a source).
+        """
+        for refs in [["U1", "U2"], ["U2", "U3"], ["U3", "U4"]]:
+            c = _make_call("q5", is_fresh_state=False)
+            record_warning(c, "singleton", "warn", refs, [])
+
+        rows = query_convergence_stats(schematic_hash="q5")
+        assert rows[0]["warnings_reemitted"] == 2
+
+    def test_reemission_non_overlapping_refs_not_counted(self, isolated_db: Path):
+        """Two warnings of the same type with disjoint refs are NOT reemissions."""
+        c1 = _make_call("q6", is_fresh_state=False)
+        record_warning(c1, "orphan", "info", ["U1"], [])
+        c2 = _make_call("q6", is_fresh_state=False)
+        record_warning(c2, "orphan", "info", ["U9"], [])  # no overlap
+
+        rows = query_convergence_stats(schematic_hash="q6")
+        assert rows[0]["warnings_reemitted"] == 0
+
+    def test_convergence_stats_empty_db_returns_no_rows(self, isolated_db: Path):
+        """On a fresh DB, convergence_stats returns empty list."""
+        rows = query_convergence_stats()
+        assert rows == []
+
+    def test_system_events_returns_events(self, isolated_db: Path):
+        """system_events query returns events inserted into system_events table."""
+        # Trigger DB initialization by making a call, then insert a synthetic event.
+        _make_call("qsys1")
+        conn = sqlite3.connect(str(isolated_db))
+        conn.execute(
+            "INSERT INTO system_events (timestamp, severity, code, message)"
+            " VALUES (?, 'info', 'test_code', 'test msg')",
+            (_now_minus(),),
+        )
+        conn.commit()
+        conn.close()
+
+        rows = query_system_events()
+        codes = [r["code"] for r in rows]
+        assert "test_code" in codes
+
+    def test_system_events_flips_seen_flag(self, isolated_db: Path):
+        """Rows returned by query_system_events have their seen flag set to 1."""
+        # Initialize the DB, then insert an unseen event.
+        _make_call("qsys2")
+        conn = sqlite3.connect(str(isolated_db))
+        conn.execute(
+            "INSERT INTO system_events (timestamp, severity, code, message, seen)"
+            " VALUES (?, 'info', 'unseen_evt', 'msg', 0)",
+            (_now_minus(),),
+        )
+        conn.commit()
+        conn.close()
+
+        rows = query_system_events()
+        evt = next(r for r in rows if r["code"] == "unseen_evt")
+        # The returned dict reflects the pre-flip state (seen=False on first return)
+        assert evt["seen"] is False
+
+        # Second query: should now be seen=1 in DB, so unseen_only filter hides it
+        rows2 = query_system_events(unseen_only=True)
+        codes2 = [r["code"] for r in rows2 if r["severity"] != "error"]
+        assert "unseen_evt" not in codes2, (
+            "Event was returned once; subsequent unseen_only query must exclude it"
+        )
+
+    def test_system_events_unseen_only_excludes_seen(self, isolated_db: Path):
+        """unseen_only=True excludes non-error events already marked seen."""
+        _make_call("qsys3")
+        conn = sqlite3.connect(str(isolated_db))
+        conn.execute(
+            "INSERT INTO system_events (timestamp, severity, code, message, seen)"
+            " VALUES (?, 'info', 'already_seen', 'msg', 1)",
+            (_now_minus(),),
+        )
+        conn.commit()
+        conn.close()
+
+        rows = query_system_events(unseen_only=True)
+        codes = [r["code"] for r in rows]
+        assert "already_seen" not in codes
+
+    def test_system_events_empty_db_returns_no_rows(self, isolated_db: Path):
+        """On a fresh DB without any emitted events, system_events returns empty list."""
+        # No calls, no warnings, no explicit events
+        rows = query_system_events()
+        # The schema migration event IS emitted on init; filter for explicitly empty case
+        # by checking a specific code that was never inserted
+        codes = [r["code"] for r in rows]
+        assert "nonexistent_code" not in codes
+        # More importantly: the function must not error on a nearly-empty DB
+        assert isinstance(rows, list)
+
+
+# ---------------------------------------------------------------------------
+# TestConfidenceBucket
+# ---------------------------------------------------------------------------
+
+
+class TestConfidenceBucket:
+    @pytest.mark.parametrize("confidence,expected_bucket", [
+        (0.0,  "0.0-0.2"),   # exactly at lower bound → [0.0, 0.2)
+        (0.1,  "0.0-0.2"),
+        (0.19, "0.0-0.2"),
+        (0.2,  "0.2-0.4"),   # exactly at next boundary → [0.2, 0.4) not [0.0, 0.2)
+        (0.39, "0.2-0.4"),
+        (0.4,  "0.4-0.6"),
+        (0.59, "0.4-0.6"),
+        (0.6,  "0.6-0.8"),
+        (0.79, "0.6-0.8"),
+        (0.8,  "0.8-1.0"),   # exactly at top threshold → [0.8, 1.0]
+        (1.0,  "0.8-1.0"),   # top endpoint included (closed)
+        (None, "none"),       # no confidence → "none" bucket
+    ])
+    def test_confidence_bucket_boundaries(self, confidence, expected_bucket):
+        assert _confidence_bucket(confidence) == expected_bucket
+
+    def test_calibration_confidence_bucket_assignment_via_cluster(self, isolated_db: Path):
+        """Calibration table uses max cluster label_confidence from same call to bucket warnings."""
+        call_id = _make_call("qb1")
+        # Record a cluster decision with known confidence=0.9 → bucket "0.8-1.0"
+        record_cluster_decision(
+            call_id=call_id,
+            cluster_id="c0",
+            member_count=2,
+            anchor_ref="U1",
+            label="mcu",
+            label_confidence=0.9,
+            label_source="pattern_recognition",
+            tier=1,
+            louvain_modularity=None,
+        )
+        record_warning(call_id, "bus_bridge", "warn", ["U1"], ["c0"])
+
+        rows = query_calibration_table(warning_type="bus_bridge")
+        assert len(rows) == 1
+        assert rows[0]["confidence_bucket"] == "0.8-1.0"
+
+    def test_calibration_no_cluster_decision_lands_in_none_bucket(self, isolated_db: Path):
+        """Warning with affected_cluster_ids=[] and no cluster_decision → bucket 'none'."""
+        call_id = _make_call("qb2")
+        record_warning(call_id, "singleton_orphan", "info", ["C5"], [])
+
+        rows = query_calibration_table(warning_type="singleton_orphan")
+        assert len(rows) == 1
+        assert rows[0]["confidence_bucket"] == "none"
+
+
+# ---------------------------------------------------------------------------
+# TestValidation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_empty_targets_warning_rejected_no_insert(self, isolated_db: Path):
+        """record_warning with both affected_refs=[] and affected_cluster_ids=[] → no insert."""
+        call_id = _make_call("v1")
+        record_warning(call_id, "bad_warning", "warn", [], [])
+
+        assert _count_warnings(isolated_db) == 0, (
+            "Empty-target warning must not be inserted into warnings_emitted"
+        )
+
+    def test_empty_targets_emits_soft_failure_event(self, isolated_db: Path):
+        """record_warning with both empty → emits soft_failure with code='warning_emit_invalid'."""
+        from mcp_events import event_context, get_current
+
+        call_id = _make_call("v2")
+        with event_context():
+            record_warning(call_id, "bad_type", "warn", [], [])
+            acc = get_current()
+            assert acc is not None
+            codes = [e.code for e in acc._events]
+            assert "warning_emit_invalid" in codes
+
+    def test_warning_with_only_refs_accepted(self, isolated_db: Path):
+        """record_warning with non-empty affected_refs but empty cluster_ids → inserted."""
+        call_id = _make_call("v3")
+        record_warning(call_id, "valid", "warn", ["U1"], [])
+        assert _count_warnings(isolated_db) == 1
+
+    def test_warning_with_only_cluster_ids_accepted(self, isolated_db: Path):
+        """record_warning with empty affected_refs but non-empty affected_cluster_ids → inserted."""
+        call_id = _make_call("v4")
+        record_warning(call_id, "valid", "warn", [], ["c0"])
+        assert _count_warnings(isolated_db) == 1
+
+    def test_opt_out_disables_writes(self, isolated_db: Path, monkeypatch: pytest.MonkeyPatch):
+        """With KICAD_MCP_NO_TELEMETRY=1, write functions no-op."""
+        monkeypatch.setenv("KICAD_MCP_NO_TELEMETRY", "1")
+        telemetry._reset_for_tests(db_path_override=isolated_db)
+
+        call_id = record_call(
+            tool_name="t",
+            schematic_hash="opt_out",
+            inputs_summary={},
+        )
+        assert call_id is None, "record_call must return None when telemetry is disabled"
+
+    def test_opt_out_reads_still_work(self, isolated_db: Path, monkeypatch: pytest.MonkeyPatch):
+        """With KICAD_MCP_NO_TELEMETRY=1, read queries return empty lists rather than erroring."""
+        # Write some data first (opt-in)
+        _make_call("opt_out_read")
+
+        # Now disable writes
+        monkeypatch.setenv("KICAD_MCP_NO_TELEMETRY", "1")
+        telemetry._reset_for_tests(db_path_override=isolated_db)
+
+        # Reads must still function (schema is migrated on first read)
+        rows_cal = query_calibration_table()
+        rows_conv = query_convergence_stats()
+        rows_sys = query_system_events()
+
+        assert isinstance(rows_cal, list)
+        assert isinstance(rows_conv, list)
+        assert isinstance(rows_sys, list)
+
+    def test_migration_on_first_read_with_writes_disabled(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Fresh DB triggers migration even when writes are disabled (opt-out)."""
+        fresh_db = tmp_path / "fresh_optout.db"
+
+        monkeypatch.setenv("KICAD_MCP_NO_TELEMETRY", "1")
+        telemetry._reset_for_tests(db_path_override=fresh_db)
+
+        # Read query should migrate the schema (creating tables) without error
+        rows = query_calibration_table()
+        assert isinstance(rows, list)
+
+        # Verify the schema_version row was inserted (migration ran)
+        assert fresh_db.exists(), "DB file must be created even when writes are disabled"
+        conn = sqlite3.connect(str(fresh_db))
+        row = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()
+        conn.close()
+        assert row is not None and row[0] == 1, (
+            "Schema migration must run on first read even with KICAD_MCP_NO_TELEMETRY=1"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestBoundary
+# ---------------------------------------------------------------------------
+
+
+class TestBoundary:
+    def test_action_rate_with_pending_only_is_null(self, isolated_db: Path):
+        """addressed=0, abandoned=0, pending=5 → action_rate is None (insufficient data)."""
+        call_id = _make_call("b1")
+        for i in range(5):
+            record_warning(call_id, "pending_only", "warn", [f"R{i}"], [])
+
+        rows = query_calibration_table(warning_type="pending_only")
+        assert len(rows) == 1
+        assert rows[0]["action_rate"] is None
+        assert rows[0]["pending"] == 5
+        assert rows[0]["addressed"] == 0
+        assert rows[0]["abandoned"] == 0
+
+    def test_age_boundary_7_days_plus_1_second_abandoned(self, isolated_db: Path):
+        """A call exactly 7d+1s old → abandoned (strictly older than cutoff)."""
+        call_id = _make_call("b2")
+        record_warning(call_id, "orphan", "warn", ["U1"], [])
+        _set_call_timestamp(isolated_db, call_id, _now_minus(days=7, seconds=1))
+
+        count = sweep_abandoned(max_age_days=7)
+        assert count == 1
+
+    def test_age_boundary_6_days_23_hours_stays_pending(self, isolated_db: Path):
+        """A call 6 days 23 hours old (< 7 days) → stays pending."""
+        call_id = _make_call("b3")
+        record_warning(call_id, "orphan", "warn", ["U1"], [])
+        _set_call_timestamp(isolated_db, call_id, _now_minus(days=6, hours=23))
+
+        count = sweep_abandoned(max_age_days=7)
+        assert count == 0
+
+    def test_age_boundary_exactly_7_days_abandoned(self, isolated_db: Path):
+        """A call at exactly 7 days → abandoned (non-strict boundary, per SPEC).
+
+        The sweep SQL uses `timestamp <= cutoff`, so a warning whose call timestamp
+        equals the cutoff (= now - max_age_days) gets swept. Pinned because the
+        strict/non-strict distinction is the kind of silent-shadowing bug the
+        CLAUDE.md syntactic-semantic seam rule warns about.
+        """
+        call_id = _make_call("b_exact_7d")
+        record_warning(call_id, "orphan", "warn", ["U1"], [])
+        _set_call_timestamp(isolated_db, call_id, _now_minus(days=7))
+
+        count = sweep_abandoned(max_age_days=7)
+        assert count == 1
+
+    def test_iteration_index_auto_increments_per_schematic(self, isolated_db: Path):
+        """iteration_index counts prior calls on the same schematic_hash."""
+        c1 = _make_call("b4")
+        c2 = _make_call("b4", is_fresh_state=False)
+        c3 = _make_call("b4", is_fresh_state=False)
+        # Different schematic — index resets
+        cx = _make_call("b4_other")
+
+        conn = sqlite3.connect(str(isolated_db))
+        idx = {
+            r[0]: r[1]
+            for r in conn.execute(
+                "SELECT call_id, iteration_index FROM calls ORDER BY call_id"
+            ).fetchall()
+        }
+        conn.close()
+        assert idx[c1] == 0
+        assert idx[c2] == 1
+        assert idx[c3] == 2
+        assert idx[cx] == 0, "Different schematic_hash must start iteration_index at 0"
+
+    def test_multiple_warnings_across_schematics_isolated(self, isolated_db: Path):
+        """Attribution only matches warnings on the same schematic_hash."""
+        c1 = _make_call("schema_A")
+        record_warning(c1, "orphan", "warn", ["U1"], [])
+
+        c2 = _make_call("schema_B")
+        record_warning(c2, "orphan", "warn", ["U2"], [])
+
+        # Attribute with hints for schema_A only
+        c3 = _make_call("schema_A", is_fresh_state=False)
+        addressed = attribute_pending_warnings("schema_A", c3, {"hints": {"U1": {}}})
+
+        assert addressed == 1  # only the schema_A warning is matched
+        conn = sqlite3.connect(str(isolated_db))
+        rows = conn.execute(
+            "SELECT status FROM warnings_emitted ORDER BY warning_id"
+        ).fetchall()
+        conn.close()
+        assert rows[0][0] == "addressed"  # schema_A warning
+        assert rows[1][0] == "pending"    # schema_B warning untouched
+
+    def test_calibration_filter_by_warning_type(self, isolated_db: Path):
+        """calibration_table(warning_type=X) filters to only that type."""
+        call_id = _make_call("b5")
+        record_warning(call_id, "type_alpha", "warn", ["U1"], [])
+        record_warning(call_id, "type_beta", "warn", ["U2"], [])
+
+        rows = query_calibration_table(warning_type="type_alpha")
+        assert all(r["warning_type"] == "type_alpha" for r in rows)
+        assert len(rows) == 1
+
+    def test_convergence_stats_filter_by_schematic_hash(self, isolated_db: Path):
+        """convergence_stats(schematic_hash=X) returns only that schematic."""
+        for sh in ["s_apple", "s_banana", "s_cherry"]:
+            _make_call(sh)
+
+        rows = query_convergence_stats(schematic_hash="s_banana")
+        assert len(rows) == 1
+        assert rows[0]["schematic_hash"] == "s_banana"
+
+
+# ---------------------------------------------------------------------------
+# TestSchemaMigration — schema version tracking and the migration system_event
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaMigration:
+    def test_schema_version_row_inserted_on_first_use(self, isolated_db: Path):
+        """First call to any write triggers migration → schema_version row v1."""
+        _make_call("m1")
+
+        conn = sqlite3.connect(str(isolated_db))
+        cur = conn.execute("SELECT version FROM schema_version")
+        versions = [r[0] for r in cur.fetchall()]
+        conn.close()
+
+        assert 1 in versions
+
+    def test_migration_event_written_to_system_events(self, isolated_db: Path):
+        """A migration emits a telemetry_schema_migrated system_event row."""
+        _make_call("m2")
+
+        # Use the read API: it migrates first, then we query
+        events = query_system_events()
+        codes = [e["code"] for e in events]
+        assert "telemetry_schema_migrated" in codes
+
+    def test_migration_runs_on_first_read_when_writes_disabled(
+        self, monkeypatch: pytest.MonkeyPatch, isolated_db: Path
+    ):
+        """Even with KICAD_MCP_NO_TELEMETRY=1, reads create the DB + schema."""
+        monkeypatch.setenv("KICAD_MCP_NO_TELEMETRY", "1")
+        # No writes performed; the DB doesn't exist yet
+        assert not isolated_db.exists()
+
+        rows = query_calibration_table()
+
+        assert rows == []
+        assert isolated_db.exists()  # schema was applied for the read
+
+
+# ---------------------------------------------------------------------------
+# TestCountReemissions — pure-function unit tests, no DB needed
+# ---------------------------------------------------------------------------
+
+
+class TestCountReemissions:
+    """Unit tests for the standalone `_count_reemissions` helper.
+
+    Inputs are tuples of (warning_type, set_of_refs) ordered by emission time
+    within each type. No DB connection required.
+    """
+
+    def test_empty_chain_returns_zero(self):
+        assert _count_reemissions([]) == 0
+
+    def test_single_warning_returns_zero(self):
+        """One warning can't be a re-emission of anything."""
+        assert _count_reemissions([("orphan", {"U1"})]) == 0
+
+    def test_chain_of_two_overlapping_returns_one(self):
+        """W2 reemits W1."""
+        chain = [("orphan", {"U1", "U2"}), ("orphan", {"U2", "U3"})]
+        assert _count_reemissions(chain) == 1
+
+    def test_chain_of_three_overlapping_returns_two_not_three(self):
+        """W2 reemits W1; W3 reemits W2. W1 not double-counted as a source."""
+        chain = [
+            ("orphan", {"U1", "U2"}),
+            ("orphan", {"U2", "U3"}),
+            ("orphan", {"U3", "U4"}),
+        ]
+        assert _count_reemissions(chain) == 2
+
+    def test_disjoint_refs_not_counted(self):
+        """Two warnings of the same type with no overlap → not a reemission."""
+        chain = [("orphan", {"U1"}), ("orphan", {"U2"})]
+        assert _count_reemissions(chain) == 0
+
+    def test_different_warning_types_dont_count(self):
+        """Overlapping refs across DIFFERENT warning_types → not a reemission."""
+        chain = [("type_a", {"U1", "U2"}), ("type_b", {"U1", "U2"})]
+        assert _count_reemissions(chain) == 0
+
+
+# ---------------------------------------------------------------------------
+# TestCalibrationSamples — the verbosity=full include_samples feature
+# ---------------------------------------------------------------------------
+
+
+class TestCalibrationSamples:
+    def test_include_samples_false_omits_field(self, isolated_db: Path):
+        """Default include_samples=False → no sample_warnings field."""
+        call_id = _make_call("cs1")
+        record_warning(call_id, "orphan", "warn", ["U1"], [])
+
+        rows = query_calibration_table()
+
+        assert len(rows) == 1
+        assert "sample_warnings" not in rows[0]
+
+    def test_include_samples_true_adds_field(self, isolated_db: Path):
+        """include_samples=True → sample_warnings list of {warning_id, call_id}."""
+        call_id = _make_call("cs2")
+        record_warning(call_id, "orphan", "warn", ["U1"], [])
+
+        rows = query_calibration_table(include_samples=True)
+
+        assert len(rows) == 1
+        samples = rows[0]["sample_warnings"]
+        assert len(samples) == 1
+        assert set(samples[0].keys()) == {"warning_id", "call_id"}
+        assert samples[0]["call_id"] == call_id
+
+    def test_samples_capped_at_three(self, isolated_db: Path):
+        """Per-bucket samples cap at 3 even when more warnings exist in that bucket."""
+        call_id = _make_call("cs3")
+        for i in range(5):
+            record_warning(call_id, "orphan", "warn", [f"U{i}"], [])
+
+        rows = query_calibration_table(include_samples=True)
+
+        assert len(rows) == 1
+        assert len(rows[0]["sample_warnings"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# TestAnalyzePlacementTelemetryTool — the MCP dispatch layer
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzePlacementTelemetryTool:
+    """End-to-end tests for the analyze_placement_telemetry MCP tool dispatch.
+
+    Each test instantiates a fresh FastMCP, registers the tool, then calls
+    it via the framework. Verifies the response envelope structure beyond
+    what the pure query functions test.
+    """
+
+    def _get_tool(self):
+        """Build and return the registered analyze_placement_telemetry tool."""
+        import asyncio
+
+        from fastmcp import FastMCP
+
+        from kicad_mcp.tools.telemetry_analyze import register_telemetry_analyze_tools
+
+        mcp = FastMCP("test")
+        register_telemetry_analyze_tools(mcp)
+        return asyncio.run(mcp.get_tool("analyze_placement_telemetry"))
+
+    def test_unknown_query_returns_error(self, isolated_db: Path):
+        import asyncio
+        import json
+
+        tool = self._get_tool()
+        result = asyncio.run(tool.run({"query": "bogus_query_name"}))
+        text = result.content[0].text
+        payload = json.loads(text)
+        assert payload["status"] == "error"
+        assert "bogus_query_name" in payload["error"]
+
+    def test_unknown_verbosity_returns_error(self, isolated_db: Path):
+        import asyncio
+        import json
+
+        tool = self._get_tool()
+        result = asyncio.run(
+            tool.run({"query": "calibration_table", "verbosity": "loud"})
+        )
+        text = result.content[0].text
+        payload = json.loads(text)
+        assert payload["status"] == "error"
+        assert "verbosity" in payload["error"].lower()
+
+    def test_all_three_queries_return_ok_on_empty_db(self, isolated_db: Path):
+        """All supported queries return status=ok on a fresh DB.
+
+        Warnings-based queries return empty rows; system_events has the
+        migration event row from schema init.
+        """
+        import asyncio
+        import json
+
+        tool = self._get_tool()
+        for query in ("calibration_table", "convergence_stats", "system_events"):
+            result = asyncio.run(tool.run({"query": query}))
+            text = result.content[0].text
+            payload = json.loads(text)
+            assert payload["status"] == "ok", f"{query} returned {payload}"
+            if query in ("calibration_table", "convergence_stats"):
+                assert payload["rows"] == [], (
+                    f"{query} returned non-empty rows on fresh DB"
+                )
+            else:  # system_events
+                # Has the migration event from schema init
+                codes = [r["code"] for r in payload["rows"]]
+                assert "telemetry_schema_migrated" in codes
+
+    def test_verbosity_full_adds_metadata(self, isolated_db: Path):
+        """verbosity=full augments the response with query+filters+row_count."""
+        import asyncio
+        import json
+
+        tool = self._get_tool()
+        result = asyncio.run(
+            tool.run({"query": "convergence_stats", "verbosity": "full"})
+        )
+        payload = json.loads(result.content[0].text)
+        assert payload["status"] == "ok"
+        assert payload["query"] == "convergence_stats"
+        assert "filters_applied" in payload
+        assert "row_count" in payload

--- a/uv.lock
+++ b/uv.lock
@@ -1007,7 +1007,7 @@ requires-dist = [
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "fastmcp", specifier = ">=3.3.1" },
     { name = "kicad-sch-api", specifier = ">=0.5.6" },
-    { name = "mcp-events", editable = "../mcp-events" },
+    { name = "mcp-events", specifier = ">=0.1.0" },
     { name = "python-multipart", specifier = ">=0.0.29" },
     { name = "pyyaml", specifier = ">=6.0.3" },
 ]
@@ -1263,15 +1263,10 @@ wheels = [
 [[package]]
 name = "mcp-events"
 version = "0.1.0"
-source = { editable = "../mcp-events" }
-
-[package.metadata]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "mypy", specifier = ">=2.0" },
-    { name = "pytest", specifier = ">=8.0" },
-    { name = "ruff", specifier = ">=0.9" },
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/cf/90b4af882a55e7d95ea0c9177914095c8132e4652fda296739769be9eb11/mcp_events-0.1.0.tar.gz", hash = "sha256:d9c26adde5fa1f7c511d8207a2361b89e78c8dca0ba712340168e7f5729a0fb8", size = 33513, upload-time = "2026-05-27T22:57:36.845Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/92/a112182f36b255075bf0dca99f35465a92835cf4d7e1b9766a052d19d2a8/mcp_events-0.1.0-py3-none-any.whl", hash = "sha256:21a5c44b241e8d2b89289f4bdf88e8ab9f636a488a6552031c96c7e4092997ef", size = 4891, upload-time = "2026-05-27T22:57:35.844Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -984,6 +984,7 @@ dependencies = [
     { name = "defusedxml" },
     { name = "fastmcp" },
     { name = "kicad-sch-api" },
+    { name = "mcp-events" },
     { name = "python-multipart" },
     { name = "pyyaml" },
 ]
@@ -1006,6 +1007,7 @@ requires-dist = [
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "fastmcp", specifier = ">=3.3.1" },
     { name = "kicad-sch-api", specifier = ">=0.5.6" },
+    { name = "mcp-events", editable = "../mcp-events" },
     { name = "python-multipart", specifier = ">=0.0.29" },
     { name = "pyyaml", specifier = ">=6.0.3" },
 ]
@@ -1256,6 +1258,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+]
+
+[[package]]
+name = "mcp-events"
+version = "0.1.0"
+source = { editable = "../mcp-events" }
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=2.0" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "ruff", specifier = ">=0.9" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements [`docs/SPEC_Feedback_Infrastructure.md`](docs/SPEC_Feedback_Infrastructure.md) (merged via #37). Local SQLite-backed telemetry + action-attribution for kicad-mcp tools. Synchronous at call boundary; no daemon; safe under multi-process concurrency.

**Schema** (5 tables at `~/.cache/kicad-mcp/telemetry.db`):
- `calls` — per tool invocation with iteration_index, perf, hashes
- `cluster_decisions` — per-cluster outputs (label, confidence, source, tier)
- `warnings_emitted` — pending → addressed/abandoned lifecycle
- `system_events` — persisted info/warn/error events (migration, sweep, failures); paired with mcp-events for in-call surfacing
- `sweep_state` — throttle row for the abandonment sweep

**Public API:**
- `record_call`, `record_cluster_decision`, `record_warning` — write paths; fail soft via `_emit_soft_failure` (mcp_events surfacing + system_events persist)
- `attribute_pending_warnings` — first-match-wins matcher over `hints` / `cluster_assignments` / `fixed_positions`, called synchronously at consumer entry
- `sweep_abandoned` — non-strict 7-day age cutoff (`<=`) + fresh-state reset; throttled to once per hour via opportunistic `_maybe_sweep` in `record_call`
- `query_calibration_table` — per (warning_type, confidence_bucket) action rates; optional `sample_warnings` for `verbosity=full`
- `query_convergence_stats` — per-schematic iteration + reemission counts (pure `_count_reemissions` helper, unit-tested separately)
- `query_system_events` — recent events with seen-flag flip and `unseen_only` filter that passes through errors regardless

The attribution runs inline at consumer entry (no daemon, no scheduling) per the [`synchronous-at-call-boundary`](https://github.com/blwfish/kicad-mcp/blob/main/docs/SPEC_Feedback_Infrastructure.md#design-principles-applied) principle. Failures propagate to system_events persistence + mcp_events stderr fallback; the calling tool's main behavior is unaffected.

**Tool surface:** adds `analyze_placement_telemetry` (standalone, not behind a router). Tool count: 89 → 90.

## ⚠️ Merge blocker

This PR depends on `mcp-events>=0.1.0` being available on PyPI. CI uses `uv sync --frozen`, which fails when the lockfile references a local-path dependency that doesn't exist on the runner. The `mcp-events` package already exists at `/Volumes/Files/claude/mcp-events/` (47 tests, mypy clean) but PyPI account creation has been intermittent. **Do not merge until `mcp-events 0.1.0` is published.**

## Test plan

- [x] 1043/1043 tests pass (969 baseline + 74 new in `tests/test_telemetry.py`)
- [x] mypy clean across 43 source files
- [x] Wheel build verified to include `telemetry_schema.sql`
- [x] Schema migrates lazily on first DB connection per process; `KICAD_MCP_NO_TELEMETRY=1` opt-out short-circuits writes; reads still work on a fresh disable-then-read sequence
- [x] System events table verified to receive migration + sweep + failure events (closes a real gap discovered during merge with a parallel implementation)