### PR TITLE
refactor(ci): replace fragile grep-based doc check with sync script

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -11,32 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2  # Need parent commit for diff
-
-      - name: Check if tool files changed without TOOLS.md update
-        run: |
-          # Get changed files vs parent commit
-          CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "")
-
-          # Check if any tool-related files changed
-          TOOL_CHANGES=$(echo "$CHANGED" | grep -E '^src/kicad_mcp/(tools/|server\.py)' || true)
-
-          if [ -n "$TOOL_CHANGES" ]; then
-            echo "Tool files changed:"
-            echo "$TOOL_CHANGES"
-
-            # Check if TOOLS.md was also updated
-            TOOLS_CHANGED=$(echo "$CHANGED" | grep '^TOOLS.md$' || true)
-            README_CHANGED=$(echo "$CHANGED" | grep '^README.md$' || true)
-
-            if [ -z "$TOOLS_CHANGED" ] && [ -z "$README_CHANGED" ]; then
-              echo ""
-              echo "::warning::Tool files changed but neither TOOLS.md nor README.md were updated. If you added, removed, or renamed tools, please update the docs."
-            fi
-          else
-            echo "No tool file changes detected."
-          fi
 
       - uses: actions/setup-python@v5
         with:
@@ -45,55 +19,12 @@ jobs:
       - name: Install dependencies
         run: pip install -e .
 
-      - name: Verify tool count consistency
+      - name: Verify tool count is in sync
         run: |
