### PR TITLE
feat(design): Phase 2 — peripheral-block templates (power & glue)

### DIFF
--- a/src/kicad_mcp/tools/design.py
+++ b/src/kicad_mcp/tools/design.py
@@ -10,6 +10,10 @@ Operations:
   import_firmware(firmware_path, out_path?) -> {status, intent_path, summary, gaps}
       Parse firmware -> design-intent YAML. firmware_path is a config.h file or a
       directory containing one. Auto-detects the MCU from platformio.ini.
+  expand_templates(intent_path, out_path?) -> {status, components_added, gaps_resolved}
+      Expand recognized components into support circuitry (power tree, decoupling,
+      pull-ups, address strapping). Writes the richer intent (in place unless
+      out_path given). Run between import_firmware and generate_schematic.
   generate_schematic(intent_path, schematic_path) -> {status, ...}
       Materialize MCU + recognized peripherals + signal nets into a .kicad_sch.
   show_intent(intent_path) -> {status, summary, gaps}
@@ -31,6 +35,7 @@ from kicad_mcp.utils.firmware.intent import (
     save_intent,
 )
 from kicad_mcp.utils.firmware.parse import parse_defines, partition
+from kicad_mcp.utils.firmware.templates import expand_intent
 
 
 def _find_config_header(firmware_path: str) -> Optional[Path]:
