### PR TITLE
fix(pcb): dedupe net injection + fix KiCad-10 fresh-board net loss

### DIFF
--- a/src/kicad_mcp/tools/pcb_nets.py
+++ b/src/kicad_mcp/tools/pcb_nets.py
@@ -8,6 +8,7 @@ import logging
 import os
 from typing import Any, Dict, List, Optional
 
+from kicad_mcp.utils.net_injection import inject_net_definitions
 from kicad_mcp.utils.pcbnew_bridge import run_pcbnew_script
 
 logger = logging.getLogger(__name__)
@@ -40,22 +41,12 @@ def _op_add_net(pcb_path: str, net_name: str) -> Dict[str, Any]:
     net_codes = [int(m.group(1)) for m in _re.finditer(r'\(net\s+(\d+)\s+"', content)]
     next_code = max(net_codes) + 1 if net_codes else 1
 
-    last_net_match = None
-    for m in _re.finditer(r'\(net\s+\d+\s+"(?:[^"\\]|\\.)*"\)', content):
-        last_net_match = m
-
-    if last_net_match:
-        insert_pos = last_net_match.end()
-    else:
-        fp_match = _re.search(r'\n\t\(footprint\b', content)
-        if fp_match:
-            insert_pos = fp_match.start()
-        else:
-            insert_pos = content.rfind('\n)')
-            if insert_pos == -1:
-                return {"error": "Could not find insertion point in PCB file"}
-    new_net_line = f'\n\t(net {next_code} "{net_name}")'
-    content = content[:insert_pos] + new_net_line + content[insert_pos:]
+    # Insertion point + line formatting live in utils/net_injection (single
+    # source of truth, shared with pcb_pipeline's bulk injector).
+    new_content = inject_net_definitions(content, [(next_code, net_name)])
+    if new_content is None:
+        return {"error": "Could not find insertion point in PCB file"}
+    content = new_content
 
     with open(pcb_path, "w") as f:
         f.write(content)

--- a/src/kicad_mcp/tools/pcb_pipeline.py
+++ b/src/kicad_mcp/tools/pcb_pipeline.py
@@ -12,6 +12,7 @@ from fastmcp import FastMCP
 
 from kicad_mcp.utils.keepout_helpers import KEEPOUT_HELPER, LIB_SEARCH_HELPER
 from kicad_mcp.utils.kicad_cli import KiCadCLIError, get_kicad_cli_path
+from kicad_mcp.utils.net_injection import existing_net_codes, inject_net_definitions
 from kicad_mcp.utils.netlist_parser import POWER_NET_HELPER, extract_netlist_via_cli
 from kicad_mcp.utils.pcbnew_bridge import run_pcbnew_script
 