-          # Get actual tool count from server
-          ACTUAL=$(python -c "
-          from kicad_mcp.server import create_server
-          import asyncio
-          s = create_server()
-          tools = asyncio.run(s.list_tools())
-          print(len(tools))
-          ")
-          echo "Server reports $ACTUAL tools"
-
-          # Check test_server.py
-          TEST_COUNT=$(grep -oP 'Expected \K\d+' tests/test_server.py | head -1)
-          echo "test_server.py expects $TEST_COUNT tools"
-
-          # Check README.md — looks for "N tools covering" or "N tools for AI"
-          README_COUNT=$(grep -oP '(\d+) tools (covering|for AI)' README.md | grep -oP '^\d+' | head -1)
-          echo "README.md says $README_COUNT tools"
-
-          # Check TOOLS.md
-          TOOLS_COUNT=$(grep -oP '(\d+) MCP tools' TOOLS.md | grep -oP '^\d+' | head -1)
-          echo "TOOLS.md says $TOOLS_COUNT tools"
-
-          # Check AGENT-INSTALL.md
-          AGENT_COUNT=$(grep -oP 'providing (\d+) tools' AGENT-INSTALL.md | grep -oP '\d+' | head -1)
-          echo "AGENT-INSTALL.md says $AGENT_COUNT tools"
-
-          # Compare
-          MISMATCH=0
-          if [ "$ACTUAL" != "$TEST_COUNT" ]; then
-            echo "::error::Tool count mismatch: server has $ACTUAL but test_server.py expects $TEST_COUNT"
-            MISMATCH=1
-          fi
-          if [ "$ACTUAL" != "$README_COUNT" ]; then
-            echo "::error::Tool count mismatch: server has $ACTUAL but README.md says $README_COUNT"
-            MISMATCH=1
-          fi
-          if [ "$ACTUAL" != "$TOOLS_COUNT" ]; then
-            echo "::error::Tool count mismatch: server has $ACTUAL but TOOLS.md says $TOOLS_COUNT"
-            MISMATCH=1
-          fi
-          if [ -n "$AGENT_COUNT" ] && [ "$ACTUAL" != "$AGENT_COUNT" ]; then
-            echo "::error::Tool count mismatch: server has $ACTUAL but AGENT-INSTALL.md says $AGENT_COUNT"
-            MISMATCH=1
-          fi
-
-          if [ "$MISMATCH" = "1" ]; then
+          python scripts/sync_tool_count.py
+          if ! git diff --exit-code; then
+            echo ""
+            echo "::error::Tool count in docs is out of sync with the server."
+            echo "Run 'python scripts/sync_tool_count.py' locally and commit the result."
             exit 1
-          else
-            echo "All tool counts match: $ACTUAL"
           fi

--- a/AGENT-INSTALL.md
+++ b/AGENT-INSTALL.md
@@ -4,7 +4,7 @@ This file is for you, the AI agent. It tells you what needs to be true on this s
 
 ## What This Is
 
-kicad-mcp is a Model Context Protocol (MCP) server providing 15 tools for KiCad electronic design automation — schematic capture, PCB layout, autorouting, DRC, and more. Once installed and registered, these tools appear in your tool list and you can design circuit boards conversationally.
+kicad-mcp is a Model Context Protocol (MCP) server providing <!-- tool-count -->15<!-- /tool-count --> tools for KiCad electronic design automation — schematic capture, PCB layout, autorouting, DRC, and more. Once installed and registered, these tools appear in your tool list and you can design circuit boards conversationally.
 
 **Origin:** Built by one person for personal use, on a Mac, with Claude Code. Other platforms *should* work (the code handles macOS, Windows, and Linux) but are untested. PRs for other agents and platforms will be considered.
 
@@ -156,7 +156,7 @@ If you are registered as an MCP server for a project that does KiCad work, the p
 
 ### Client Compatibility
 
-kicad-mcp exposes 13 tools — well within every known MCP client limit. Claude Code, Cursor (~40-tool limit), and Gemini (~100-tool limit) are all supported.
+kicad-mcp exposes <!-- tool-count -->15<!-- /tool-count --> tools — well within every known MCP client limit. Claude Code, Cursor (~40-tool limit), and Gemini (~100-tool limit) are all supported.
 
 Claude Code is the recommended client: it provides automatic prompt caching (critical for iterative KiCad workflows) and subagent support for parallel exploration tasks.
 
@@ -260,7 +260,7 @@ When filing an issue, include:
 - PRs for bug fixes, new platform support, and new tools are welcome
 - New operations fold into an existing router (schematic, pcb, audit, drc, autoroute, library, project, analyze, export) or add a new standalone tool if they don't fit any router's domain
 - PCB tools use the subprocess bridge (`run_pcbnew_script`); schematic tools use kicad-sch-api in-process
-- Run `pytest` before submitting — all tests should pass (currently 609 tests)
+- Run `pytest` before submitting — all tests should pass (currently 1134 tests)
 - Tools return `{"status": "ok", ...}` on success or `{"error": "..."}` on failure — follow this convention
 
 ### Adding a New Operation to an Existing Router
@@ -277,7 +277,7 @@ When filing an issue, include:
 2. Register it in the module's `register_*_tools(mcp)` function
 3. If it's a new module, import and call the registration function in `server.py`
 4. Add the tool name to `EXPECTED_TOOLS` in `tests/test_server.py`
-5. Update the snapshot tool count in `test_server.py`
+5. Run `python scripts/sync_tool_count.py` to update the count in all docs
 6. Run `pytest` to verify
 
 ## License

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This tool enables your AI agent to use [KiCad](https://www.kicad.org/) — the i
 
 ## What This Does
 
-You describe what you need — "design a board for this ESP32 circuit" or "here's the schematic, lay out the PCB" — and your AI agent does the rest: drawing the schematic, choosing components, placing them on the board, routing traces, checking for errors, and producing manufacturing-ready files. All using the same KiCad that professional engineers use, with 15 tools covering the full design workflow.
+You describe what you need — "design a board for this ESP32 circuit" or "here's the schematic, lay out the PCB" — and your AI agent does the rest: drawing the schematic, choosing components, placing them on the board, routing traces, checking for errors, and producing manufacturing-ready files. All using the same KiCad that professional engineers use, with <!-- tool-count -->15<!-- /tool-count --> tools covering the full design workflow.
 
 You don't need to know KiCad. You don't need to know what a PCB layout tool does. You just need an AI agent (like [Claude](https://claude.ai/)).
 
@@ -18,7 +18,7 @@ Your agent will handle the rest — installing prerequisites, cloning the repo, 
 
 **For best results:** Use Claude Opus (not Haiku or Sonnet) with the ability to spawn subagents. For autorouting, use [FreeRouter v2.2.4+](https://github.com/freerouting/freerouting/releases) — v2.2.3+ is 10–30× faster than v2.1.0 and deterministic; see [AGENT-INSTALL.md](AGENT-INSTALL.md) for details. The combination of a capable model and parallel exploration (component research, placement suggestions) dramatically improves PCB design workflows. [Claude Code](https://claude.ai/code) provides automatic prompt caching that speeds up iterative design tasks.
 
-**Client compatibility:** kicad-mcp exposes 15 tools, well within every known MCP client limit. Claude Code, Cursor, and Gemini are all supported. Claude Code is recommended for its automatic prompt caching and subagent support.
+**Client compatibility:** kicad-mcp exposes <!-- tool-count -->15<!-- /tool-count --> tools, well within every known MCP client limit. Claude Code, Cursor, and Gemini are all supported. Claude Code is recommended for its automatic prompt caching and subagent support.
 
 ## What You Can Ask Your Agent To Do
 
@@ -34,7 +34,7 @@ The agent knows the full workflow — schematic → board sizing → component p
 
 I built this because I need it. I'm not an electrical engineer — I build things for my model railroad that need custom PCBs, and I can't design circuits without this tool and Claude. This is how I actually get boards made: I describe what I need, Claude drives KiCad through this server, and I send the Gerbers to fab. It's not a demo or a hackathon project.
 
-That means reliability matters. The test suite (609 tests) exists because I depend on this working correctly when I sit down to design a board. Bugs in PCB layout tools turn into real problems — wrong footprints, shorted traces, boards that don't work when they arrive from the manufacturer.
+That means reliability matters. The test suite (1134 tests) exists because I depend on this working correctly when I sit down to design a board. Bugs in PCB layout tools turn into real problems — wrong footprints, shorted traces, boards that don't work when they arrive from the manufacturer.
 
 I use Claude Code on a Mac. Other platforms *should* work — the code handles macOS, Windows, and Linux — but are untested. PRs for other agents and platforms will be considered.
 
@@ -42,7 +42,7 @@ If you hit a bug, [open an issue](https://github.com/blwfish/kicad-mcp/issues/ne
 
 ### What's Under the Hood
 
-The server provides 13 domain-router tools:
+The server provides <!-- tool-count -->15<!-- /tool-count --> tools — 10 domain routers and 5 standalones:
 
 - **`schematic`** — create and edit circuit schematics, place components, wire connections, labels, sheets
 - **`pcb`** — board layout, footprint placement, nets, routing, copper zones, silkscreen management
@@ -53,24 +53,26 @@ The server provides 13 domain-router tools:
 - **`project`** — project file management: list, open, structure, validate
 - **`analyze`** — read-only analysis: connections, circuit patterns, BOM, netlist
 - **`export`** — manufacturing output: Gerbers, BOM CSV, PCB thumbnail
+- **`lcsc`** — LCSC/JLCPCB component search, footprint resolution, and part selection
 - **`build_pcb_from_schematic`** *(standalone)* — top-level schematic → board pipeline
 - **`panelize_pcb`** *(standalone)* — manufacturing panelization
 - **`estimate_board_size`** *(standalone)* — pre-PCB board size estimation
 - **`suggest_placement`** *(standalone)* — connectivity-based component placement suggestions
+- **`analyze_placement_telemetry`** *(standalone)* — placement quality scoring and telemetry analysis
 
 The server uses [FastMCP](https://github.com/jlowin/fastmcp) and delegates PCB operations to KiCad's bundled Python via subprocess. Schematic operations use [kicad-sch-api](https://pypi.org/project/kicad-sch-api/).
 
 ### For Developers
 
 ```bash
-# 609 tests, no KiCad installation required — runs in ~4 seconds
+# 1134 tests, no KiCad installation required — runs in ~14 seconds
 pytest
 
 # Lint
 ruff check src/ tests/
 ```
 
-Tests cover all 15 tools across every module — schematic, PCB board setup, footprints, nets, routing, zones, silkscreen, planning, DRC, BOM, autorouting, netlist/patterns — plus utilities like the pcbnew subprocess bridge, component value parsing, and project file handling. Everything is unit-testable without a KiCad installation because PCB operations go through a single subprocess bridge (`run_pcbnew_script`) that's easy to mock.
+Tests cover all <!-- tool-count -->15<!-- /tool-count --> tools across every module — schematic, PCB board setup, footprints, nets, routing, zones, silkscreen, planning, DRC, BOM, autorouting, netlist/patterns — plus utilities like the pcbnew subprocess bridge, component value parsing, and project file handling. Everything is unit-testable without a KiCad installation because PCB operations go through a single subprocess bridge (`run_pcbnew_script`) that's easy to mock.
 
 See [AGENT-INSTALL.md](AGENT-INSTALL.md) for full technical details, architecture, contributing guidelines, and how to add new tools.
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1,6 +1,6 @@
 # Tool Summary
 
-This MCP server exposes 15 MCP tools for KiCad EDA — 10 domain routers and 5 standalones.
+This MCP server exposes <!-- tool-count -->15<!-- /tool-count --> MCP tools for KiCad EDA — 10 domain routers and 5 standalones.
 
 Each router takes an `operation` parameter that selects the sub-operation.
 Unknown operations return an error listing valid choices.

--- a/scripts/sync_tool_count.py
+++ b/scripts/sync_tool_count.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Sync the tool count across all docs.
+
+Run before committing when tools are added or removed:
+    python scripts/sync_tool_count.py
+
+CI runs this then checks `git diff --exit-code`.
+
+Markers kept in sync
+--------------------
+Markdown files:   <!-- tool-count -->N<!-- /tool-count -->
+test_server.py:   EXPECTED_TOOL_COUNT = N
+"""
+import asyncio
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+MARKDOWN_MARKER = re.compile(r"<!-- tool-count -->\d+<!-- /tool-count -->")
+TEST_CONSTANT = re.compile(r"^(EXPECTED_TOOL_COUNT = )\d+", re.MULTILINE)
+
+MARKDOWN_FILES = [
+    ROOT / "README.md",
+    ROOT / "TOOLS.md",
+    ROOT / "AGENT-INSTALL.md",
+]
+TEST_FILE = ROOT / "tests" / "test_server.py"
+
+
+def get_tool_count() -> int:
+    sys.path.insert(0, str(ROOT / "src"))
+    from kicad_mcp.server import create_server  # noqa: PLC0415
+
+    s = create_server()
+    tools = asyncio.run(s.list_tools())
+    return len(tools)
+
+
+def sync_file(path: Path, pattern: re.Pattern, replacement: str) -> bool:
+    """Apply pattern replacement. Returns True if the file changed."""
+    text = path.read_text(encoding="utf-8")
+    new = pattern.sub(replacement, text)
+    if new == text:
+        return False
+    path.write_text(new, encoding="utf-8")
+    return True
+
+
+def main() -> None:
+    count = get_tool_count()
+    print(f"Server reports {count} tools")
+
+    md_replacement = f"<!-- tool-count -->{count}<!-- /tool-count -->"
+    test_replacement = f"\\g<1>{count}"
+
+    changed: list[str] = []
+
+    for md in MARKDOWN_FILES:
+        if sync_file(md, MARKDOWN_MARKER, md_replacement):
+            changed.append(md.name)
+            print(f"  Updated {md.name}")
+        else:
+            # Warn if the file has no markers at all — likely forgotten.
+            text = md.read_text(encoding="utf-8")
+            if "<!-- tool-count -->" not in text:
+                print(f"  WARNING: {md.name} has no <!-- tool-count --> markers")
+
+    if sync_file(TEST_FILE, TEST_CONSTANT, test_replacement):
+        changed.append(TEST_FILE.name)
+        print(f"  Updated {TEST_FILE.name}")
+
+    if changed:
+        print(f"\nUpdated {len(changed)} file(s): {', '.join(changed)}")
+        print("Review the changes and commit them.")
+    else:
+        print(f"\nAll files already show {count} — nothing to update.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,6 +7,8 @@ from fastmcp import FastMCP
 
 from kicad_mcp.server import create_server
 
+EXPECTED_TOOL_COUNT = 15  # updated by scripts/sync_tool_count.py
+
 
 class TestCreateServer:
     """Verify that create_server() returns a properly configured FastMCP instance."""
@@ -22,12 +24,14 @@ class TestCreateServer:
     def test_at_least_15_tools_registered(self, mcp_server):
         """Floor — the consolidated surface targets 15 tools."""
         tools = asyncio.run(mcp_server.list_tools())
-        assert len(tools) >= 15, (
-            f"Expected at least 15 tools, got {len(tools)}"
+        assert len(tools) >= EXPECTED_TOOL_COUNT, (
+            f"Expected at least {EXPECTED_TOOL_COUNT} tools, got {len(tools)}"
         )
 
     def test_current_tool_count(self, mcp_server):
         """Snapshot test: update when tools are intentionally added or removed.
+
+        Run scripts/sync_tool_count.py to update this constant and all docs in one pass.
 
         Tool-consolidation complete (see docs/SPEC_Tool_Consolidation.md).
         Final surface: 10 routers + 5 standalones = 15 tools.
@@ -41,9 +45,9 @@ class TestCreateServer:
           Post-consolidation: lcsc component-intelligence router added → 15 total.
         """
         tools = asyncio.run(mcp_server.list_tools())
-        assert len(tools) == 15, (
-            f"Expected 15 tools, got {len(tools)}. "
-            "Update this test if tools were intentionally added or removed."
+        assert len(tools) == EXPECTED_TOOL_COUNT, (
+            f"Expected {EXPECTED_TOOL_COUNT} tools, got {len(tools)}. "
+            "Run scripts/sync_tool_count.py and commit the result."
         )
 
 


### PR DESCRIPTION
## Summary

- Replaces the brittle `grep -oP` natural-language pattern matching in `docs-check.yml` with a `scripts/sync_tool_count.py` script that reads the live server count and updates all docs via stable `<!-- tool-count -->N<!-- /tool-count -->` markers
- CI now just runs the script and checks `git diff --exit-code` — same check developers can run locally before pushing
- Fixes two stale counts that the old CI never caught: README "13 domain-router tools" and AGENT-INSTALL.md line 159 "13 tools"; also updates tool list to include `lcsc` and `analyze_placement_telemetry`
- Updates stale test count 609 → 1134 in README and AGENT-INSTALL

## Test plan

- [ ] CI `check-docs` job passes on this PR
- [ ] `python scripts/sync_tool_count.py` runs cleanly locally and reports "nothing to update"
- [ ] All 1134 tests pass (`pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)