@@ -82,14 +87,16 @@ def register_design_tools(mcp: FastMCP) -> None:
         """
         if operation == "import_firmware":
             return _op_import(firmware_path=firmware_path, out_path=out_path)
+        if operation == "expand_templates":
+            return _op_expand(intent_path=intent_path, out_path=out_path)
         if operation == "generate_schematic":
             return _op_generate(intent_path=intent_path, schematic_path=schematic_path)
         if operation == "show_intent":
             return _op_show(intent_path=intent_path)
         return {
             "status": "error", "code": "unknown_operation",
-            "message": (f"Unknown operation: {operation!r}. "
-                        "Valid: import_firmware, generate_schematic, show_intent."),
+            "message": (f"Unknown operation: {operation!r}. Valid: import_firmware, "
+                        "expand_templates, generate_schematic, show_intent."),
         }
 
 
@@ -116,6 +123,30 @@ def _op_import(*, firmware_path: Optional[str], out_path: Optional[str]) -> dict
     return {
         "status": "ok", "intent_path": str(dest),
         "board": board, "summary": _summary(intent), "gaps": _gaps_list(intent),
+    }
+
+
+def _op_expand(*, intent_path: Optional[str], out_path: Optional[str]) -> dict:
+    if not intent_path:
+        return {"status": "error", "code": "missing_parameter",
+                "message": "intent_path is required."}
+    if not Path(intent_path).exists():
+        return {"status": "error", "code": "intent_not_found",
+                "message": f"Intent doc not found: {intent_path}"}
+    intent = load_intent(intent_path)
+    n_comp_before = len(intent.peripherals)
+    intent = expand_intent(intent)
+    dest = out_path or intent_path
+    try:
+        save_intent(intent, str(dest))
+    except OSError as e:
+        return {"status": "error", "code": "write_failed",
+                "message": f"Could not write expanded intent: {e}"}
+    return {
+        "status": "ok", "intent_path": str(dest),
+        "components_added": len(intent.peripherals) - n_comp_before,
+        "gaps_resolved": [g.kind for g in intent.gaps if g.resolved],
+        "summary": _summary(intent),
     }
 
 

--- a/src/kicad_mcp/utils/firmware/generate.py
+++ b/src/kicad_mcp/utils/firmware/generate.py
@@ -17,6 +17,12 @@ from kicad_mcp.utils.firmware.mcu_pinmap import gpio_to_pin_number, pin_number_b
 _PITCH_MM = 63.5
 _COLS = 4
 
+# Power-rail name -> KiCad power symbol lib_id (verified to resolve).
+_RAIL_LIB = {
+    "+3V3": "power:+3V3", "+5V": "power:+5V",
+    "GND": "power:GND", "VBUS": "power:VBUS",
+}
+
 
 def generate_schematic(intent: DesignIntent, schematic_path: str) -> dict[str, Any]:
     import kicad_sch_api as ksa
@@ -34,15 +40,17 @@ def generate_schematic(intent: DesignIntent, schematic_path: str) -> dict[str, A
     sch = ksa.create_schematic("firmware_gen")
 
     # --- place components (MCU first, then peripherals) ---
-    to_place: list[tuple[str, Optional[str], str]] = [
-        (intent.mcu.ref, intent.mcu.lib_id, intent.mcu.part)
+    to_place: list[tuple[str, Optional[str], str, Optional[str]]] = [
+        (intent.mcu.ref, intent.mcu.lib_id, intent.mcu.part, intent.mcu.footprint)
     ]
-    to_place += [(p.ref, p.lib_id, p.value or p.type) for p in intent.peripherals]
+    to_place += [
+        (p.ref, p.lib_id, p.value or p.type, p.footprint) for p in intent.peripherals
+    ]
 
     placed: dict[str, Any] = {}
     symbols: dict[str, Any] = {}
     component_errors: list[dict[str, Any]] = []
-    for i, (ref, lib_id, value) in enumerate(to_place):
+    for i, (ref, lib_id, value, footprint) in enumerate(to_place):
         if not lib_id:
             component_errors.append({"ref": ref, "error": "no lib_id in intent"})
             continue
@@ -53,7 +61,8 @@ def generate_schematic(intent: DesignIntent, schematic_path: str) -> dict[str, A
         col, row = i % _COLS, i // _COLS
         pos = (25.4 + col * _PITCH_MM, 25.4 + row * _PITCH_MM)
         try:
-            comp = sch.components.add(lib_id=lib_id, reference=ref, value=value, position=pos)
+            comp = sch.components.add(lib_id=lib_id, reference=ref, value=value,
+                                      position=pos, footprint=footprint)
         except Exception as e:  # noqa: BLE001 - record + continue, don't abort the build
             component_errors.append({"ref": ref, "error": f"add failed: {e}"})
             continue
@@ -62,10 +71,15 @@ def generate_schematic(intent: DesignIntent, schematic_path: str) -> dict[str, A
 
     type_by_ref = {p.ref: p.type for p in intent.peripherals}
 
-    def resolve_pin(ref: str, gpio: Any, role: Any) -> Any:
+    def resolve_pin(ref: str, gpio: Any, role: Any, pin: Any) -> Any:
         sym = symbols.get(ref)
         if sym is None:
             return None
+        if pin is not None:                        # direct pin NAME or number
+            num = pin_number_by_name(sym, pin)
+            if num is not None:
+                return num
+            return pin if str(pin).isdigit() else None
         if gpio is not None:                       # MCU side
             return gpio_to_pin_number(sym, int(gpio))
         ptype = type_by_ref.get(ref)               # peripheral side
@@ -74,6 +88,17 @@ def generate_schematic(intent: DesignIntent, schematic_path: str) -> dict[str, A
         if num is None and role:                   # last resort: role == pin name
             num = pin_number_by_name(sym, role)
         return num
+
+    def wire_pin(comp: Any, pin_num: str, net_name: str) -> bool:
+        """Add a wire stub + net label at a pin (the connectivity primitive)."""
+        pin_pos = _kicad_pin_position(comp, pin_num)
+        if pin_pos is None:
+            return False
+        dx, dy = _pin_wire_offset(comp, pin_num, 2.54)
+        lx, ly = pin_pos.x + dx, pin_pos.y + dy
+        sch.add_wire(start=(pin_pos.x, pin_pos.y), end=(lx, ly))
+        sch.add_label(net_name, (lx, ly))
+        return True
 
     # --- wire nets ---
     nets_by_kind: dict[str, int] = {}
@@ -85,24 +110,46 @@ def generate_schematic(intent: DesignIntent, schematic_path: str) -> dict[str, A
                 unresolved.append({"net": net.name, "ref": ep.ref,
                                    "reason": "component not placed"})
                 continue
-            pin_num = resolve_pin(ep.ref, ep.gpio, ep.role)
+            pin_num = resolve_pin(ep.ref, ep.gpio, ep.role, ep.pin)
             if pin_num is None:
-                unresolved.append({"net": net.name, "ref": ep.ref,
-                                   "gpio": ep.gpio, "role": ep.role,
+                unresolved.append({"net": net.name, "ref": ep.ref, "gpio": ep.gpio,
+                                   "role": ep.role, "pin": ep.pin,
                                    "reason": "pin unresolved"})
                 continue
-            comp = placed[ep.ref]
-            pin_pos = _kicad_pin_position(comp, pin_num)
-            if pin_pos is None:
+            if wire_pin(placed[ep.ref], pin_num, net.name):
+                endpoints_wired += 1
+            else:
                 unresolved.append({"net": net.name, "ref": ep.ref, "pin": pin_num,
                                    "reason": "pin position unavailable"})
-                continue
-            dx, dy = _pin_wire_offset(comp, pin_num, 2.54)
-            lx, ly = pin_pos.x + dx, pin_pos.y + dy
-            sch.add_wire(start=(pin_pos.x, pin_pos.y), end=(lx, ly))
-            sch.add_label(net.name, (lx, ly))
-            endpoints_wired += 1
         nets_by_kind[net.kind] = nets_by_kind.get(net.kind, 0) + 1
+
+    # --- idiomatic power-rail markers (best-effort) ---
+    # Rail connectivity is already established by the rail-named labels above;
+    # these add KiCad's conventional power symbol + PWR_FLAG per rail so the net
+    # is recognized as a power rail (and ERC has a driver). Failure never aborts.
+    # Markers go in a clear band BELOW all placed components. Position is
+    # irrelevant to connectivity (labels join by name), but a marker dropped
+    # onto a component pin would merge that pin's net into the rail — so keep
+    # them well clear of the grid.
+    rows = (len(placed) + _COLS - 1) // _COLS
+    marker_y = 25.4 + rows * _PITCH_MM + _PITCH_MM
+    rail_markers = 0
+    pwr_idx = 0
+    for rail in sorted({n.name for n in intent.nets if n.kind == "power"}):
+        rail_lib = _RAIL_LIB.get(rail)
+        if rail_lib is None:
+            continue
+        for mlib in (rail_lib, "power:PWR_FLAG"):
+            if cache.get_symbol(mlib) is None:
+                continue
+            try:
+                mcomp = sch.components.add(lib_id=mlib, reference=f"#PWR{pwr_idx:02d}",
+                                           value=rail, position=(25.4 + pwr_idx * 20.32, marker_y))
+            except Exception:  # noqa: BLE001 - markers are best-effort
+                continue
+            pwr_idx += 1
+            if wire_pin(mcomp, "1", rail):
+                rail_markers += 1
 
     sch.save(schematic_path)
     return {
@@ -113,6 +160,7 @@ def generate_schematic(intent: DesignIntent, schematic_path: str) -> dict[str, A
         "nets_total": len(intent.nets),
         "nets_by_kind": nets_by_kind,
         "endpoints_wired": endpoints_wired,
+        "rail_markers": rail_markers,
         "unresolved_endpoints": unresolved,
         "gaps": len(intent.gaps),
     }

--- a/src/kicad_mcp/utils/firmware/intent.py
+++ b/src/kicad_mcp/utils/firmware/intent.py
@@ -9,6 +9,7 @@ a confidence tier (bus / peripheral / orphan). YAML is the on-disk form.
 from __future__ import annotations
 
 import dataclasses
+import logging
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -16,10 +17,12 @@ from typing import Any, Optional
 
 import yaml
 
+logger = logging.getLogger(__name__)
+
 from kicad_mcp.utils.firmware.knowledge import resolve_mcu, resolve_peripheral
 from kicad_mcp.utils.firmware.parse import ParsedFirmware
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2  # v2: power/passive nets, footprints, template origin, gap provenance
 
 # Gap categories firmware is structurally blind to — always emitted so the doc
 # is honest about what a human/LLM must still supply.
@@ -35,18 +38,20 @@ _ALWAYS_GAPS = [
 @dataclass
 class Endpoint:
     ref: str
-    gpio: Optional[int] = None   # set on the MCU side
+    gpio: Optional[int] = None   # set on the MCU side (resolved via IO{n})
     role: Optional[str] = None   # firmware signal-role on the peripheral side
+    pin: Optional[str] = None    # direct pin NAME/number — for passives & power
+                                 # pins that are neither a GPIO nor a known role
 
 
 @dataclass
 class Net:
     name: str
-    kind: str                    # "bus" | "peripheral" | "orphan"
+    kind: str                    # "bus"|"peripheral"|"orphan"|"power"|"passive"
     confidence: str              # "high" | "low"
     endpoints: list[Endpoint] = field(default_factory=list)
     bus: Optional[str] = None
-    origin: str = "imported"     # "imported" | "user" — merge preserves "user"
+    origin: str = "imported"     # "imported"|"template"|"user" (see merge())
 
 
 @dataclass
@@ -55,9 +60,10 @@ class Peripheral:
     type: str
     lib_id: Optional[str] = None
     value: Optional[str] = None
+    footprint: Optional[str] = None
     bus: Optional[str] = None
     address: Optional[int] = None
-    origin: str = "imported"
+    origin: str = "imported"     # "imported"|"template"|"user"
 
 
 @dataclass
@@ -65,6 +71,7 @@ class Mcu:
     ref: str
     part: str
     lib_id: str
+    footprint: Optional[str] = None
 
 
 @dataclass
@@ -72,6 +79,8 @@ class Gap:
     kind: str
     detail: str = ""
     resolved: bool = False
+    resolved_by: Optional[str] = None             # template name or "user"
+    resolved_components: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -134,7 +143,8 @@ def build_intent(
     # --- MCU ---
     mcu_info = resolve_mcu(board_id)
     if mcu_info is not None:
-        intent.mcu = Mcu(ref="U1", part=mcu_info["part"], lib_id=mcu_info["lib_id"])
+        intent.mcu = Mcu(ref="U1", part=mcu_info["part"], lib_id=mcu_info["lib_id"],
+                         footprint=mcu_info["footprint"])
     else:
         intent.gaps.append(Gap("mcu_unknown",
                                f"Could not resolve MCU from board id {board_id!r}."))
@@ -164,7 +174,7 @@ def build_intent(
             continue
         p = Peripheral(
             ref=f"U{next_ref}", type=t, lib_id=info["lib_id"], value=info["value"],
-            bus=info["bus"], address=addr_by_type.get(t),
+            footprint=info["footprint"], bus=info["bus"], address=addr_by_type.get(t),
         )
         next_ref += 1
         peripherals.append(p)
@@ -245,6 +255,14 @@ def to_dict(intent: DesignIntent) -> dict[str, Any]:
 
 
 def from_dict(d: dict[str, Any]) -> DesignIntent:
+    ver = d.get("schema_version", 1)
+    if ver != SCHEMA_VERSION:
+        # Warn, don't raise: optional fields default-fill, so older docs still
+        # load. A newer doc loaded by older code would silently drop fields.
+        logger.warning(
+            "design-intent schema_version %s != current %s; loading anyway "
+            "(fields may default-fill).", ver, SCHEMA_VERSION,
+        )
     mcu_d = d.get("mcu")
     return DesignIntent(
         schema_version=d.get("schema_version", SCHEMA_VERSION),
@@ -275,17 +293,26 @@ def load_intent(path: str) -> DesignIntent:
 
 
 def merge(existing: DesignIntent, fresh: DesignIntent) -> DesignIntent:
-    """Re-import without clobbering hand edits. ``fresh`` (importer output) wins
-    for imported facts; user-authored items (``origin == "user"``) from
-    ``existing`` are preserved, and any gaps the user marked resolved stay
-    resolved."""
+    """Re-import without clobbering hand edits. Three-way by ``origin``:
+
+    * ``imported`` — ``fresh`` (the new firmware parse) wins.
+    * ``user`` — hand-authored items from ``existing`` are always preserved.
+    * ``template`` — NOT carried here; template-added circuitry is *re-runnable*
+      via ``expand_templates`` (re-running it regenerates the items), so merge
+      drops them rather than risk duplicating on the next expand.
+
+    Gaps the user/existing marked resolved keep ``resolved`` + its provenance.
+    """
     out = dataclasses.replace(fresh)
     existing_user_peri = [p for p in existing.peripherals if p.origin == "user"]
     existing_user_nets = [n for n in existing.nets if n.origin == "user"]
     out.peripherals = list(fresh.peripherals) + existing_user_peri
     out.nets = list(fresh.nets) + existing_user_nets
-    resolved = {(g.kind, g.detail) for g in existing.gaps if g.resolved}
+    resolved = {(g.kind, g.detail): g for g in existing.gaps if g.resolved}
     for g in out.gaps:
-        if (g.kind, g.detail) in resolved:
+        src = resolved.get((g.kind, g.detail))
+        if src is not None:
             g.resolved = True
+            g.resolved_by = src.resolved_by
+            g.resolved_components = list(src.resolved_components)
     return out

--- a/src/kicad_mcp/utils/firmware/knowledge.py
+++ b/src/kicad_mcp/utils/firmware/knowledge.py
@@ -23,37 +23,90 @@ class McuInfo(TypedDict):
     part: str
     lib_id: str
     value: str
+    footprint: str
+    needs_3v3: bool      # board needs a 3V3 supply (power_tree template fires)
+    supply_pin: str      # pin NAME for the 3V3 supply
+    ground_pin: str      # pin NAME for ground (ESP32: the merged "GND" pin)
+    en_pin: str          # chip-enable pin NAME (needs pull-up)
+    boot_pin: str        # boot/strap pin NAME (needs pull-up)
 
 
 class PeripheralInfo(TypedDict):
     lib_id: str
     value: str
     bus: Optional[str]
+    footprint: str
     # firmware signal-role (upper-cased) -> symbol pin NAME
     roles: dict[str, str]
+    supply_pins: list[str]   # pin NAMES tied to +3V3
+    ground_pins: list[str]   # pin NAMES tied to GND
 
+
+# ESP32-WROOM-32E facts. GND is the symbol's MERGED pin (physical pads
+# 1/15/38/39 collapsed) — resolve it by NAME, never by number.
+_ESP32: McuInfo = {
+    "part": "ESP32-WROOM-32E", "lib_id": "RF_Module:ESP32-WROOM-32E",
+    "value": "ESP32-WROOM-32E", "footprint": "RF_Module:ESP32-WROOM-32E",
+    "needs_3v3": True, "supply_pin": "VDD", "ground_pin": "GND",
+    "en_pin": "EN", "boot_pin": "IO0",
+}
 
 # board-id substrings (from platformio.ini ``board =``) -> MCU.
-_MCUS: dict[str, McuInfo] = {
-    "esp32dev": {"part": "ESP32-WROOM-32E", "lib_id": "RF_Module:ESP32-WROOM-32E",
-                 "value": "ESP32-WROOM-32E"},
-    "esp32": {"part": "ESP32-WROOM-32E", "lib_id": "RF_Module:ESP32-WROOM-32E",
-              "value": "ESP32-WROOM-32E"},
-}
+_MCUS: dict[str, McuInfo] = {"esp32dev": _ESP32, "esp32": _ESP32}
 
 _PERIPHERALS: dict[str, PeripheralInfo] = {
     "MCP23017": {
         "lib_id": "Interface_Expansion:MCP23017x-x-SO",
         "value": "MCP23017", "bus": "I2C",
+        "footprint": "Package_SO:SOIC-28W_7.5x17.9mm_P1.27mm",
         # NB: I2C clock pin is named "SCK" on this symbol, not "SCL".
         "roles": {"SDA": "SDA", "SCL": "SCK", "INT": "INTA", "INTA": "INTA"},
+        "supply_pins": ["V_{DD}"], "ground_pins": ["V_{SS}"],
     },
     "HX711": {
         "lib_id": "Analog_ADC:HX711",
         "value": "HX711", "bus": None,
+        "footprint": "Package_SO:SOIC-16_3.9x9.9mm_P1.27mm",
         "roles": {"DOUT": "DOUT", "SCK": "PD_SCK", "PD_SCK": "PD_SCK"},
+        # HX711 has no separate DGND — analog + digital ground share AGND.
+        "supply_pins": ["VSUP", "AVDD", "DVDD"], "ground_pins": ["AGND"],
     },
 }
+
+# --- verified footprints (speed-cal v5 BOM) for template-placed passives ---
+LIB_C = "Device:C"
+LIB_R = "Device:R"
+FP_C_BULK = "Capacitor_SMD:C_0805_2012Metric"     # 10µF
+FP_C_BYPASS = "Capacitor_SMD:C_0603_1608Metric"   # 100nF
+FP_R_0603 = "Resistor_SMD:R_0603_1608Metric"
+
+# AMS1117-3.3 LDO (instantiated by the power_tree template; firmware never names
+# it). Tab = pin 2 (VO) — a copper-pour note for the PCB step, not a separate net.
+AMS1117 = {
+    "lib_id": "Regulator_Linear:AMS1117-3.3", "value": "AMS1117-3.3",
+    "footprint": "Package_TO_SOT_SMD:SOT-223-3_TabPin2",
+    "vin_pin": "VI", "vout_pin": "VO", "gnd_pin": "GND",
+}
+
+# MCP23017 I2C address strapping. Base 0x20; bits A2 A1 A0 select 0x20..0x27.
+MCP23017_ADDRESS_BASE = 0x20
+MCP23017_ADDRESS_PINS = ("A0", "A1", "A2")   # index = bit position
+MCP23017_RESET_PIN = "~{RESET}"
+
+
+def mcp23017_address_straps(address: int) -> Optional[list[tuple[str, str]]]:
+    """Return [(addr_pin_name, rail)] for an MCP23017 I2C address, or None if the
+    address is outside the strappable range 0x20..0x27. Each address pin ties to
+    "+3V3" (bit set) or "GND" (bit clear). This is the single source of truth for
+    the address→strap mapping (the silent-wrong hotspot — boundary-tested)."""
+    offset = address - MCP23017_ADDRESS_BASE
+    if offset < 0 or offset > 0b111:
+        return None
+    out: list[tuple[str, str]] = []
+    for bit, pin in enumerate(MCP23017_ADDRESS_PINS):
+        rail = "+3V3" if (offset >> bit) & 1 else "GND"
+        out.append((pin, rail))
+    return out
 
 
 def resolve_mcu(board_id: Optional[str]) -> Optional[McuInfo]:
@@ -66,6 +119,16 @@ def resolve_mcu(board_id: Optional[str]) -> Optional[McuInfo]:
         return _MCUS[key]
     for sub, info in _MCUS.items():
         if sub in key:
+            return info
+    return None
+
+
+def resolve_mcu_by_part(part: Optional[str]) -> Optional[McuInfo]:
+    """Look up MCU facts by part string (templates have ``intent.mcu.part``)."""
+    if not part:
+        return None
+    for info in _MCUS.values():
+        if info["part"] == part:
             return info
     return None
 

--- a/src/kicad_mcp/utils/firmware/templates.py
+++ b/src/kicad_mcp/utils/firmware/templates.py
@@ -1,0 +1,277 @@
+"""Peripheral-block templates: expand recognized components into their mandatory
+support circuitry (power tree, decoupling, I2C pull-ups, MCU straps, MCP23017
+address strapping). Firmware never states any of this — the templates encode the
+*design knowledge* every board needs.
+
+Each template is a pure function ``(intent, alloc) -> Expansion``. ``expand_intent``
+runs the registry, applies the expansions, and marks resolved gaps. ALL pin
+facts come from ``knowledge.py`` (single source of truth — Rule 3); no pin
+literals live here.
+
+Expansion channels keep templates declarative:
+  * ``components`` — new parts (origin="template")
+  * ``power``      — (rail_name, Endpoint) contributions, merged into one net/rail
+  * ``joins``      — (existing_net_name, Endpoint) appended to that net
+  * ``new_nets``   — standalone new nets (e.g. the MCU EN pull-up net)
+  * ``resolved``   — gap kinds this template fills
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+from kicad_mcp.utils.firmware import knowledge as K
+from kicad_mcp.utils.firmware.intent import (
+    DesignIntent,
+    Endpoint,
+    Gap,
+    Net,
+    Peripheral,
+)
+
+
+@dataclass
+class Expansion:
+    components: list[Peripheral] = field(default_factory=list)
+    power: list[tuple[str, Endpoint]] = field(default_factory=list)
+    joins: list[tuple[str, Endpoint]] = field(default_factory=list)
+    new_nets: list[Net] = field(default_factory=list)
+    resolved: list[str] = field(default_factory=list)
+
+
+class RefAllocator:
+    """Hand out fresh refs (C3, R4, U5 …) continuing past the intent's existing
+    refs so templates never collide with imported components."""
+
+    def __init__(self, intent: DesignIntent) -> None:
+        self._next: dict[str, int] = {}
+        existing = list(intent.peripherals) + ([intent.mcu] if intent.mcu else [])
+        for comp in existing:
+            m = re.match(r"([A-Za-z#]+)(\d+)$", comp.ref)
+            if m:
+                pre, num = m.group(1), int(m.group(2))
+                self._next[pre] = max(self._next.get(pre, 0), num)
+
+    def next(self, prefix: str) -> str:
+        self._next[prefix] = self._next.get(prefix, 0) + 1
+        return f"{prefix}{self._next[prefix]}"
+
+
+def _cap(alloc: RefAllocator, value: str, footprint: str) -> Peripheral:
+    return Peripheral(ref=alloc.next("C"), type="C", lib_id=K.LIB_C, value=value,
+                      footprint=footprint, origin="template")
+
+
+def _res(alloc: RefAllocator, value: str, footprint: str) -> Peripheral:
+    return Peripheral(ref=alloc.next("R"), type="R", lib_id=K.LIB_R, value=value,
+                      footprint=footprint, origin="template")
+
+
+def _ic_power_pins(intent: DesignIntent) -> list[tuple[str, list[str], list[str]]]:
+    """(ref, supply_pin_names, ground_pin_names) for every placed IC."""
+    out: list[tuple[str, list[str], list[str]]] = []
+    if intent.mcu is not None:
+        mi = K.resolve_mcu_by_part(intent.mcu.part)
+        if mi is not None:
+            out.append((intent.mcu.ref, [mi["supply_pin"]], [mi["ground_pin"]]))
+    for p in intent.peripherals:
+        info = K.resolve_peripheral(p.type)
+        if info is not None:
+            out.append((p.ref, list(info["supply_pins"]), list(info["ground_pins"])))
+    return out
+
+
+# --- templates ----------------------------------------------------------------
+
+def power_tree(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
+    """AMS1117 5V→3V3 + in/out caps; tie every IC supply→+3V3, ground→GND.
+    Fires only for a 3V3 MCU. The regulator choice (AMS1117) is a design default
+    firmware never states — flagged in the resolved gap detail."""
+    ex = Expansion()
+    if intent.mcu is None:
+        return ex
+    mi = K.resolve_mcu_by_part(intent.mcu.part)
+    if mi is None or not mi["needs_3v3"]:
+        return ex
+
+    ldo = Peripheral(ref=alloc.next("U"), type="AMS1117", lib_id=K.AMS1117["lib_id"],
+                     value=K.AMS1117["value"], footprint=K.AMS1117["footprint"],
+                     origin="template")
+    c_in = _cap(alloc, "10uF", K.FP_C_BULK)
+    c_out = _cap(alloc, "10uF", K.FP_C_BULK)
+    c_byp = _cap(alloc, "100nF", K.FP_C_BYPASS)
+    ex.components += [ldo, c_in, c_out, c_byp]
+
+    vi, vo, gnd = K.AMS1117["vin_pin"], K.AMS1117["vout_pin"], K.AMS1117["gnd_pin"]
+    # +5V (input rail; source — USB/connector — is out of scope, stays a gap)
+    ex.power += [("+5V", Endpoint(ref=ldo.ref, pin=vi)),
+                 ("+5V", Endpoint(ref=c_in.ref, pin="1"))]
+    # +3V3 (regulated): LDO out, output caps, and EVERY IC supply pin
+    ex.power += [("+3V3", Endpoint(ref=ldo.ref, pin=vo)),
+                 ("+3V3", Endpoint(ref=c_out.ref, pin="1")),
+                 ("+3V3", Endpoint(ref=c_byp.ref, pin="1"))]
+    # GND: LDO gnd, all cap returns, and EVERY IC ground pin
+    ex.power += [("GND", Endpoint(ref=ldo.ref, pin=gnd)),
+                 ("GND", Endpoint(ref=c_in.ref, pin="2")),
+                 ("GND", Endpoint(ref=c_out.ref, pin="2")),
+                 ("GND", Endpoint(ref=c_byp.ref, pin="2"))]
+    for ref, supplies, grounds in _ic_power_pins(intent):
+        for s in supplies:
+            ex.power.append(("+3V3", Endpoint(ref=ref, pin=s)))
+        for g in grounds:
+            ex.power.append(("GND", Endpoint(ref=ref, pin=g)))
+    ex.resolved.append("power_tree")
+    return ex
+
+
+def decoupling(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
+    """A 100nF bypass cap between +3V3 and GND for each IC."""
+    ex = Expansion()
+    for ref, supplies, grounds in _ic_power_pins(intent):
+        if not supplies or not grounds:
+            continue
+        c = _cap(alloc, "100nF", K.FP_C_BYPASS)
+        ex.components.append(c)
+        ex.power.append(("+3V3", Endpoint(ref=c.ref, pin="1")))
+        ex.power.append(("GND", Endpoint(ref=c.ref, pin="2")))
+    if ex.components:
+        ex.resolved.append("decoupling")
+    return ex
+
+
+def i2c_pullups(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
+    """4.7k pull-ups to +3V3 on SDA and SCL, once per I2C bus with a device.
+    Joins the existing bus nets (so the resistor sits on the real I2C line)."""
+    ex = Expansion()
+    seen_bus = False
+    for net in intent.nets:
+        if net.kind != "bus" or net.bus != "I2C":
+            continue
+        # which line? the peripheral endpoint's role is SDA or SCL.
+        roles = {e.role for e in net.endpoints if e.role}
+        if not (roles & {"SDA", "SCL"}):
+            continue
+        seen_bus = True
+        r = _res(alloc, "4.7k", K.FP_R_0603)
+        ex.components.append(r)
+        ex.joins.append((net.name, Endpoint(ref=r.ref, pin="1")))   # onto the I2C line
+        ex.power.append(("+3V3", Endpoint(ref=r.ref, pin="2")))
+    if seen_bus:
+        ex.resolved.append("pullups")
+    return ex
+
+
+def mcu_straps(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
+    """ESP32 EN and IO0 (boot) each pulled up to +3V3 via 10k."""
+    ex = Expansion()
+    if intent.mcu is None:
+        return ex
+    mi = K.resolve_mcu_by_part(intent.mcu.part)
+    if mi is None:
+        return ex
+    for net_name, pin_name in (("MCU_EN", mi["en_pin"]), ("MCU_BOOT", mi["boot_pin"])):
+        r = _res(alloc, "10k", K.FP_R_0603)
+        ex.components.append(r)
+        ex.new_nets.append(Net(
+            name=net_name, kind="passive", confidence="high", origin="template",
+            endpoints=[Endpoint(ref=intent.mcu.ref, pin=pin_name),
+                       Endpoint(ref=r.ref, pin="1")],
+        ))
+        ex.power.append(("+3V3", Endpoint(ref=r.ref, pin="2")))
+    ex.resolved.append("pullups")
+    return ex
+
+
+def mcp23017_config(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
+    """Strap each MCP23017's A0/A1/A2 per its I2C address, and tie RESET high.
+    Direct ties (no resistors) — correct for a fixed address. The bit→rail map is
+    knowledge.mcp23017_address_straps (the boundary-tested single source)."""
+    ex = Expansion()
+    for p in intent.peripherals:
+        if p.type.upper() != "MCP23017" or p.address is None:
+            continue
+        straps = K.mcp23017_address_straps(p.address)
+        if straps is None:
+            ex.resolved.append("__invalid_address")  # surfaced as a gap below
+            continue
+        for addr_pin, rail in straps:
+            ex.power.append((rail, Endpoint(ref=p.ref, pin=addr_pin)))
+        # RESET is active-low — hold high.
+        ex.power.append(("+3V3", Endpoint(ref=p.ref, pin=K.MCP23017_RESET_PIN)))
+    return ex
+
+
+_REGISTRY: list[tuple[str, Callable[[DesignIntent, RefAllocator], Expansion]]] = [
+    ("power_tree", power_tree),
+    ("decoupling", decoupling),
+    ("i2c_pullups", i2c_pullups),
+    ("mcu_straps", mcu_straps),
+    ("mcp23017_config", mcp23017_config),
+]
+
+
+# --- expansion pass -----------------------------------------------------------
+
+def expand_intent(intent: DesignIntent) -> DesignIntent:
+    """Run all templates over ``intent`` (mutated in place and returned)."""
+    alloc = RefAllocator(intent)
+    rail_endpoints: dict[str, list[Endpoint]] = {}
+    nets_by_name = {n.name: n for n in intent.nets}
+    gaps_by_kind: dict[str, Gap] = {}
+    for g in intent.gaps:
+        gaps_by_kind.setdefault(g.kind, g)
+
+    for tname, fn in _REGISTRY:
+        ex = fn(intent, alloc)
+        added_refs = [c.ref for c in ex.components]
+        intent.peripherals.extend(ex.components)
+
+        for rail, ep in ex.power:
+            rail_endpoints.setdefault(rail, []).append(ep)
+
+        for net_name, ep in ex.joins:
+            tgt = nets_by_name.get(net_name)
+            if tgt is not None:
+                tgt.endpoints.append(ep)
+            else:  # no such net — materialize a passive one
+                n = Net(name=net_name, kind="passive", confidence="high",
+                        origin="template", endpoints=[ep])
+                intent.nets.append(n)
+                nets_by_name[net_name] = n
+
+        for n in ex.new_nets:
+            intent.nets.append(n)
+            nets_by_name[n.name] = n
+
+        for kind in ex.resolved:
+            if kind == "__invalid_address":
+                intent.gaps.append(Gap("invalid_address",
+                                       "MCP23017 I2C address outside 0x20–0x27; not strapped."))
+                continue
+            gap = gaps_by_kind.get(kind)
+            if gap is not None and not gap.resolved:
+                gap.resolved = True
+                gap.resolved_by = tname
+                gap.resolved_components = added_refs
+
+    # Merge accumulated rail contributions into one power net per rail.
+    for rail, eps in rail_endpoints.items():
+        existing = nets_by_name.get(rail)
+        deduped: list[Endpoint] = []
+        seen: set[tuple[str, Optional[str]]] = set()
+        pool = (existing.endpoints if existing else []) + eps
+        for ep in pool:
+            key = (ep.ref, ep.pin)
+            if key not in seen:
+                seen.add(key)
+                deduped.append(ep)
+        if existing is not None:
+            existing.kind = "power"
+            existing.endpoints = deduped
+        else:
+            n = Net(name=rail, kind="power", confidence="high", origin="template",
+                    endpoints=deduped)
+            intent.nets.append(n)
+            nets_by_name[rail] = n
+    return intent

--- a/tests/test_firmware_templates.py
+++ b/tests/test_firmware_templates.py
@@ -1,0 +1,190 @@
+"""Tests for the peripheral-block templates + expansion pass.
+
+The MCP23017 address→strap bit mapping is the highest silent-wrong risk, so it
+gets at/below/above boundary coverage (CLAUDE.md threshold rule)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_mcp.utils.firmware import knowledge as K
+from kicad_mcp.utils.firmware.intent import (
+    build_intent,
+    from_dict,
+    to_dict,
+)
+from kicad_mcp.utils.firmware.parse import parse_defines, partition
+from kicad_mcp.utils.firmware.templates import (
+    RefAllocator,
+    decoupling,
+    expand_intent,
+    i2c_pullups,
+    mcp23017_config,
+    mcu_straps,
+    power_tree,
+)
+
+SPEEDCAL_CONFIG = Path(
+    "/Volumes/Files/claude/mr-esp32/speed-cal/firmware/include/config.h"
+)
+
+_SAMPLE = """\
+#define I2C_SDA 21
+#define I2C_SCL 22
+#define MCP23017_ADDR 0x27
+#define MCP23017_INT_PIN 13
+#define HX711_DOUT_PIN 16
+#define HX711_SCK_PIN 17
+"""
+
+
+def _intent():
+    return build_intent(partition(parse_defines(_SAMPLE)),
+                        firmware_path="c.h", board_id="esp32dev")
+
+
+# --- the silent-wrong hotspot: address strapping -----------------------------
+
+def test_address_strap_all_low():
+    # 0x20 = base -> A2,A1,A0 all to GND
+    assert K.mcp23017_address_straps(0x20) == [("A0", "GND"), ("A1", "GND"), ("A2", "GND")]
+
+def test_address_strap_all_high():
+    # 0x27 = base + 0b111 -> all to +3V3
+    assert K.mcp23017_address_straps(0x27) == [("A0", "+3V3"), ("A1", "+3V3"), ("A2", "+3V3")]
+
+def test_address_strap_mixed():
+    # 0x24 = base + 0b100 -> A2 high, A1/A0 low
+    assert K.mcp23017_address_straps(0x24) == [("A0", "GND"), ("A1", "GND"), ("A2", "+3V3")]
+
+def test_address_strap_lsb_only():
+    # 0x21 = base + 0b001 -> A0 high only
+    assert K.mcp23017_address_straps(0x21) == [("A0", "+3V3"), ("A1", "GND"), ("A2", "GND")]
+
+@pytest.mark.parametrize("addr", [0x1F, 0x28, 0x00, 0x50])
+def test_address_strap_out_of_range_is_none(addr):
+    assert K.mcp23017_address_straps(addr) is None
+
+
+# --- ref allocation -----------------------------------------------------------
+
+def test_ref_allocator_continues_past_existing():
+    alloc = RefAllocator(_intent())   # has U1(mcu), U2/U3 peripherals
+    assert alloc.next("U") == "U4"
+    assert alloc.next("C") == "C1"
+    assert alloc.next("R") == "R1"
+    assert alloc.next("C") == "C2"
+
+
+# --- individual templates -----------------------------------------------------
+
+def test_power_tree_instantiates_ldo_and_caps():
+    ex = power_tree(_intent(), RefAllocator(_intent()))
+    types = [c.type for c in ex.components]
+    assert "AMS1117" in types and types.count("C") == 3
+    rails = {rail for rail, _ in ex.power}
+    assert rails == {"+5V", "+3V3", "GND"}
+    # every IC supply lands on +3V3 (MCU VDD + HX711 + MCP)
+    plus3 = {(ep.ref, ep.pin) for rail, ep in ex.power if rail == "+3V3"}
+    assert ("U1", "VDD") in plus3              # ESP32 supply by NAME
+    assert "power_tree" in ex.resolved
+
+def test_decoupling_one_cap_per_ic():
+    ex = decoupling(_intent(), RefAllocator(_intent()))
+    # MCU + 2 peripherals = 3 ICs -> 3 caps
+    assert len([c for c in ex.components if c.type == "C"]) == 3
+    assert "decoupling" in ex.resolved
+
+def test_i2c_pullups_join_bus_and_pull_to_3v3():
+    ex = i2c_pullups(_intent(), RefAllocator(_intent()))
+    assert len(ex.components) == 2                       # SDA + SCL pull-ups
+    joined = {name for name, _ in ex.joins}
+    assert joined == {"I2C_SDA", "I2C_SCL"}             # onto the real I2C lines
+    assert all(rail == "+3V3" for rail, _ in ex.power)
+    assert "pullups" in ex.resolved
+
+def test_mcu_straps_en_and_boot():
+    ex = mcu_straps(_intent(), RefAllocator(_intent()))
+    names = {n.name for n in ex.new_nets}
+    assert names == {"MCU_EN", "MCU_BOOT"}
+    # each strap net ties the MCU pin (by name) to a resistor
+    en = next(n for n in ex.new_nets if n.name == "MCU_EN")
+    assert any(e.ref == "U1" and e.pin == "EN" for e in en.endpoints)
+
+def test_mcp23017_config_straps_for_0x27():
+    ex = mcp23017_config(_intent(), RefAllocator(_intent()))
+    assert not ex.components                             # direct ties, no parts
+    # all three address pins on +3V3 (0x27) + RESET high
+    plus3_pins = {ep.pin for rail, ep in ex.power if rail == "+3V3"}
+    assert {"A0", "A1", "A2", K.MCP23017_RESET_PIN} <= plus3_pins
+
+
+# --- expansion pass -----------------------------------------------------------
+
+def test_expand_grows_intent_and_resolves_gaps():
+    intent = expand_intent(_intent())
+    assert len(intent.peripherals) > 2                  # template parts added
+    resolved = {g.kind: g for g in intent.gaps if g.resolved}
+    assert {"power_tree", "decoupling", "pullups"} <= set(resolved)
+    # provenance recorded
+    assert resolved["power_tree"].resolved_by == "power_tree"
+    assert resolved["power_tree"].resolved_components
+
+def test_expand_merges_power_rails():
+    intent = expand_intent(_intent())
+    power_nets = [n for n in intent.nets if n.kind == "power"]
+    names = {n.name for n in power_nets}
+    assert names == {"+5V", "+3V3", "GND"}              # one net per rail
+    plus3 = next(n for n in power_nets if n.name == "+3V3")
+    # endpoints deduped (no repeated ref/pin)
+    keys = [(e.ref, e.pin) for e in plus3.endpoints]
+    assert len(keys) == len(set(keys))
+
+def test_expanded_intent_round_trips(tmp_path):
+    intent = expand_intent(_intent())
+    assert to_dict(from_dict(to_dict(intent))) == to_dict(intent)
+
+def test_template_components_carry_footprints():
+    intent = expand_intent(_intent())
+    tmpl = [p for p in intent.peripherals if p.origin == "template"]
+    assert tmpl and all(p.footprint for p in tmpl)      # PCB-ready
+
+
+# --- KiCad-gated full E2E -----------------------------------------------------
+
+def _kicad_available() -> bool:
+    try:
+        from kicad_sch_api.library.cache import get_symbol_cache
+        return get_symbol_cache().get_symbol("RF_Module:ESP32-WROOM-32E") is not None
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _kicad_available(), reason="KiCad symbol libraries not available")
+@pytest.mark.skipif(not SPEEDCAL_CONFIG.exists(), reason="speed-cal config.h not present")
+def test_generate_expanded_speedcal(tmp_path):
+    from kicad_mcp.utils.firmware.generate import generate_schematic
+    from kicad_mcp.utils.firmware.intent import find_board_id
+    from kicad_mcp.utils.netlist_parser import extract_netlist_via_cli
+
+    parsed = partition(parse_defines(SPEEDCAL_CONFIG.read_text()))
+    intent = expand_intent(build_intent(parsed, firmware_path=str(SPEEDCAL_CONFIG),
+                                        board_id=find_board_id(str(SPEEDCAL_CONFIG))))
+    out = tmp_path / "expanded.kicad_sch"
+    res = generate_schematic(intent, str(out))
+    assert res["status"] == "ok" and not res["unresolved_endpoints"]
+    assert res["components_placed"] >= 13               # 3 ICs + LDO + caps + R
+
+    nl = extract_netlist_via_cli(str(out))
+    def members(name):
+        return {f"{x['component']}.{x['pin']}" for x in nl["nets"].get(name, [])}
+
+    p3, gnd, p5 = members("+3V3"), members("GND"), members("+5V")
+    assert "U1.2" in p3                                  # ESP32 VDD on +3V3
+    assert {"U1.1", "U1.15", "U1.38", "U1.39"} <= gnd   # all ESP32 GND pads
+    assert p5 == {"C1.1", "U4.3"}                        # +5V clean (LDO in + cap)
+    # MCP 0x27 address straps + reset on +3V3 (pins 15/16/17/18)
+    assert {"U3.15", "U3.16", "U3.17", "U3.18", "U3.9"} <= p3
+    # the MCP_INT signal net is NOT polluted into a rail
+    assert members("MCP23017_INT") == {"U1.16", "U3.20"}


### PR DESCRIPTION
## What
Phase 2 of the firmware front end. Expands the Phase-1 signal-net **skeleton** into an **electrically-complete I2C+power core** by giving each recognized component its mandatory support circuitry — the power tree, decoupling, pull-ups, and I2C address strapping that firmware never states.

Flow: `import_firmware → expand_templates → generate_schematic`.

## Part 1 — schema/generator surgery
A fresh-eyes review found the intent spine was **MCU-centric** (an endpoint was only a GPIO or a known role) and couldn't represent a decoupling cap, a power rail, or a footprint. Fixed first:
- `intent.py`: `Endpoint.pin` (direct pin name/number), `Peripheral.footprint`, `Net.kind` += `power`/`passive`, `origin` += `template` (3-way merge), `Gap.resolved_by`/`resolved_components`, `SCHEMA_VERSION=2`.
- `generate.py`: a `pin` resolution branch, footprint threading, and per-rail `power:` symbol + `PWR_FLAG` markers — **placed clear of the component grid** (a marker landing on the big ESP32 symbol merged its rail into a signal net, since labels join by *name*).
- `knowledge.py`: now the verified-fact source — footprints, supply/ground pin **names** per IC, and `mcp23017_address_straps()` (the boundary-tested address→strap map).

## Part 2 — template library
`templates.py` + an `expand_intent` pass. Five firmware-grounded templates: **power_tree** (AMS1117 5V→3V3 + caps, ties every IC to the rails), **decoupling** (100nF per IC), **i2c_pullups** (4.7k on SDA/SCL, joined onto the real bus nets), **mcu_straps** (ESP32 EN/IO0), **mcp23017_config** (A0/A1/A2 strapped per address, RESET high). New `design` operation `expand_templates` (no new tool).

## Verified landmines
ESP32 merged GND resolved by **name** (kicad-cli expands it to pads 1/15/38/39); MCP23017 SCL pin is named `SCK`; AMS1117 tab = pin 2.

## Verification — the payoff
On the real speed-cal `config.h`: `import → expand → generate` yields a **14-component** schematic, and `build_pcb_from_schematic` then **fully routes it** — 56 pads, **193 tracks, 8 vias, 0 unconnected**, 2 GND zones. (Phase 1 produced 3 components and was unbuildable.)

- `test_firmware_templates.py` (19): address-strap boundaries (0x20 / 0x24 / 0x27 / out-of-range), each template, the expansion pass, and a KiCad-gated PCB-net E2E.
- Full suite **1403 passing**, mypy clean. No tool-count change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)