### PR TITLE
feat(design): firmware-spec front end (firmware → partial schematic)

### DIFF
--- a/AGENT-INSTALL.md
+++ b/AGENT-INSTALL.md
@@ -4,7 +4,7 @@ This file is for you, the AI agent. It tells you what needs to be true on this s
 
 ## What This Is
 
-kicad-mcp is a Model Context Protocol (MCP) server providing <!-- tool-count -->16<!-- /tool-count --> tools for KiCad electronic design automation — schematic capture, PCB layout, autorouting, DRC, and more. Once installed and registered, these tools appear in your tool list and you can design circuit boards conversationally.
+kicad-mcp is a Model Context Protocol (MCP) server providing <!-- tool-count -->17<!-- /tool-count --> tools for KiCad electronic design automation — schematic capture, PCB layout, autorouting, DRC, and more. Once installed and registered, these tools appear in your tool list and you can design circuit boards conversationally.
 
 **Origin:** Built by one person for personal use, on a Mac, with Claude Code. Other platforms *should* work (the code handles macOS, Windows, and Linux) but are untested. PRs for other agents and platforms will be considered.
 
@@ -156,7 +156,7 @@ If you are registered as an MCP server for a project that does KiCad work, the p
 
 ### Client Compatibility
 
-kicad-mcp exposes <!-- tool-count -->16<!-- /tool-count --> tools — well within every known MCP client limit. Claude Code, Cursor (~40-tool limit), and Gemini (~100-tool limit) are all supported.
+kicad-mcp exposes <!-- tool-count -->17<!-- /tool-count --> tools — well within every known MCP client limit. Claude Code, Cursor (~40-tool limit), and Gemini (~100-tool limit) are all supported.
 
 Claude Code is the recommended client: it provides automatic prompt caching (critical for iterative KiCad workflows) and subagent support for parallel exploration tasks.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This tool enables your AI agent to use [KiCad](https://www.kicad.org/) — the i
 
 ## What This Does
 
-You describe what you need — "design a board for this ESP32 circuit" or "here's the schematic, lay out the PCB" — and your AI agent does the rest: drawing the schematic, choosing components, placing them on the board, routing traces, checking for errors, and producing manufacturing-ready files. All using the same KiCad that professional engineers use, with <!-- tool-count -->16<!-- /tool-count --> tools covering the full design workflow.
+You describe what you need — "design a board for this ESP32 circuit" or "here's the schematic, lay out the PCB" — and your AI agent does the rest: drawing the schematic, choosing components, placing them on the board, routing traces, checking for errors, and producing manufacturing-ready files. All using the same KiCad that professional engineers use, with <!-- tool-count -->17<!-- /tool-count --> tools covering the full design workflow.
 
 You don't need to know KiCad. You don't need to know what a PCB layout tool does. You just need an AI agent (like [Claude](https://claude.ai/)).
 
@@ -18,7 +18,7 @@ Your agent will handle the rest — installing prerequisites, cloning the repo, 
 
 **For best results:** Use Claude Opus (not Haiku or Sonnet) with the ability to spawn subagents. For autorouting, use [FreeRouter v2.2.4+](https://github.com/freerouting/freerouting/releases) — v2.2.3+ is 10–30× faster than v2.1.0 and deterministic; see [AGENT-INSTALL.md](AGENT-INSTALL.md) for details. The combination of a capable model and parallel exploration (component research, placement suggestions) dramatically improves PCB design workflows. [Claude Code](https://claude.ai/code) provides automatic prompt caching that speeds up iterative design tasks.
 
-**Client compatibility:** kicad-mcp exposes <!-- tool-count -->16<!-- /tool-count --> tools, well within every known MCP client limit. Claude Code, Cursor, and Gemini are all supported. Claude Code is recommended for its automatic prompt caching and subagent support.
+**Client compatibility:** kicad-mcp exposes <!-- tool-count -->17<!-- /tool-count --> tools, well within every known MCP client limit. Claude Code, Cursor, and Gemini are all supported. Claude Code is recommended for its automatic prompt caching and subagent support.
 
 ## What You Can Ask Your Agent To Do
 
@@ -42,7 +42,7 @@ If you hit a bug, [open an issue](https://github.com/blwfish/kicad-mcp/issues/ne
 
 ### What's Under the Hood
 
-The server provides <!-- tool-count -->16<!-- /tool-count --> tools — 11 domain routers and 5 standalones:
+The server provides <!-- tool-count -->17<!-- /tool-count --> tools — 11 domain routers and 5 standalones:
 
 - **`schematic`** — create and edit circuit schematics, place components, wire connections, labels, sheets
 - **`pcb`** — board layout, footprint placement, nets, routing, copper zones, silkscreen management
@@ -73,7 +73,7 @@ pytest
 ruff check src/ tests/
 ```
 
-Tests cover all <!-- tool-count -->16<!-- /tool-count --> tools across every module — schematic, PCB board setup, footprints, nets, routing, zones, silkscreen, planning, DRC, BOM, autorouting, netlist/patterns — plus utilities like the pcbnew subprocess bridge, component value parsing, and project file handling. Everything is unit-testable without a KiCad installation because PCB operations go through a single subprocess bridge (`run_pcbnew_script`) that's easy to mock.
+Tests cover all <!-- tool-count -->17<!-- /tool-count --> tools across every module — schematic, PCB board setup, footprints, nets, routing, zones, silkscreen, planning, DRC, BOM, autorouting, netlist/patterns — plus utilities like the pcbnew subprocess bridge, component value parsing, and project file handling. Everything is unit-testable without a KiCad installation because PCB operations go through a single subprocess bridge (`run_pcbnew_script`) that's easy to mock.
 
 See [AGENT-INSTALL.md](AGENT-INSTALL.md) for full technical details, architecture, contributing guidelines, and how to add new tools.
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1,6 +1,6 @@
 # Tool Summary
 
-This MCP server exposes <!-- tool-count -->16<!-- /tool-count --> MCP tools for KiCad EDA — 11 domain routers and 5 standalones.
+This MCP server exposes <!-- tool-count -->17<!-- /tool-count --> MCP tools for KiCad EDA — 11 domain routers and 5 standalones.
 
 Each router takes an `operation` parameter that selects the sub-operation.
 Unknown operations return an error listing valid choices.

--- a/src/kicad_mcp/server.py
+++ b/src/kicad_mcp/server.py
@@ -64,6 +64,11 @@ def create_server() -> FastMCP:
 
     register_schematic_layout_tools(mcp)
 
+    # Firmware-spec front end (firmware -> design-intent -> partial schematic)
+    from kicad_mcp.tools.design import register_design_tools
+
+    register_design_tools(mcp)
+
     logger.info("KiCad MCP server initialized with all tool modules")
     return mcp
 

--- a/src/kicad_mcp/tools/design.py
+++ b/src/kicad_mcp/tools/design.py
@@ -1,0 +1,141 @@
+"""``design`` router — firmware-spec front end.
+
+Turns a firmware spec (ESP32-style ``config.h`` ``#define`` pin map) into a
+canonical design-intent doc, and generates a partial ``.kicad_sch`` from it.
+Recovers the MCU-side signal nets deterministically; everything firmware can't
+know (power, passives, connectors, parts) is emitted as an explicit gap manifest
+— never invented.
+
+Operations:
+  import_firmware(firmware_path, out_path?) -> {status, intent_path, summary, gaps}
+      Parse firmware -> design-intent YAML. firmware_path is a config.h file or a
+      directory containing one. Auto-detects the MCU from platformio.ini.
+  generate_schematic(intent_path, schematic_path) -> {status, ...}
+      Materialize MCU + recognized peripherals + signal nets into a .kicad_sch.
+  show_intent(intent_path) -> {status, summary, gaps}
+      Validate + summarize an intent doc (facts vs gaps).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional
+
+from fastmcp import FastMCP
+
+from kicad_mcp.utils.firmware.generate import generate_schematic as _generate
+from kicad_mcp.utils.firmware.intent import (
+    DesignIntent,
+    build_intent,
+    find_board_id,
+    load_intent,
+    save_intent,
+)
+from kicad_mcp.utils.firmware.parse import parse_defines, partition
+
+
+def _find_config_header(firmware_path: str) -> Optional[Path]:
+    """Resolve the config.h to parse from a file or directory path."""
+    p = Path(firmware_path)
+    if p.is_file():
+        return p
+    if p.is_dir():
+        prefer = p / "include" / "config.h"
+        if prefer.exists():
+            return prefer
+        matches = sorted(p.rglob("config.h"))
+        return matches[0] if matches else None
+    return None
+
+
+def _summary(intent: DesignIntent) -> dict[str, Any]:
+    by_kind: dict[str, int] = {}
+    for n in intent.nets:
+        by_kind[n.kind] = by_kind.get(n.kind, 0) + 1
+    return {
+        "mcu": intent.mcu.part if intent.mcu else None,
+        "peripherals": [{"ref": p.ref, "type": p.type} for p in intent.peripherals],
+        "net_count": len(intent.nets),
+        "nets_by_kind": by_kind,
+        "gap_count": len(intent.gaps),
+        "unmodeled_macros": intent.provenance.get("unparsed_count", 0),
+    }
+
+
+def _gaps_list(intent: DesignIntent) -> list[dict[str, str]]:
+    return [{"kind": g.kind, "detail": g.detail} for g in intent.gaps]
+
+
+def register_design_tools(mcp: FastMCP) -> None:
+    """Register the ``design`` router."""
+
+    @mcp.tool()
+    def design(
+        operation: str,
+        firmware_path: str | None = None,
+        intent_path: str | None = None,
+        schematic_path: str | None = None,
+        out_path: str | None = None,
+    ) -> dict:
+        """Firmware-spec front end: firmware -> design-intent -> partial schematic.
+
+        See the module docstring for operations and arguments.
+        """
+        if operation == "import_firmware":
+            return _op_import(firmware_path=firmware_path, out_path=out_path)
+        if operation == "generate_schematic":
+            return _op_generate(intent_path=intent_path, schematic_path=schematic_path)
+        if operation == "show_intent":
+            return _op_show(intent_path=intent_path)
+        return {
+            "status": "error", "code": "unknown_operation",
+            "message": (f"Unknown operation: {operation!r}. "
+                        "Valid: import_firmware, generate_schematic, show_intent."),
+        }
+
+
+def _op_import(*, firmware_path: Optional[str], out_path: Optional[str]) -> dict:
+    if not firmware_path:
+        return {"status": "error", "code": "missing_parameter",
+                "message": "firmware_path is required."}
+    cfg = _find_config_header(firmware_path)
+    if cfg is None:
+        return {"status": "error", "code": "config_not_found",
+                "message": f"No config.h found at or under {firmware_path!r}."}
+
+    board = find_board_id(str(cfg))
+    parsed = partition(parse_defines(cfg.read_text(errors="replace")))
+    intent = build_intent(parsed, firmware_path=str(cfg), board_id=board)
+
+    dest = Path(out_path) if out_path else cfg.parent / "design_intent.yaml"
+    try:
+        save_intent(intent, str(dest))
+    except OSError as e:
+        return {"status": "error", "code": "write_failed",
+                "message": f"Could not write intent doc: {e}"}
+
+    return {
+        "status": "ok", "intent_path": str(dest),
+        "board": board, "summary": _summary(intent), "gaps": _gaps_list(intent),
+    }
+
+
+def _op_generate(*, intent_path: Optional[str], schematic_path: Optional[str]) -> dict:
+    if not intent_path or not schematic_path:
+        return {"status": "error", "code": "missing_parameter",
+                "message": "intent_path and schematic_path are both required."}
+    if not Path(intent_path).exists():
+        return {"status": "error", "code": "intent_not_found",
+                "message": f"Intent doc not found: {intent_path}"}
+    intent = load_intent(intent_path)
+    return _generate(intent, schematic_path)
+
+
+def _op_show(*, intent_path: Optional[str]) -> dict:
+    if not intent_path:
+        return {"status": "error", "code": "missing_parameter",
+                "message": "intent_path is required."}
+    if not Path(intent_path).exists():
+        return {"status": "error", "code": "intent_not_found",
+                "message": f"Intent doc not found: {intent_path}"}
+    intent = load_intent(intent_path)
+    return {"status": "ok", "summary": _summary(intent), "gaps": _gaps_list(intent)}

--- a/src/kicad_mcp/utils/firmware/__init__.py
+++ b/src/kicad_mcp/utils/firmware/__init__.py
@@ -1,0 +1,7 @@
+"""Firmware-spec front end: parse a firmware spec into a design-intent doc and
+generate a partial schematic from it.
+
+See docs/ and the plan: firmware code (#defines) -> design-intent doc
+(facts + flagged gaps) -> partial .kicad_sch (MCU + recognized peripherals +
+signal nets; power/passives/connectors left as explicit gaps).
+"""

--- a/src/kicad_mcp/utils/firmware/generate.py
+++ b/src/kicad_mcp/utils/firmware/generate.py
@@ -1,0 +1,118 @@
+"""Generate a partial ``.kicad_sch`` from a DesignIntent.
+
+Places the MCU + recognized peripherals on a naive grid and wires each net by
+label-at-pin (same net name on every resolved endpoint → KiCad connectivity),
+the same mechanism the schematic-build tools use. Endpoints that don't resolve
+to a real symbol pin are recorded (not silently skipped). Orphan nets get only
+their MCU pin labeled — the far end is left open, matching the intent's gap.
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from kicad_mcp.utils.firmware.intent import DesignIntent
+from kicad_mcp.utils.firmware.knowledge import role_to_pin_name
+from kicad_mcp.utils.firmware.mcu_pinmap import gpio_to_pin_number, pin_number_by_name
+
+_PITCH_MM = 63.5
+_COLS = 4
+
+
+def generate_schematic(intent: DesignIntent, schematic_path: str) -> dict[str, Any]:
+    import kicad_sch_api as ksa
+    from kicad_sch_api.library.cache import get_symbol_cache
+
+    from kicad_mcp.tools.schematic_impl import _kicad_pin_position, _pin_wire_offset
+
+    if intent.mcu is None:
+        return {
+            "status": "error", "code": "no_mcu",
+            "message": "Design intent has no MCU (unresolved board); cannot generate.",
+        }
+
+    cache = get_symbol_cache()
+    sch = ksa.create_schematic("firmware_gen")
+
+    # --- place components (MCU first, then peripherals) ---
+    to_place: list[tuple[str, Optional[str], str]] = [
+        (intent.mcu.ref, intent.mcu.lib_id, intent.mcu.part)
+    ]
+    to_place += [(p.ref, p.lib_id, p.value or p.type) for p in intent.peripherals]
+
+    placed: dict[str, Any] = {}
+    symbols: dict[str, Any] = {}
+    component_errors: list[dict[str, Any]] = []
+    for i, (ref, lib_id, value) in enumerate(to_place):
+        if not lib_id:
+            component_errors.append({"ref": ref, "error": "no lib_id in intent"})
+            continue
+        sym = cache.get_symbol(lib_id)
+        if sym is None:
+            component_errors.append({"ref": ref, "error": f"symbol {lib_id!r} not found"})
+            continue
+        col, row = i % _COLS, i // _COLS
+        pos = (25.4 + col * _PITCH_MM, 25.4 + row * _PITCH_MM)
+        try:
+            comp = sch.components.add(lib_id=lib_id, reference=ref, value=value, position=pos)
+        except Exception as e:  # noqa: BLE001 - record + continue, don't abort the build
+            component_errors.append({"ref": ref, "error": f"add failed: {e}"})
+            continue
+        placed[ref] = comp
+        symbols[ref] = sym
+
+    type_by_ref = {p.ref: p.type for p in intent.peripherals}
+
+    def resolve_pin(ref: str, gpio: Any, role: Any) -> Any:
+        sym = symbols.get(ref)
+        if sym is None:
+            return None
+        if gpio is not None:                       # MCU side
+            return gpio_to_pin_number(sym, int(gpio))
+        ptype = type_by_ref.get(ref)               # peripheral side
+        pin_name = role_to_pin_name(ptype, role) if ptype else None
+        num = pin_number_by_name(sym, pin_name) if pin_name else None
+        if num is None and role:                   # last resort: role == pin name
+            num = pin_number_by_name(sym, role)
+        return num
+
+    # --- wire nets ---
+    nets_by_kind: dict[str, int] = {}
+    endpoints_wired = 0
+    unresolved: list[dict[str, Any]] = []
+    for net in intent.nets:
+        for ep in net.endpoints:
+            if ep.ref not in placed:
+                unresolved.append({"net": net.name, "ref": ep.ref,
+                                   "reason": "component not placed"})
+                continue
+            pin_num = resolve_pin(ep.ref, ep.gpio, ep.role)
+            if pin_num is None:
+                unresolved.append({"net": net.name, "ref": ep.ref,
+                                   "gpio": ep.gpio, "role": ep.role,
+                                   "reason": "pin unresolved"})
+                continue
+            comp = placed[ep.ref]
+            pin_pos = _kicad_pin_position(comp, pin_num)
+            if pin_pos is None:
+                unresolved.append({"net": net.name, "ref": ep.ref, "pin": pin_num,
+                                   "reason": "pin position unavailable"})
+                continue
+            dx, dy = _pin_wire_offset(comp, pin_num, 2.54)
+            lx, ly = pin_pos.x + dx, pin_pos.y + dy
+            sch.add_wire(start=(pin_pos.x, pin_pos.y), end=(lx, ly))
+            sch.add_label(net.name, (lx, ly))
+            endpoints_wired += 1
+        nets_by_kind[net.kind] = nets_by_kind.get(net.kind, 0) + 1
+
+    sch.save(schematic_path)
+    return {
+        "status": "ok",
+        "schematic_path": schematic_path,
+        "components_placed": len(placed),
+        "component_errors": component_errors,
+        "nets_total": len(intent.nets),
+        "nets_by_kind": nets_by_kind,
+        "endpoints_wired": endpoints_wired,
+        "unresolved_endpoints": unresolved,
+        "gaps": len(intent.gaps),
+    }

--- a/src/kicad_mcp/utils/firmware/intent.py
+++ b/src/kicad_mcp/utils/firmware/intent.py
@@ -1,0 +1,291 @@
+"""Design-intent doc: the canonical, human/LLM-editable seam between the
+firmware importer and the schematic generator.
+
+``build_intent`` turns parsed firmware into a ``DesignIntent`` — high-confidence
+*facts* (MCU, peripherals, signal nets) plus an explicit *gap* manifest for
+everything firmware can't know (power, passives, connectors, parts). Nets carry
+a confidence tier (bus / peripheral / orphan). YAML is the on-disk form.
+"""
+from __future__ import annotations
+
+import dataclasses
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+from kicad_mcp.utils.firmware.knowledge import resolve_mcu, resolve_peripheral
+from kicad_mcp.utils.firmware.parse import ParsedFirmware
+
+SCHEMA_VERSION = 1
+
+# Gap categories firmware is structurally blind to — always emitted so the doc
+# is honest about what a human/LLM must still supply.
+_ALWAYS_GAPS = [
+    ("power_tree", "Firmware declares no power rails or regulator."),
+    ("decoupling", "Decoupling/bypass capacitors are not in firmware."),
+    ("pullups", "Pull-up/down resistors (I2C, EN, boot) are not in firmware."),
+    ("connectors", "Connector parts and pinouts are not in firmware."),
+    ("parts", "Part numbers/footprints beyond recognized ICs are not in firmware."),
+]
+
+
+@dataclass
+class Endpoint:
+    ref: str
+    gpio: Optional[int] = None   # set on the MCU side
+    role: Optional[str] = None   # firmware signal-role on the peripheral side
+
+
+@dataclass
+class Net:
+    name: str
+    kind: str                    # "bus" | "peripheral" | "orphan"
+    confidence: str              # "high" | "low"
+    endpoints: list[Endpoint] = field(default_factory=list)
+    bus: Optional[str] = None
+    origin: str = "imported"     # "imported" | "user" — merge preserves "user"
+
+
+@dataclass
+class Peripheral:
+    ref: str
+    type: str
+    lib_id: Optional[str] = None
+    value: Optional[str] = None
+    bus: Optional[str] = None
+    address: Optional[int] = None
+    origin: str = "imported"
+
+
+@dataclass
+class Mcu:
+    ref: str
+    part: str
+    lib_id: str
+
+
+@dataclass
+class Gap:
+    kind: str
+    detail: str = ""
+    resolved: bool = False
+
+
+@dataclass
+class DesignIntent:
+    schema_version: int = SCHEMA_VERSION
+    source: dict[str, Any] = field(default_factory=dict)
+    mcu: Optional[Mcu] = None
+    peripherals: list[Peripheral] = field(default_factory=list)
+    nets: list[Net] = field(default_factory=list)
+    gaps: list[Gap] = field(default_factory=list)
+    provenance: dict[str, Any] = field(default_factory=dict)
+
+
+# --- platformio board detection ----------------------------------------------
+
+_BOARD_RE = re.compile(r"^\s*board\s*=\s*(\S+)", re.MULTILINE)
+
+
+def find_board_id(start_path: str) -> Optional[str]:
+    """Walk up from a firmware file/dir to find platformio.ini and read its
+    ``board =`` id. Returns None if not found."""
+    p = Path(start_path)
+    search_dirs = [p] if p.is_dir() else [p.parent]
+    cur = search_dirs[0]
+    for _ in range(6):  # bounded walk-up
+        ini = cur / "platformio.ini"
+        if ini.exists():
+            m = _BOARD_RE.search(ini.read_text(errors="replace"))
+            if m:
+                return m.group(1).strip()
+        if cur.parent == cur:
+            break
+        cur = cur.parent
+    return None
+
+
+# --- importer ----------------------------------------------------------------
+
+def _strip_pin_suffix(name: str) -> str:
+    for suf in ("_PIN", "_GPIO"):
+        if name.endswith(suf):
+            return name[: -len(suf)]
+    return name
+
+
+def _peripheral_type_from_addr(name: str) -> str:
+    for suf in ("_ADDRESS", "_ADDR"):
+        if name.endswith(suf):
+            return name[: -len(suf)]
+    return name
+
+
+def build_intent(
+    parsed: ParsedFirmware, *, firmware_path: str, board_id: Optional[str],
+) -> DesignIntent:
+    """Assemble a DesignIntent from parsed firmware. Deterministic ordering."""
+    intent = DesignIntent()
+    intent.source = {"firmware_path": firmware_path, "board": board_id}
+
+    # --- MCU ---
+    mcu_info = resolve_mcu(board_id)
+    if mcu_info is not None:
+        intent.mcu = Mcu(ref="U1", part=mcu_info["part"], lib_id=mcu_info["lib_id"])
+    else:
+        intent.gaps.append(Gap("mcu_unknown",
+                               f"Could not resolve MCU from board id {board_id!r}."))
+
+    # --- collect candidate peripheral types (addresses + pin hints) ---
+    addr_by_type: dict[str, int] = {}
+    for a in parsed.addresses:
+        addr_by_type.setdefault(_peripheral_type_from_addr(a.name), a.address or 0)
+    hint_types = {
+        m.peripheral_hint for m in parsed.pins
+        if m.peripheral_hint and m.bus is None
+    }
+    candidate_types = sorted(set(addr_by_type) | {h for h in hint_types if h})
+
+    # --- materialize peripherals we have a symbol for ---
+    peripherals: list[Peripheral] = []
+    periph_by_type: dict[str, Peripheral] = {}
+    next_ref = 2
+    for t in candidate_types:
+        info = resolve_peripheral(t)
+        if info is None:
+            intent.gaps.append(Gap(
+                "unknown_peripheral",
+                f"Peripheral {t!r} is referenced by firmware but has no known "
+                f"symbol; not placed.",
+            ))
+            continue
+        p = Peripheral(
+            ref=f"U{next_ref}", type=t, lib_id=info["lib_id"], value=info["value"],
+            bus=info["bus"], address=addr_by_type.get(t),
+        )
+        next_ref += 1
+        peripherals.append(p)
+        periph_by_type[t] = p
+    intent.peripherals = peripherals
+
+    by_bus: dict[str, list[Peripheral]] = {}
+    for p in peripherals:
+        if p.bus:
+            by_bus.setdefault(p.bus, []).append(p)
+
+    # --- nets, with first-wins on duplicate net names ---
+    mcu_ref = intent.mcu.ref if intent.mcu else "U1"
+    seen_names: set[str] = set()
+    for m in parsed.pins:
+        name = _strip_pin_suffix(m.name)
+        if name in seen_names:
+            intent.gaps.append(Gap(
+                "duplicate_signal",
+                f"Duplicate signal name {name!r} (macro {m.name}); first-wins.",
+            ))
+            continue
+        seen_names.add(name)
+        mcu_ep = Endpoint(ref=mcu_ref, gpio=m.gpio)
+
+        if m.bus is not None:
+            devices = by_bus.get(m.bus, [])
+            if devices:
+                eps = [mcu_ep] + [Endpoint(ref=d.ref, role=m.signal_role) for d in devices]
+                intent.nets.append(Net(name, "bus", "high", eps, bus=m.bus))
+            else:
+                intent.nets.append(Net(name, "orphan", "low", [mcu_ep], bus=m.bus))
+                intent.gaps.append(Gap(
+                    "unknown_peripheral",
+                    f"{m.bus} signal {name!r} on GPIO{m.gpio}: no {m.bus} device "
+                    f"declared in firmware — far end unknown.",
+                ))
+        elif m.peripheral_hint and m.peripheral_hint in periph_by_type:
+            dev = periph_by_type[m.peripheral_hint]
+            eps = [mcu_ep, Endpoint(ref=dev.ref, role=m.signal_role)]
+            intent.nets.append(Net(name, "peripheral", "high", eps))
+        else:
+            intent.nets.append(Net(name, "orphan", "low", [mcu_ep]))
+            intent.gaps.append(Gap(
+                "unknown_peripheral",
+                f"Signal {name!r} on GPIO{m.gpio}: peripheral "
+                f"{m.peripheral_hint or '?'!r} has no known symbol — far end unknown.",
+            ))
+
+    # --- invalid pins (kept + flagged, never wired) ---
+    for m in parsed.invalid_pins:
+        intent.gaps.append(Gap(
+            "invalid_pin",
+            f"{m.name} = {m.raw_value} ({m.note}); not wired.",
+        ))
+
+    # --- always-on firmware-blind gaps ---
+    for kind, detail in _ALWAYS_GAPS:
+        intent.gaps.append(Gap(kind, detail))
+
+    # --- provenance: retain every unmodeled macro (data-capture rule) ---
+    intent.provenance = {
+        "source_file": firmware_path,
+        "board": board_id,
+        "unparsed": [
+            {"name": m.name, "value": m.raw_value, "line": m.line_no}
+            for m in parsed.other
+        ],
+        "unparsed_count": len(parsed.other),
+    }
+    return intent
+
+
+# --- (de)serialization --------------------------------------------------------
+
+def to_dict(intent: DesignIntent) -> dict[str, Any]:
+    return dataclasses.asdict(intent)
+
+
+def from_dict(d: dict[str, Any]) -> DesignIntent:
+    mcu_d = d.get("mcu")
+    return DesignIntent(
+        schema_version=d.get("schema_version", SCHEMA_VERSION),
+        source=d.get("source", {}),
+        mcu=Mcu(**mcu_d) if mcu_d else None,
+        peripherals=[Peripheral(**p) for p in d.get("peripherals", [])],
+        nets=[
+            Net(
+                name=n["name"], kind=n["kind"], confidence=n["confidence"],
+                endpoints=[Endpoint(**e) for e in n.get("endpoints", [])],
+                bus=n.get("bus"), origin=n.get("origin", "imported"),
+            )
+            for n in d.get("nets", [])
+        ],
+        gaps=[Gap(**g) for g in d.get("gaps", [])],
+        provenance=d.get("provenance", {}),
+    )
+
+
+def save_intent(intent: DesignIntent, path: str) -> None:
+    with open(path, "w") as f:
+        yaml.safe_dump(to_dict(intent), f, sort_keys=False, default_flow_style=False)
+
+
+def load_intent(path: str) -> DesignIntent:
+    with open(path) as f:
+        return from_dict(yaml.safe_load(f))
+
+
+def merge(existing: DesignIntent, fresh: DesignIntent) -> DesignIntent:
+    """Re-import without clobbering hand edits. ``fresh`` (importer output) wins
+    for imported facts; user-authored items (``origin == "user"``) from
+    ``existing`` are preserved, and any gaps the user marked resolved stay
+    resolved."""
+    out = dataclasses.replace(fresh)
+    existing_user_peri = [p for p in existing.peripherals if p.origin == "user"]
+    existing_user_nets = [n for n in existing.nets if n.origin == "user"]
+    out.peripherals = list(fresh.peripherals) + existing_user_peri
+    out.nets = list(fresh.nets) + existing_user_nets
+    resolved = {(g.kind, g.detail) for g in existing.gaps if g.resolved}
+    for g in out.gaps:
+        if (g.kind, g.detail) in resolved:
+            g.resolved = True
+    return out

--- a/src/kicad_mcp/utils/firmware/knowledge.py
+++ b/src/kicad_mcp/utils/firmware/knowledge.py
@@ -1,0 +1,87 @@
+"""Seed knowledge base — the single source of truth (CLAUDE.md Rule 3) for:
+
+  * MCU board-id  -> symbol/part        (``resolve_mcu``)
+  * peripheral type -> symbol + bus + role→pin-name map (``resolve_peripheral``)
+
+Deliberately small and explicit. A firmware ``#define`` names a *role*
+(``HX711_SCK_PIN``, role ``SCK``); the device symbol names the *pin*. These are
+NOT always equal — e.g. the MCP23017 symbol's I2C-clock pin is named ``SCK`` and
+its data pin ``SDA``; the HX711 clock pin is named ``PD_SCK``. The ``roles`` map
+below captures that firmware-role → symbol-pin-name translation per peripheral,
+so no caller assumes identity. (Pin *names* verified against the symbols used in
+the speed-cal v5 netlist.)
+
+Unknown MCUs / peripherals resolve to ``None`` — the importer turns that into an
+explicit gap rather than guessing.
+"""
+from __future__ import annotations
+
+from typing import Optional, TypedDict
+
+
+class McuInfo(TypedDict):
+    part: str
+    lib_id: str
+    value: str
+
+
+class PeripheralInfo(TypedDict):
+    lib_id: str
+    value: str
+    bus: Optional[str]
+    # firmware signal-role (upper-cased) -> symbol pin NAME
+    roles: dict[str, str]
+
+
+# board-id substrings (from platformio.ini ``board =``) -> MCU.
+_MCUS: dict[str, McuInfo] = {
+    "esp32dev": {"part": "ESP32-WROOM-32E", "lib_id": "RF_Module:ESP32-WROOM-32E",
+                 "value": "ESP32-WROOM-32E"},
+    "esp32": {"part": "ESP32-WROOM-32E", "lib_id": "RF_Module:ESP32-WROOM-32E",
+              "value": "ESP32-WROOM-32E"},
+}
+
+_PERIPHERALS: dict[str, PeripheralInfo] = {
+    "MCP23017": {
+        "lib_id": "Interface_Expansion:MCP23017x-x-SO",
+        "value": "MCP23017", "bus": "I2C",
+        # NB: I2C clock pin is named "SCK" on this symbol, not "SCL".
+        "roles": {"SDA": "SDA", "SCL": "SCK", "INT": "INTA", "INTA": "INTA"},
+    },
+    "HX711": {
+        "lib_id": "Analog_ADC:HX711",
+        "value": "HX711", "bus": None,
+        "roles": {"DOUT": "DOUT", "SCK": "PD_SCK", "PD_SCK": "PD_SCK"},
+    },
+}
+
+
+def resolve_mcu(board_id: Optional[str]) -> Optional[McuInfo]:
+    """Map a platformio ``board =`` id to an MCU. Exact match first, then
+    substring (so ``esp32dev`` and ``esp32-s3-...`` both resolve)."""
+    if not board_id:
+        return None
+    key = board_id.strip().lower()
+    if key in _MCUS:
+        return _MCUS[key]
+    for sub, info in _MCUS.items():
+        if sub in key:
+            return info
+    return None
+
+
+def resolve_peripheral(type_name: Optional[str]) -> Optional[PeripheralInfo]:
+    """Map a peripheral type (e.g. ``MCP23017``, derived from ``MCP23017_ADDR``
+    or a pin macro's name prefix) to its symbol + role map."""
+    if not type_name:
+        return None
+    return _PERIPHERALS.get(type_name.strip().upper())
+
+
+def role_to_pin_name(type_name: str, role: Optional[str]) -> Optional[str]:
+    """Translate a firmware signal-role to the device symbol's pin NAME, or
+    None if unknown (caller flags it)."""
+    info = resolve_peripheral(type_name)
+    if info is None or role is None:
+        return None
+    return info["roles"].get(role.upper())

--- a/src/kicad_mcp/utils/firmware/mcu_pinmap.py
+++ b/src/kicad_mcp/utils/firmware/mcu_pinmap.py
@@ -1,0 +1,47 @@
+"""Resolve signals to symbol pin NUMBERS.
+
+Two pure helpers over a kicad-sch-api symbol's ``.pins`` list:
+
+  * ``gpio_to_pin_number`` — maps an MCU GPIO number to the symbol pin whose
+    name carries the ``IO{n}`` token (ESP32 names pins ``IO21``, ``RXD0/IO3``,
+    ``IO0`` …). Derived from the symbol's own pin names — no hardcoded table —
+    so it generalizes to any ESP32 variant whose pins follow the ``IO{n}``
+    convention. Returns None (caller flags) when no such pin exists, e.g.
+    input-only ``SENSOR_VP``/``SENSOR_VN`` pins that lack an ``IO`` token.
+  * ``pin_number_by_name`` — exact pin-name lookup (for peripheral pins whose
+    name we resolved via the knowledge ``roles`` map).
+
+Tokenized matching (split on non-alphanumerics) prevents ``IO3`` from matching
+``IO35``.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any, Optional
+
+_TOKEN_RE = re.compile(r"[^A-Za-z0-9]+")
+
+
+def _tokens(name: str) -> list[str]:
+    return [t for t in _TOKEN_RE.split(name) if t]
+
+
+def gpio_to_pin_number(symbol: Any, gpio: int) -> Optional[str]:
+    """Return the pin NUMBER (str) for the symbol pin naming GPIO ``gpio``."""
+    if symbol is None:
+        return None
+    want = f"IO{gpio}"
+    for pin in getattr(symbol, "pins", None) or ():
+        if want in _tokens(pin.name or ""):
+            return str(pin.number)
+    return None
+
+
+def pin_number_by_name(symbol: Any, pin_name: Optional[str]) -> Optional[str]:
+    """Return the pin NUMBER (str) for the pin named exactly ``pin_name``."""
+    if symbol is None or not pin_name:
+        return None
+    for pin in getattr(symbol, "pins", None) or ():
+        if (pin.name or "") == pin_name:
+            return str(pin.number)
+    return None

--- a/src/kicad_mcp/utils/firmware/parse.py
+++ b/src/kicad_mcp/utils/firmware/parse.py
@@ -1,0 +1,226 @@
+"""``#define`` extraction + classification — the single source of truth for
+"what kind of thing is this macro" (CLAUDE.md Rule 3).
+
+The hard lesson from real firmware (mr-esp32 speed-cal ``config.h``): a macro's
+*value* cannot classify it. The file is full of GPIO-range integers that are NOT
+pins (``NUM_SENSORS 6``, ``MAX_SENSORS 16``, ``AUDIO_DMA_BUF_COUNT 4``) and hex
+values that are NOT I2C addresses (the ``MCP_IODIRA 0x00`` … ``MCP_GPIOB 0x13``
+register table). So:
+
+  * The **name** decides candidacy: a macro is a *pin* only if its name ends in
+    ``_PIN`` / ``_GPIO`` or is a known bare alias (``I2C_SDA`` / ``I2C_SCL``); an
+    *address* only if its name ends in ``_ADDR`` / ``_ADDRESS``.
+  * The **value** only *validates* (a pin's value must be a plausible GPIO int;
+    an address's value must be an int).
+
+Every macro is returned with a disposition. Nothing is silently dropped — macros
+we don't model are kept as ``MacroKind.OTHER`` with their raw text (data-capture
+rule), so a caller can surface them in ``provenance.unparsed``.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+# ESP32 GPIO numbers span 0..48 across the family (classic ~0..39, S2/S3 up to
+# 48). We accept the generous upper bound here as a *plausibility* gate; the
+# authoritative check is whether the MCU symbol actually exposes an IO{n} pin,
+# which the generator does later. A pin-named macro whose value is outside this
+# range (e.g. the common ``-1`` "unused" sentinel) is kept but flagged.
+GPIO_MIN = 0
+GPIO_MAX = 48
+
+# Bare signal names that are pins despite lacking a ``_PIN`` suffix. This is an
+# explicit, audited allow-list — NOT a naming-convention guess. speed-cal uses
+# bare ``I2C_SDA`` / ``I2C_SCL``; track-geometry uses ``I2C_SDA_PIN`` (caught by
+# the suffix rule). Extend deliberately, with evidence.
+BARE_PIN_ALIASES = frozenset({"I2C_SDA", "I2C_SCL"})
+
+_PIN_SUFFIXES = ("_PIN", "_GPIO")
+_ADDR_SUFFIXES = ("_ADDR", "_ADDRESS")
+
+# Bus prefixes recognized in a pin macro's name -> canonical bus id.
+_BUS_PREFIXES = {
+    "I2C": "I2C",
+    "I2S": "I2S",
+    "SPI": "SPI",
+    "UART": "UART",
+}
+
+# #define NAME[(args)] value... [// comment]   (object-like only; function-like
+# macros — NAME immediately followed by '(' — are captured but flagged so we
+# never treat ``MIN(a,b)`` as a value.)
+_DEFINE_RE = re.compile(
+    r"^\s*#\s*define\s+(?P<name>[A-Za-z_]\w*)(?P<args>\([^)]*\))?"
+    r"(?:[ \t]+(?P<value>[^\n]*?))?[ \t]*$"
+)
+_TRAILING_COMMENT_RE = re.compile(r"(?P<value>.*?)\s*//(?P<comment>.*)$")
+
+
+class MacroKind(str, Enum):
+    PIN = "pin"
+    ADDRESS = "address"
+    OTHER = "other"          # numeric/string config, registers, counts, etc.
+    FUNCTION = "function"    # function-like macro, not a value
+    EMPTY = "empty"          # include guard / value-less define
+
+
+@dataclass
+class Macro:
+    """One ``#define`` and its classification. ``raw_value`` is always retained
+    verbatim so nothing is lost even when we don't model the macro."""
+    name: str
+    raw_value: str
+    line_no: int
+    comment: str = ""
+    kind: MacroKind = MacroKind.OTHER
+    # Populated for PIN: the validated GPIO number, or None if the name says
+    # "pin" but the value isn't a plausible GPIO (kept + flagged).
+    gpio: Optional[int] = None
+    pin_value_valid: bool = True
+    # Populated for ADDRESS: the integer address (hex or decimal source).
+    address: Optional[int] = None
+    # Populated for PIN: parsed (peripheral_hint, signal_role, bus) from the name.
+    peripheral_hint: Optional[str] = None
+    signal_role: Optional[str] = None
+    bus: Optional[str] = None
+    # Reason a pin-named macro was rejected, for provenance.
+    note: str = ""
+
+
+def _as_int(raw: str) -> Optional[int]:
+    """Parse an integer literal (decimal or ``0x``), tolerating C int suffixes.
+    Returns None for floats, strings, expressions — i.e. "not a plain int"."""
+    s = raw.strip()
+    # Reject obvious non-ints fast (strings, floats with a dot, multi-token).
+    if not s or '"' in s or "'" in s or "." in s or " " in s:
+        return None
+    s = s.rstrip("uUlL")
+    try:
+        return int(s, 0)
+    except ValueError:
+        return None
+
+
+def _split_comment(value_field: str) -> tuple[str, str]:
+    m = _TRAILING_COMMENT_RE.match(value_field)
+    if m:
+        return m.group("value").strip(), m.group("comment").strip()
+    return value_field.strip(), ""
+
+
+def parse_pin_name(name: str) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    """Split a pin macro name into ``(peripheral_hint, signal_role, bus)``.
+
+    Heuristic and best-effort — the result is a *hint* the generator validates
+    against real symbols; it is never load-bearing on its own.
+
+      ``I2C_SDA``            -> (None, "SDA", "I2C")
+      ``I2S_SCK_PIN``        -> (None, "SCK", "I2S")
+      ``HX711_DOUT_PIN``     -> ("HX711", "DOUT", None)
+      ``MCP23017_INT_PIN``   -> ("MCP23017", "INT", None)
+      ``PIEZO_ADC_PIN``      -> ("PIEZO", "ADC", None)
+    """
+    base = name
+    for suf in _PIN_SUFFIXES:
+        if base.endswith(suf):
+            base = base[: -len(suf)]
+            break
+    parts = base.split("_")
+    if not parts:
+        return (None, None, None)
+    if parts[0] in _BUS_PREFIXES:
+        bus = _BUS_PREFIXES[parts[0]]
+        role = "_".join(parts[1:]) or None
+        return (None, role, bus)
+    if len(parts) == 1:
+        # Just a peripheral name with no role, e.g. ``BUZZER_PIN``.
+        return (parts[0], None, None)
+    # First token = peripheral hint, remainder = role.
+    return (parts[0], "_".join(parts[1:]), None)
+
+
+def classify(name: str, value: str, args: Optional[str]) -> Macro:
+    """Classify a single macro. Pure; name-primary, value-validating."""
+    if args:
+        return Macro(name=name, raw_value=value, line_no=0,
+                     kind=MacroKind.FUNCTION, note="function-like macro")
+    if value == "":
+        return Macro(name=name, raw_value="", line_no=0, kind=MacroKind.EMPTY)
+
+    # ADDRESS: name says address AND value is an int.
+    if name.endswith(_ADDR_SUFFIXES):
+        ival = _as_int(value)
+        if ival is not None:
+            return Macro(name=name, raw_value=value, line_no=0,
+                         kind=MacroKind.ADDRESS, address=ival)
+        return Macro(name=name, raw_value=value, line_no=0,
+                     kind=MacroKind.OTHER,
+                     note="name suggests address but value is not an integer")
+
+    # PIN: name says pin (suffix or bare alias) — value validates.
+    is_pin_named = name.endswith(_PIN_SUFFIXES) or name in BARE_PIN_ALIASES
+    if is_pin_named:
+        ival = _as_int(value)
+        peripheral, role, bus = parse_pin_name(name)
+        if ival is None:
+            return Macro(name=name, raw_value=value, line_no=0,
+                         kind=MacroKind.OTHER, peripheral_hint=peripheral,
+                         signal_role=role, bus=bus,
+                         note="name suggests pin but value is not an integer")
+        valid = GPIO_MIN <= ival <= GPIO_MAX
+        return Macro(
+            name=name, raw_value=value, line_no=0, kind=MacroKind.PIN,
+            gpio=ival, pin_value_valid=valid,
+            peripheral_hint=peripheral, signal_role=role, bus=bus,
+            note="" if valid else f"value {ival} outside GPIO range "
+                                  f"[{GPIO_MIN},{GPIO_MAX}] (unused/-1?)",
+        )
+
+    return Macro(name=name, raw_value=value, line_no=0, kind=MacroKind.OTHER)
+
+
+def parse_defines(text: str) -> list[Macro]:
+    """Extract and classify every ``#define`` in ``text``. Order-preserving;
+    every macro is returned (nothing dropped)."""
+    out: list[Macro] = []
+    for i, line in enumerate(text.splitlines(), start=1):
+        m = _DEFINE_RE.match(line)
+        if not m:
+            continue
+        name = m.group("name")
+        args = m.group("args")
+        raw_value_field = m.group("value") or ""
+        value, comment = _split_comment(raw_value_field)
+        macro = classify(name, value, args)
+        macro.line_no = i
+        macro.comment = comment
+        out.append(macro)
+    return out
+
+
+@dataclass
+class ParsedFirmware:
+    """The structured result of parsing one firmware header."""
+    pins: list[Macro] = field(default_factory=list)          # valid PIN macros
+    addresses: list[Macro] = field(default_factory=list)     # ADDRESS macros
+    invalid_pins: list[Macro] = field(default_factory=list)  # pin-named, bad value
+    other: list[Macro] = field(default_factory=list)         # everything retained
+
+
+def partition(macros: list[Macro]) -> ParsedFirmware:
+    """Sort classified macros into the buckets the importer consumes. Invalid
+    pins are split out (kept, flagged) rather than mixed with valid ones."""
+    pf = ParsedFirmware()
+    for mac in macros:
+        if mac.kind is MacroKind.PIN and mac.pin_value_valid:
+            pf.pins.append(mac)
+        elif mac.kind is MacroKind.PIN:
+            pf.invalid_pins.append(mac)
+        elif mac.kind is MacroKind.ADDRESS:
+            pf.addresses.append(mac)
+        else:
+            pf.other.append(mac)
+    return pf

--- a/tests/test_firmware_generate.py
+++ b/tests/test_firmware_generate.py
@@ -1,0 +1,105 @@
+"""Tests for pin resolution (CI-safe, fake symbols) + schematic generation
+(gated on a real KiCad symbol library being present)."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from kicad_mcp.utils.firmware.mcu_pinmap import gpio_to_pin_number, pin_number_by_name
+
+
+# --- fake symbol for pin-map unit tests (no KiCad needed) --------------------
+
+@dataclass
+class _Pin:
+    name: str
+    number: str
+
+@dataclass
+class _Sym:
+    pins: list
+
+
+_ESP_LIKE = _Sym(pins=[
+    _Pin("IO21", "33"), _Pin("IO22", "36"), _Pin("IO16", "27"),
+    _Pin("RXD0/IO3", "34"), _Pin("TXD0/IO1", "35"), _Pin("IO0", "25"),
+    _Pin("SENSOR_VP", "5"),    # input-only, no IO token
+])
+
+
+@pytest.mark.parametrize("gpio,expected", [
+    (21, "33"), (22, "36"), (16, "27"),
+    (3, "34"),   # RXD0/IO3
+    (1, "35"),   # TXD0/IO1
+    (0, "25"),
+])
+def test_gpio_to_pin_number(gpio, expected):
+    assert gpio_to_pin_number(_ESP_LIKE, gpio) == expected
+
+def test_gpio_token_does_not_partial_match():
+    # gpio 2 must NOT match "IO21"/"IO22"; gpio 3 must NOT match nonexistent IO35.
+    assert gpio_to_pin_number(_ESP_LIKE, 2) is None
+    assert gpio_to_pin_number(_ESP_LIKE, 5) is None  # SENSOR_VP has no IO token
+
+def test_pin_number_by_name():
+    sym = _Sym(pins=[_Pin("SDA", "13"), _Pin("SCK", "12"), _Pin("INTA", "20")])
+    assert pin_number_by_name(sym, "SDA") == "13"
+    assert pin_number_by_name(sym, "INTA") == "20"
+    assert pin_number_by_name(sym, "MISSING") is None
+    assert pin_number_by_name(sym, None) is None
+
+def test_pin_map_handles_none_symbol():
+    assert gpio_to_pin_number(None, 5) is None
+    assert pin_number_by_name(None, "SDA") is None
+
+
+# --- generation integration (needs real KiCad symbol libraries) --------------
+
+SPEEDCAL_CONFIG = Path(
+    "/Volumes/Files/claude/mr-esp32/speed-cal/firmware/include/config.h"
+)
+
+
+def _kicad_symbols_available() -> bool:
+    try:
+        from kicad_sch_api.library.cache import get_symbol_cache
+        return get_symbol_cache().get_symbol("RF_Module:ESP32-WROOM-32E") is not None
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _kicad_symbols_available(),
+                    reason="KiCad symbol libraries not available")
+@pytest.mark.skipif(not SPEEDCAL_CONFIG.exists(), reason="speed-cal config.h not present")
+def test_generate_speedcal_end_to_end(tmp_path):
+    from kicad_mcp.utils.firmware.generate import generate_schematic
+    from kicad_mcp.utils.firmware.intent import build_intent, find_board_id
+    from kicad_mcp.utils.firmware.parse import parse_defines, partition
+    from kicad_mcp.utils.netlist_parser import extract_netlist_via_cli
+
+    parsed = partition(parse_defines(SPEEDCAL_CONFIG.read_text()))
+    intent = build_intent(parsed, firmware_path=str(SPEEDCAL_CONFIG),
+                          board_id=find_board_id(str(SPEEDCAL_CONFIG)))
+    out = tmp_path / "gen.kicad_sch"
+    res = generate_schematic(intent, str(out))
+
+    assert res["status"] == "ok"
+    assert res["components_placed"] == 3        # ESP32 + MCP23017 + HX711
+    assert not res["component_errors"] and not res["unresolved_endpoints"]
+
+    nl = extract_netlist_via_cli(str(out))
+    assert nl is not None
+
+    def members(name):
+        return {f"{x['component']}.{x['pin']}" for x in nl["nets"].get(name, [])}
+
+    # bus + peripheral nets join the correct pins (matches v5 connectivity)
+    assert members("I2C_SDA") == {"U1.33", "U3.13"}      # ESP32 IO21 ↔ MCP SDA
+    assert members("I2C_SCL") == {"U1.36", "U3.12"}      # ESP32 IO22 ↔ MCP SCL(=SCK pin)
+    assert members("HX711_DOUT") == {"U1.27", "U2.12"}
+    assert members("HX711_SCK") == {"U1.28", "U2.11"}    # firmware SCK -> PD_SCK pin
+    assert members("MCP23017_INT") == {"U1.16", "U3.20"} # -> INTA pin
+    # orphan net: MCU pin only, far end open
+    assert members("I2S_SCK") == {"U1.30"}

--- a/tests/test_firmware_intent.py
+++ b/tests/test_firmware_intent.py
@@ -1,0 +1,138 @@
+"""Tests for the design-intent importer + serialization."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from kicad_mcp.utils.firmware.intent import (
+    Gap,
+    Net,
+    build_intent,
+    find_board_id,
+    from_dict,
+    load_intent,
+    merge,
+    save_intent,
+    to_dict,
+)
+from kicad_mcp.utils.firmware.parse import parse_defines, partition
+
+SPEEDCAL_CONFIG = Path(
+    "/Volumes/Files/claude/mr-esp32/speed-cal/firmware/include/config.h"
+)
+
+_SAMPLE = """\
+#define I2C_SDA 21
+#define I2C_SCL 22
+#define MCP23017_ADDR 0x27
+#define MCP23017_INT_PIN 13
+#define HX711_DOUT_PIN 16
+#define HX711_SCK_PIN 17
+#define I2S_SCK_PIN 18
+#define PIEZO_ADC_PIN 35
+#define BAD_PIN -1
+#define MCP_IODIRA 0x00
+#define NUM_SENSORS 6
+"""
+
+
+def _intent(board="esp32dev"):
+    parsed = partition(parse_defines(_SAMPLE))
+    return build_intent(parsed, firmware_path="config.h", board_id=board)
+
+
+def _net(intent, name):
+    return next(n for n in intent.nets if n.name == name)
+
+def _gap_kinds(intent):
+    return {g.kind for g in intent.gaps}
+
+
+def test_mcu_resolved():
+    assert _intent().mcu.part == "ESP32-WROOM-32E"
+
+def test_mcu_unknown_when_no_board():
+    i = _intent(board=None)
+    assert i.mcu is None and "mcu_unknown" in _gap_kinds(i)
+
+def test_peripherals_materialized():
+    types = {p.type for p in _intent().peripherals}
+    assert types == {"HX711", "MCP23017"}  # PIEZO has no symbol -> not placed
+
+def test_bus_net_tier():
+    n = _net(_intent(), "I2C_SDA")
+    assert n.kind == "bus" and n.confidence == "high"
+    # MCU + the one I2C device (MCP23017 = U3 in this sample)
+    assert any(e.role == "SDA" for e in n.endpoints)
+    assert any(e.gpio == 21 for e in n.endpoints)
+
+def test_peripheral_net_tier():
+    n = _net(_intent(), "HX711_DOUT")
+    assert n.kind == "peripheral" and n.confidence == "high"
+    assert {e.role for e in n.endpoints if e.role} == {"DOUT"}
+
+def test_orphan_net_tiers():
+    i = _intent()
+    assert _net(i, "I2S_SCK").kind == "orphan"     # no I2S device declared
+    assert _net(i, "PIEZO_ADC").kind == "orphan"   # PIEZO has no symbol
+
+def test_always_gaps_present():
+    assert {"power_tree", "decoupling", "pullups", "connectors", "parts"} <= _gap_kinds(_intent())
+
+def test_invalid_pin_becomes_gap_not_net():
+    i = _intent()
+    assert "invalid_pin" in _gap_kinds(i)
+    assert all(n.name != "BAD" for n in i.nets)
+
+def test_unknown_peripheral_gaps():
+    # I2S (no device) and PIEZO (no symbol) each flag a gap.
+    details = " ".join(g.detail for g in _intent().gaps if g.kind == "unknown_peripheral")
+    assert "I2S" in details and "PIEZO" in details
+
+def test_provenance_retains_unmodeled_macros():
+    prov = _intent().provenance
+    names = {u["name"] for u in prov["unparsed"]}
+    assert "MCP_IODIRA" in names and "NUM_SENSORS" in names
+    assert prov["unparsed_count"] >= 2
+
+def test_duplicate_signal_first_wins():
+    parsed = partition(parse_defines("#define FOO_PIN 5\n#define FOO_PIN 6\n"))
+    i = build_intent(parsed, firmware_path="c.h", board_id="esp32dev")
+    foo = [n for n in i.nets if n.name == "FOO"]
+    assert len(foo) == 1
+    assert foo[0].endpoints[0].gpio == 5            # first wins
+    assert "duplicate_signal" in _gap_kinds(i)
+
+
+# --- serialization + merge ---------------------------------------------------
+
+def test_yaml_round_trip(tmp_path):
+    i = _intent()
+    p = tmp_path / "intent.yaml"
+    save_intent(i, str(p))
+    assert to_dict(load_intent(str(p))) == to_dict(i)
+
+def test_from_dict_to_dict_identity():
+    i = _intent()
+    assert to_dict(from_dict(to_dict(i))) == to_dict(i)
+
+def test_merge_preserves_user_items_and_resolved_gaps():
+    fresh = _intent()
+    existing = _intent()
+    existing.nets.append(Net("USER_NET", "peripheral", "high", [], origin="user"))
+    # mark the power_tree gap resolved in the existing (edited) doc
+    for g in existing.gaps:
+        if g.kind == "power_tree":
+            g.resolved = True
+    merged = merge(existing, fresh)
+    assert any(n.name == "USER_NET" and n.origin == "user" for n in merged.nets)
+    assert any(g.kind == "power_tree" and g.resolved for g in merged.gaps)
+    # imported user-less nets still present
+    assert any(n.name == "I2C_SDA" for n in merged.nets)
+
+
+# --- board detection on the real tree ----------------------------------------
+
+def test_find_board_id_real_speedcal():
+    if not SPEEDCAL_CONFIG.exists():
+        return
+    assert find_board_id(str(SPEEDCAL_CONFIG)) == "esp32dev"

--- a/tests/test_firmware_parse.py
+++ b/tests/test_firmware_parse.py
@@ -1,0 +1,190 @@
+"""Boundary tests for the firmware #define classifier.
+
+The dominant bug family here is the syntactic-semantic seam (CLAUDE.md Rule 3):
+a value in GPIO range that ISN'T a pin, a hex value that ISN'T an address. These
+tests pin the false-positive guards as hard as the happy path, per the
+threshold-boundary rule (at/below/above, ambiguous inputs).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_mcp.utils.firmware.parse import (
+    GPIO_MAX,
+    GPIO_MIN,
+    MacroKind,
+    _as_int,
+    classify,
+    parse_defines,
+    parse_pin_name,
+    partition,
+)
+
+SPEEDCAL_CONFIG = Path(
+    "/Volumes/Files/claude/mr-esp32/speed-cal/firmware/include/config.h"
+)
+
+
+# --- _as_int: the value validator --------------------------------------------
+
+@pytest.mark.parametrize("raw,expected", [
+    ("21", 21),
+    ("0x27", 0x27),       # 39
+    ("400000", 400000),
+    ("-1", -1),
+    ("16U", 16),
+    ("0x13", 0x13),
+    ("87.1f", None),      # float -> not an int
+    ('"SpeedCal"', None), # string
+    ("'a'", None),        # char
+    ("A | B", None),      # expression (has space)
+    ("", None),
+])
+def test_as_int(raw, expected):
+    assert _as_int(raw) == expected
+
+
+# --- the seam: GPIO-range integers that are NOT pins -------------------------
+
+@pytest.mark.parametrize("name,value", [
+    ("NUM_SENSORS", "6"),       # a count, in GPIO range
+    ("MAX_SENSORS", "16"),      # a count, in GPIO range
+    ("AUDIO_DMA_BUF_COUNT", "4"),
+    ("AUDIO_DMA_BUF_LEN", "1024"),
+])
+def test_count_in_gpio_range_is_not_a_pin(name, value):
+    m = classify(name, value, None)
+    assert m.kind is MacroKind.OTHER, f"{name} must not classify as PIN"
+
+
+# --- the seam: hex values that are NOT addresses (the register table) --------
+
+@pytest.mark.parametrize("name,value", [
+    ("MCP_IODIRA", "0x00"),
+    ("MCP_GPIOB", "0x13"),
+    ("MCP_IOCON", "0x0A"),
+])
+def test_register_hex_is_not_an_address(name, value):
+    m = classify(name, value, None)
+    assert m.kind is MacroKind.OTHER, f"{name} (a register) must not be ADDRESS"
+
+
+# --- real pins classify correctly --------------------------------------------
+
+@pytest.mark.parametrize("name,value,gpio,bus,role,peri", [
+    ("I2C_SDA", "21", 21, "I2C", "SDA", None),
+    ("I2C_SCL", "22", 22, "I2C", "SCL", None),
+    ("HX711_DOUT_PIN", "16", 16, None, "DOUT", "HX711"),
+    ("HX711_SCK_PIN", "17", 17, None, "SCK", "HX711"),
+    ("MCP23017_INT_PIN", "13", 13, None, "INT", "MCP23017"),
+    ("PIEZO_ADC_PIN", "35", 35, None, "ADC", "PIEZO"),
+    ("I2S_SCK_PIN", "18", 18, "I2S", "SCK", None),
+    ("I2S_WS_PIN", "19", 19, "I2S", "WS", None),
+])
+def test_real_pins(name, value, gpio, bus, role, peri):
+    m = classify(name, value, None)
+    assert m.kind is MacroKind.PIN
+    assert m.gpio == gpio and m.pin_value_valid
+    assert m.bus == bus and m.signal_role == role and m.peripheral_hint == peri
+
+
+# --- addresses ----------------------------------------------------------------
+
+def test_address_hex():
+    m = classify("MCP23017_ADDR", "0x27", None)
+    assert m.kind is MacroKind.ADDRESS and m.address == 0x27
+
+def test_address_with_non_int_value_is_other():
+    m = classify("SOME_ADDR", '"0x27"', None)
+    assert m.kind is MacroKind.OTHER and "address" in m.note
+
+
+# --- GPIO range boundaries (at / below / above) ------------------------------
+
+@pytest.mark.parametrize("value,valid", [
+    (str(GPIO_MIN), True),       # 0 — valid
+    (str(GPIO_MAX), True),       # 48 — valid
+    (str(GPIO_MAX + 1), False),  # 49 — above range
+    ("-1", False),               # common "unused" sentinel
+])
+def test_gpio_boundaries(value, valid):
+    m = classify("FOO_PIN", value, None)
+    assert m.kind is MacroKind.PIN          # name says pin -> still PIN kind
+    assert m.pin_value_valid is valid
+    if not valid:
+        assert m.note  # flagged, not silently accepted
+
+
+# --- non-pin / non-int names --------------------------------------------------
+
+def test_i2c_freq_is_not_a_pin():
+    # I2C prefix but not a pin name (no _PIN, not a bare alias).
+    m = classify("I2C_FREQ", "400000", None)
+    assert m.kind is MacroKind.OTHER
+
+def test_string_define_is_other():
+    m = classify("WIFI_AP_SSID", '"SpeedCal"', None)
+    assert m.kind is MacroKind.OTHER
+
+def test_pin_named_but_float_value_is_other_with_note():
+    m = classify("WEIRD_PIN", "1.5f", None)
+    assert m.kind is MacroKind.OTHER and "pin" in m.note
+
+def test_function_like_macro():
+    m = classify("MIN", "((a) < (b) ? (a) : (b))", "(a,b)")
+    assert m.kind is MacroKind.FUNCTION
+
+def test_value_less_define_is_empty():
+    m = classify("CONFIG_H", "", None)
+    assert m.kind is MacroKind.EMPTY
+
+
+# --- parse_pin_name -----------------------------------------------------------
+
+@pytest.mark.parametrize("name,expected", [
+    ("I2C_SDA", (None, "SDA", "I2C")),
+    ("I2S_SCK_PIN", (None, "SCK", "I2S")),
+    ("HX711_DOUT_PIN", ("HX711", "DOUT", None)),
+    ("MCP23017_INT_PIN", ("MCP23017", "INT", None)),
+    ("BUZZER_PIN", ("BUZZER", None, None)),
+])
+def test_parse_pin_name(name, expected):
+    assert parse_pin_name(name) == expected
+
+
+# --- full-text parse + duplicate handling ------------------------------------
+
+def test_parse_preserves_duplicates_in_order():
+    text = "#define X_PIN 5\n#define X_PIN 6\n"
+    pins = [m for m in parse_defines(text) if m.kind is MacroKind.PIN]
+    assert [m.gpio for m in pins] == [5, 6]   # both retained; first-wins is downstream
+
+def test_line_numbers_and_comments():
+    text = "// header\n#define HX711_DOUT_PIN 16  // Data out from HX711\n"
+    macros = parse_defines(text)
+    assert len(macros) == 1
+    assert macros[0].line_no == 2
+    assert macros[0].comment == "Data out from HX711"
+
+
+# --- integration: the REAL speed-cal config.h --------------------------------
+
+@pytest.mark.skipif(not SPEEDCAL_CONFIG.exists(), reason="speed-cal config.h not present")
+def test_real_speedcal_config():
+    pf = partition(parse_defines(SPEEDCAL_CONFIG.read_text()))
+    pin_names = {m.name for m in pf.pins}
+    # The actual hardware pins must all be recovered.
+    assert {
+        "I2C_SDA", "I2C_SCL", "MCP23017_INT_PIN", "HX711_DOUT_PIN",
+        "HX711_SCK_PIN", "PIEZO_ADC_PIN", "I2S_SCK_PIN", "I2S_WS_PIN",
+        "I2S_SD_PIN",
+    } <= pin_names
+    # The register table and counts must NOT have leaked into pins.
+    assert not any(m.name.startswith("MCP_") for m in pf.pins)
+    assert "NUM_SENSORS" not in pin_names and "MAX_SENSORS" not in pin_names
+    # The one declared I2C address is recovered.
+    assert any(m.name == "MCP23017_ADDR" and m.address == 0x27 for m in pf.addresses)
+    # I2C_FREQ is config, not a pin.
+    assert "I2C_FREQ" not in pin_names

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,7 +7,7 @@ from fastmcp import FastMCP
 
 from kicad_mcp.server import create_server
 
-EXPECTED_TOOL_COUNT = 16  # updated by scripts/sync_tool_count.py
+EXPECTED_TOOL_COUNT = 17  # updated by scripts/sync_tool_count.py
 
 
 class TestCreateServer:


### PR DESCRIPTION
## What
Adds the missing **front end** of the design pipeline — a `design` router tool that turns an ESP32-style firmware spec into electrical connectivity, feeding the existing schematic-build → PCB chain.

```
config.h ──[importer]──▶ design-intent.yaml ──[generator]──▶ partial .kicad_sch
            (deterministic,   (canonical, editable,           (MCU + recognized
             gaps flagged)     facts + gap manifest)           peripherals + signal nets)
```

## Honest by construction
Firmware only encodes the **MCU-side signal nets** (GPIO ↔ signal, I2C addresses, peripheral type when named). Power, decoupling, pull-ups, regulators, connectors, and part numbers are **emitted as an explicit gap manifest — never invented**. For speed-cal, ~11 of 41 nets are firmware-recoverable; the rest are flagged for a human/LLM to fill in the editable intent doc.

## Scope (v1)
Parse firmware **code** → **design-intent doc** (seam) → **partial schematic**. No peripheral templates, no power tree, no spec.md NLP, no PCB — deliberate Phase-2 extensions on the same spine.

## Design notes
- **`parse.py`** — `#define` classifier is **name-primary, value-validating**. Defeats the real seam traps in `config.h`: GPIO-range integers that aren't pins (`NUM_SENSORS=6`) and the `MCP_* 0x00..0x13` register table that looks like I2C addresses. Every macro retained (unmodeled ones kept in `provenance`).
- **`knowledge.py`** — single source of truth for MCU/peripheral symbols + the **firmware-role → symbol-pin-NAME** map (they differ: MCP23017's SCL pin is named `SCK`; HX711's clock is `PD_SCK`).
- **`intent.py`** — schema + importer + YAML + `merge()`. Three net confidence tiers: **bus / peripheral / orphan** (orphan = MCU side wired, far end flagged).
- **`mcu_pinmap.py`** — GPIO _n_ → symbol pin via the `IO{n}` token, tokenized so `IO3` ≠ `IO35`; no hardcoded table.
- **`generate.py`** — places components, wires nets by label-at-pin; unresolved endpoints recorded, never silently skipped.
- **`tools/design.py`** — `design` router: `import_firmware` / `generate_schematic` / `show_intent`. 17th tool; docs synced via `scripts/sync_tool_count.py`.

## Verification
End-to-end on the **real speed-cal `config.h`**: the generated 3-component schematic, re-extracted via `kicad-cli`, matches the human-designed **v5 netlist exactly** — `I2C_SDA` U1.33↔U3.13, `HX711_SCK` U1.28↔U2.11 (via `PD_SCK`), `MCP23017_INT` ↔ `INTA`, etc.

- `test_firmware_parse.py` (45 — seam/boundary guards incl. real `config.h`)
- `test_firmware_intent.py` (15 — tiers, gaps, round-trip, merge)
- `test_firmware_generate.py` (10 — fake-symbol pin-map units + KiCad-gated E2E)
- Full suite **1384 passing**, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)