@@ -306,13 +307,15 @@ def _step_inject_nets_and_assign_pads(
         return {"status": "ok", "nets_created": 0, "pads_assigned": 0,
                 "warning": "No nets found in schematic"}
 
-    # Inject nets via direct file editing (pcbnew prunes unused nets)
+    # Inject nets via direct file editing (pcbnew prunes unused nets).
+    # Insertion point + line formatting live in utils/net_injection (single
+    # source of truth, shared with pcb_nets.add_net). This is what carries the
+    # KiCad-10 (net 0 "")-absence fallback — without it, fresh K10 boards got
+    # 0 nets injected and built electrically-dead while returning status:ok.
     with open(pcb_path, "r") as f:
         pcb_content = f.read()
 
-    existing_nets = {}
-    for m in re.finditer(r'\(net\s+(\d+)\s+"([^"]*)"\)', pcb_content):
-        existing_nets[m.group(2)] = int(m.group(1))
+    existing_nets = {name: code for code, name in existing_net_codes(pcb_content)}
 
     max_code = max(existing_nets.values()) if existing_nets else 0
     nets_created = []
@@ -324,21 +327,20 @@ def _step_inject_nets_and_assign_pads(
             nets_created.append(net_name)
 
     if nets_created:
-        last_net_match = None
-        for m in re.finditer(r'\(net\s+\d+\s+"[^"]*"\)', pcb_content):
-            last_net_match = m
-
-        if last_net_match:
-            insert_pos = last_net_match.end()
-            new_lines = ""
-            for net_name in nets_created:
-                code = existing_nets[net_name]
-                new_lines += f'\n\t(net {code} "{net_name}")'
-            pcb_content = (
-                pcb_content[:insert_pos] + new_lines + pcb_content[insert_pos:]
-            )
-            with open(pcb_path, "w") as f:
-                f.write(pcb_content)
+        new_content = inject_net_definitions(
+            pcb_content,
+            [(existing_nets[name], name) for name in nets_created],
+        )
+        if new_content is None:
+            return {
+                "status": "error",
+                "error": "Could not find insertion point in PCB file",
+                "nets_created": 0,
+                "total_nets": len(net_definitions),
+            }
+        pcb_content = new_content
+        with open(pcb_path, "w") as f:
+            f.write(pcb_content)
 
     # Assign pads via pcbnew
     script = """

--- a/src/kicad_mcp/utils/net_injection.py
+++ b/src/kicad_mcp/utils/net_injection.py
@@ -1,0 +1,100 @@
+"""Single source of truth for inserting ``(net N "name")`` definitions into a
+``.kicad_pcb`` S-expression via direct text editing.
+
+Both the single-net injector (``pcb_nets._op_add_net``) and the bulk injector
+(``pcb_pipeline._step_inject_nets_and_assign_pads``) used to re-implement the
+insertion-point decision and the line formatting independently. The pipeline
+copy was missing the KiCad-10 ``(net 0 "")``-absence fallback, which produced
+electrically-dead boards (0 nets/pads/tracks while returning ``status:ok``).
+
+This module is the one place that decides *where* a net line goes and *how* it
+is formatted. Every direct-edit net injector consumes it; none re-encodes the
+rule. (CLAUDE.md Rule 3 — a semantic distinction gets a single source of truth.)
+"""
+
+import re
+from typing import List, Optional, Sequence, Tuple
+
+# Escape-aware match for an existing ``(net N "name")`` definition line. The
+# quoted-string body tolerates S-expression escapes (``\"``, ``\\``) so a net
+# name containing an escaped quote does not prematurely terminate the match.
+_NET_LINE_RE = re.compile(r'\(net\s+\d+\s+"(?:[^"\\]|\\.)*"\)')
+
+# Top-level footprint block — used as the KiCad-10 fallback anchor when a fresh
+# board omits the ``(net 0 "")`` sentinel and therefore has no net line to
+# append after.
+_FOOTPRINT_RE = re.compile(r'\n\t\(footprint\b')
+
+
+def find_net_insert_pos(pcb_content: str) -> Optional[int]:
+    """Return the byte offset at which new ``(net ...)`` lines should be inserted.
+
+    Resolution order (canonical KiCad placement, with KiCad-10 fallbacks):
+
+    1. Immediately after the last existing ``(net N "name")`` line.
+    2. Else immediately before the first top-level ``(footprint ...)`` block.
+       (KiCad 10 omits the ``(net 0 "")`` sentinel in fresh boards, so there is
+       no net line to append after.)
+    3. Else immediately before the file's final closing paren.
+
+    Returns ``None`` when no insertion point can be found, so the caller can
+    surface an explicit error rather than silently dropping the nets.
+    """
+    last_net_match = None
+    for m in _NET_LINE_RE.finditer(pcb_content):
+        last_net_match = m
+    if last_net_match is not None:
+        return last_net_match.end()
+
+    fp_match = _FOOTPRINT_RE.search(pcb_content)
+    if fp_match is not None:
+        return fp_match.start()
+
+    pos = pcb_content.rfind('\n)')
+    if pos == -1:
+        return None
+    return pos
+
+
+def format_net_line(net_code: int, net_name: str) -> str:
+    """Format one net definition exactly as it is written into a ``.kicad_pcb``.
+
+    The leading ``\\n\\t`` makes the inserted line stand on its own, indented to
+    match the top-level net block. Callers are responsible for ensuring
+    ``net_name`` needs no further S-expression escaping.
+    """
+    return f'\n\t(net {net_code} "{net_name}")'
+
+
+def inject_net_definitions(
+    pcb_content: str,
+    new_nets: Sequence[Tuple[int, str]],
+) -> Optional[str]:
+    """Insert formatted net lines for ``new_nets`` into ``pcb_content``.
+
+    ``new_nets`` is an ordered sequence of ``(net_code, net_name)`` pairs; the
+    lines are emitted in that order at the single canonical insertion point.
+    Returns the rewritten content, the original unchanged content when
+    ``new_nets`` is empty, or ``None`` when no insertion point exists.
+    """
+    if not new_nets:
+        return pcb_content
+
+    insert_pos = find_net_insert_pos(pcb_content)
+    if insert_pos is None:
+        return None
+
+    new_lines = "".join(format_net_line(code, name) for code, name in new_nets)
+    return pcb_content[:insert_pos] + new_lines + pcb_content[insert_pos:]
+
+
+def existing_net_codes(pcb_content: str) -> List[Tuple[int, str]]:
+    """Return ``(code, name)`` for every existing ``(net N "name")`` line.
+
+    Uses the same escape-aware match as the insertion logic so the two never
+    disagree about what counts as a net line.
+    """
+    out: List[Tuple[int, str]] = []
+    for m in re.finditer(r'\(net\s+(\d+)\s+"((?:[^"\\]|\\.)*)"\)', pcb_content):
+        out.append((int(m.group(1)), m.group(2)))
+    return out

--- a/tests/test_net_injection.py
+++ b/tests/test_net_injection.py
@@ -1,0 +1,158 @@
+"""Tests for utils/net_injection — the single source of truth for inserting
+``(net N "name")`` lines into a .kicad_pcb via direct text editing.
+
+This is the helper that both pcb_nets.add_net and pcb_pipeline's bulk injector
+consume. The fresh-KiCad-10-no-anchor case is the one that previously broke
+build_pcb_from_schematic (electrically-dead boards); it is pinned here, and the
+byte-identical test proves the two call paths agree.
+"""
+
+from kicad_mcp.tools.pcb_nets import _op_add_net
+from kicad_mcp.utils.net_injection import (
+    existing_net_codes,
+    find_net_insert_pos,
+    format_net_line,
+    inject_net_definitions,
+)
+
+# A board with the conventional (net 0 "") sentinel + two named nets.
+PCB_WITH_NETS = (
+    '(kicad_pcb (version 20240108) (generator "test")\n'
+    '\t(net 0 "")\n'
+    '\t(net 1 "GND")\n'
+    '\t(net 2 "VCC")\n'
+    ")\n"
+)
+
+# Fresh KiCad-10 board: NO (net ...) lines at all, footprints present. This is
+# the case the old pipeline copy silently dropped.
+PCB_FRESH_K10 = (
+    '(kicad_pcb (version 20240108) (generator "pcbnew")\n'
+    '\t(general)\n'
+    '\t(footprint "R_0603"\n'
+    '\t\t(at 10 10)\n'
+    '\t)\n'
+    ")\n"
+)
+
+# Degenerate board: no nets, no footprints — only the closing paren to anchor on.
+PCB_NO_NETS_NO_FP = (
+    '(kicad_pcb (version 20240108) (generator "pcbnew")\n'
+    '\t(general)\n'
+    ")\n"
+)
+
+
+# -- format_net_line ---------------------------------------------------------
+
+def test_format_net_line():
+    assert format_net_line(3, "SDA") == '\n\t(net 3 "SDA")'
+
+
+# -- find_net_insert_pos: three resolution branches --------------------------
+
+def test_insert_after_last_net_line():
+    pos = find_net_insert_pos(PCB_WITH_NETS)
+    # Should land right after the closing paren of (net 2 "VCC").
+    assert PCB_WITH_NETS[:pos].endswith('(net 2 "VCC")')
+
+
+def test_insert_before_first_footprint_when_no_nets():
+    """KiCad-10 fallback #1: no net lines → insert before first footprint."""
+    pos = find_net_insert_pos(PCB_FRESH_K10)
+    assert pos is not None
+    # The next top-level token after the insertion point is the footprint block.
+    assert PCB_FRESH_K10[pos:].lstrip("\n\t").startswith("(footprint")
+
+
+def test_insert_before_closing_paren_when_no_nets_no_footprint():
+    """KiCad-10 fallback #2: no nets and no footprints → before final paren."""
+    pos = find_net_insert_pos(PCB_NO_NETS_NO_FP)
+    assert pos is not None
+    assert PCB_NO_NETS_NO_FP[pos:] == "\n)\n"
+
+
+def test_insert_pos_none_when_no_anchor_at_all():
+    assert find_net_insert_pos("garbage with no closing paren") is None
+
+
+# -- inject_net_definitions --------------------------------------------------
+
+def test_inject_empty_returns_unchanged():
+    assert inject_net_definitions(PCB_WITH_NETS, []) == PCB_WITH_NETS
+
+
+def test_inject_single_net_after_existing():
+    out = inject_net_definitions(PCB_WITH_NETS, [(3, "SDA")])
+    assert out is not None
+    assert '\t(net 2 "VCC")\n\t(net 3 "SDA")\n)' in out
+
+
+def test_inject_multiple_nets_in_order():
+    out = inject_net_definitions(PCB_WITH_NETS, [(3, "SDA"), (4, "SCL")])
+    assert out is not None
+    assert '\t(net 3 "SDA")\n\t(net 4 "SCL")\n' in out
+
+
+def test_inject_into_fresh_k10_board():
+    """The regression case: nets must actually land in a fresh K10 board."""
+    out = inject_net_definitions(PCB_FRESH_K10, [(1, "GND"), (2, "VCC")])
+    assert out is not None
+    assert '(net 1 "GND")' in out
+    assert '(net 2 "VCC")' in out
+    # Inserted before the footprint, not lost.
+    assert out.index('(net 1 "GND")') < out.index('(footprint')
+
+
+def test_inject_returns_none_when_no_anchor():
+    assert inject_net_definitions("no anchor here", [(1, "GND")]) is None
+
+
+# -- existing_net_codes ------------------------------------------------------
+
+def test_existing_net_codes():
+    assert existing_net_codes(PCB_WITH_NETS) == [(0, ""), (1, "GND"), (2, "VCC")]
+
+
+def test_existing_net_codes_empty():
+    assert existing_net_codes(PCB_FRESH_K10) == []
+
+
+# -- byte-identical: both call paths agree -----------------------------------
+
+def test_add_net_matches_shared_helper_byte_identical(tmp_path):
+    """_op_add_net's file output must equal a direct shared-helper injection for
+    the same (code, name). This pins that add_net delegates to the one source of
+    truth rather than re-implementing formatting/placement."""
+    pcb = tmp_path / "b.kicad_pcb"
+    pcb.write_text(PCB_WITH_NETS)
+
+    result = _op_add_net(str(pcb), "SDA")
+    assert result["status"] == "ok"
+    assert result["net_code"] == 3
+    via_tool = pcb.read_text()
+
+    via_helper = inject_net_definitions(PCB_WITH_NETS, [(3, "SDA")])
+    assert via_tool == via_helper
+
+
+def test_both_paths_agree_on_fresh_k10_fallback():
+    """The bug was that the bulk path lacked the fallback the single path had.
+    Now both compute the insertion point through find_net_insert_pos, so a fresh
+    K10 board yields the same injection regardless of which path drives it."""
+    new_nets = [(1, "GND"), (2, "VCC")]
+
+    # "single-net path" semantics: sequential injection, one at a time.
+    seq = PCB_FRESH_K10
+    code = 0
+    for _, name in new_nets:
+        code += 1
+        seq = inject_net_definitions(seq, [(code, name)])
+        assert seq is not None
+
+    # "bulk path" semantics: all at once.
+    bulk = inject_net_definitions(PCB_FRESH_K10, new_nets)
+
+    assert seq == bulk
+    assert '(net 1 "GND")' in bulk
+    assert '(net 2 "VCC")' in bulk


### PR DESCRIPTION
## Problem
`build_pcb_from_schematic` was **broken on KiCad 10**: it produced electrically-dead boards (0 nets, 0 pads assigned, 0 tracks, no ground zone) while still returning `status: ok` and exporting gerbers.

## Root cause
`pcb_pipeline._step_inject_nets_and_assign_pads` re-implemented the net-injection logic from `pcb_nets.add_net` (a Rule-3 duplication) and was missing the KiCad-10 fallback. KiCad 10 omits the `(net 0 "")` sentinel from fresh boards, so with no `(net …)` anchor the injection silently no-op'd — leaving every pad unnetted and the autoroute/zone steps with nothing to do. The equivalent fix already lived in `pcb_nets.add_net` but never reached the duplicate.

## Fix
Consolidate both injectors onto a single source of truth — `kicad_mcp.utils.net_injection`:
- `find_net_insert_pos`: after the last `(net …)` → else before the first `(footprint` → else before the file's closing paren (the KiCad-10 fallback chain).
- `inject_net_definitions` / `format_net_line` / `existing_net_codes`.
- Escape-aware net-name matching so names with embedded quotes don't truncate the scan.

`pcb_nets.add_net` and `pcb_pipeline` both consume it now; neither re-encodes the rule (CLAUDE.md Rule 3).

## Verification
Reproduced and fixed on a real 53-component board (the `speed-cal` ESP32 sensor jig, rebuilt from its v5 netlist): **190 pads assigned, 679 tracks routed, 2 GND zones, gerbers exported.**

- Adds `tests/test_net_injection.py` (incl. the fresh-KiCad-10 no-anchor regression + boundary cases).
- Full suite: **1314 passing**; mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)