### PR TITLE
feat(design): CP2102 USB programming block template (flashable board)

### DIFF
--- a/src/kicad_mcp/utils/firmware/generate.py
+++ b/src/kicad_mcp/utils/firmware/generate.py
@@ -79,7 +79,11 @@ def generate_schematic(intent: DesignIntent, schematic_path: str) -> dict[str, A
             num = pin_number_by_name(sym, pin)
             if num is not None:
                 return num
-            return pin if str(pin).isdigit() else None
+            # else: pin may already be a literal pin NUMBER (e.g. "3", "A4").
+            # Validate against the symbol's real numbers — USB-C/QFN numbers are
+            # alphanumeric, so a digit check is not enough.
+            valid = {str(p.number) for p in (getattr(sym, "pins", None) or ())}
+            return str(pin) if str(pin) in valid else None
         if gpio is not None:                       # MCU side
             return gpio_to_pin_number(sym, int(gpio))
         ptype = type_by_ref.get(ref)               # peripheral side

--- a/src/kicad_mcp/utils/firmware/knowledge.py
+++ b/src/kicad_mcp/utils/firmware/knowledge.py
@@ -29,6 +29,8 @@ class McuInfo(TypedDict):
     ground_pin: str      # pin NAME for ground (ESP32: the merged "GND" pin)
     en_pin: str          # chip-enable pin NAME (needs pull-up)
     boot_pin: str        # boot/strap pin NAME (needs pull-up)
+    uart_rx_pin: str     # console UART RX pin NAME (<- USB bridge TXD)
+    uart_tx_pin: str     # console UART TX pin NAME (-> USB bridge RXD)
 
 
 class PeripheralInfo(TypedDict):
@@ -49,6 +51,7 @@ _ESP32: McuInfo = {
     "value": "ESP32-WROOM-32E", "footprint": "RF_Module:ESP32-WROOM-32E",
     "needs_3v3": True, "supply_pin": "VDD", "ground_pin": "GND",
     "en_pin": "EN", "boot_pin": "IO0",
+    "uart_rx_pin": "RXD0/IO3", "uart_tx_pin": "TXD0/IO1",
 }
 
 # board-id substrings (from platformio.ini ``board =``) -> MCU.
@@ -87,6 +90,32 @@ AMS1117 = {
     "footprint": "Package_TO_SOT_SMD:SOT-223-3_TabPin2",
     "vin_pin": "VI", "vout_pin": "VO", "gnd_pin": "GND",
 }
+
+# --- USB-C + CP2102 programming block (verified pins; v5 footprints) ---------
+USB_C_LIB = "Connector:USB_C_Receptacle_USB2.0_16P"
+USB_C_FP = "Connector_USB:USB_C_Receptacle_GCT_USB4105-xx-A_16P_TopMnt_Horizontal"
+USB_C_VBUS_PINS = ["A4", "A9", "B4", "B9"]   # all VBUS pins -> +5V
+USB_C_GND_PINS = ["A1", "A12", "B1", "B12"]  # all GND pins
+USB_C_CC1, USB_C_CC2 = "A5", "B5"            # 5.1k pulldown each (sink role)
+USB_C_DP, USB_C_DM = "A6", "A7"              # USB data (A-side)
+
+CP2102_LIB = "Interface_USB:CP2102N-Axx-xQFN28"
+CP2102_FP = "Package_DFN_QFN:QFN-28-1EP_5x5mm_P0.5mm_EP3.35x3.35mm"
+# Pin NAMES (unique) used by the template:
+CP2102_VREGIN, CP2102_VBUS = "VREGIN", "VBUS"  # both <- +5V (USB-powered)
+CP2102_VDD_OUT = "VDD"                          # LDO OUTPUT — bypass only, NOT +3V3!
+CP2102_DP, CP2102_DM = "D+", "D-"
+CP2102_TXD, CP2102_RXD = "TXD", "RXD"           # TXD->MCU RX, RXD<-MCU TX
+CP2102_DTR, CP2102_RST = "~{DTR}", "~{RST}"
+# GND is on TWO pins both named "GND" (pin 3 + EP pad pin 29) — name lookup
+# returns only one, so wire these by NUMBER.
+CP2102_GND_PINS = ["3", "29"]
+
+SW_PUSH_LIB = "Switch:SW_Push"
+SW_PUSH_FP = "Button_Switch_SMD:SW_SPST_B3S-1000"
+
+# 5.1k = USB-C CC sink resistors.
+FP_R_0603_5K1 = FP_R_0603
 
 # MCP23017 I2C address strapping. Base 0x20; bits A2 A1 A0 select 0x20..0x27.
 MCP23017_ADDRESS_BASE = 0x20

--- a/src/kicad_mcp/utils/firmware/templates.py
+++ b/src/kicad_mcp/utils/firmware/templates.py
@@ -202,11 +202,90 @@ def mcp23017_config(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
     return ex
 
 
+def _passive_net(name: str, *endpoints: Endpoint) -> Net:
+    return Net(name=name, kind="passive", confidence="high", origin="template",
+               endpoints=list(endpoints))
+
+
+def usb_programming(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
+    """USB-C + CP2102 programming block — makes the board flashable. Powers it
+    from USB (VBUS→+5V, giving the +5V rail its source), and gives the MCU a
+    UART console + auto-reset + boot/reset buttons. Fires for an ESP32.
+
+    Landmines (verified): CP2102 VDD (pin 6) is the chip's LDO OUTPUT — it gets a
+    bypass cap on its OWN net, never tied to +3V3. GND is on TWO pins (3 + EP 29)
+    — wired by number. Auto-reset is the v5 scheme: a 100nF couples DTR→EN, with
+    manual RESET/BOOT buttons (no transistors)."""
+    ex = Expansion()
+    if intent.mcu is None:
+        return ex
+    mi = K.resolve_mcu_by_part(intent.mcu.part)
+    if mi is None:
+        return ex
+    mcu = intent.mcu.ref
+
+    cp = Peripheral(ref=alloc.next("U"), type="CP2102", lib_id=K.CP2102_LIB,
+                    value="CP2102N", footprint=K.CP2102_FP, origin="template")
+    usb = Peripheral(ref=alloc.next("J"), type="USB_C", lib_id=K.USB_C_LIB,
+                     value="USB-C", footprint=K.USB_C_FP, origin="template")
+    r_cc1 = _res(alloc, "5.1k", K.FP_R_0603_5K1)
+    r_cc2 = _res(alloc, "5.1k", K.FP_R_0603_5K1)
+    sw_rst = Peripheral(ref=alloc.next("SW"), type="SW", lib_id=K.SW_PUSH_LIB,
+                        value="RESET", footprint=K.SW_PUSH_FP, origin="template")
+    sw_boot = Peripheral(ref=alloc.next("SW"), type="SW", lib_id=K.SW_PUSH_LIB,
+                         value="BOOT", footprint=K.SW_PUSH_FP, origin="template")
+    c_vreg = _cap(alloc, "10uF", K.FP_C_BULK)
+    c_vdd = _cap(alloc, "100nF", K.FP_C_BYPASS)
+    c_dtr = _cap(alloc, "100nF", K.FP_C_BYPASS)
+    ex.components += [cp, usb, r_cc1, r_cc2, sw_rst, sw_boot, c_vreg, c_vdd, c_dtr]
+
+    # Power: USB VBUS -> +5V (the rail's source); CP2102 VREGIN/VBUS <- +5V.
+    for vb in K.USB_C_VBUS_PINS:
+        ex.power.append(("+5V", Endpoint(ref=usb.ref, pin=vb)))
+    ex.power += [("+5V", Endpoint(ref=cp.ref, pin=K.CP2102_VREGIN)),
+                 ("+5V", Endpoint(ref=cp.ref, pin=K.CP2102_VBUS)),
+                 ("+5V", Endpoint(ref=c_vreg.ref, pin="1"))]
+    # Ground: USB GND, CP2102 GND (pin 3 + EP 29 by NUMBER), cap returns,
+    # CC resistor returns, switch returns.
+    for g in K.USB_C_GND_PINS:
+        ex.power.append(("GND", Endpoint(ref=usb.ref, pin=g)))
+    for g in K.CP2102_GND_PINS:
+        ex.power.append(("GND", Endpoint(ref=cp.ref, pin=g)))
+    ex.power += [("GND", Endpoint(ref=c_vreg.ref, pin="2")),
+                 ("GND", Endpoint(ref=c_vdd.ref, pin="2")),
+                 ("GND", Endpoint(ref=r_cc1.ref, pin="2")),
+                 ("GND", Endpoint(ref=r_cc2.ref, pin="2")),
+                 ("GND", Endpoint(ref=sw_rst.ref, pin="2")),
+                 ("GND", Endpoint(ref=sw_boot.ref, pin="2"))]
+
+    ex.new_nets += [
+        _passive_net("CC1", Endpoint(ref=usb.ref, pin=K.USB_C_CC1), Endpoint(ref=r_cc1.ref, pin="1")),
+        _passive_net("CC2", Endpoint(ref=usb.ref, pin=K.USB_C_CC2), Endpoint(ref=r_cc2.ref, pin="1")),
+        _passive_net("USB_DP", Endpoint(ref=usb.ref, pin=K.USB_C_DP), Endpoint(ref=cp.ref, pin=K.CP2102_DP)),
+        _passive_net("USB_DM", Endpoint(ref=usb.ref, pin=K.USB_C_DM), Endpoint(ref=cp.ref, pin=K.CP2102_DM)),
+        # CP2102 VDD is its LDO OUTPUT — bypass only, on its own net.
+        _passive_net("CP2102_VDD", Endpoint(ref=cp.ref, pin=K.CP2102_VDD_OUT), Endpoint(ref=c_vdd.ref, pin="1")),
+        # UART console crossover: CP2102 TXD -> MCU RX, CP2102 RXD <- MCU TX.
+        _passive_net("UART_RX", Endpoint(ref=cp.ref, pin=K.CP2102_TXD), Endpoint(ref=mcu, pin=mi["uart_rx_pin"])),
+        _passive_net("UART_TX", Endpoint(ref=cp.ref, pin=K.CP2102_RXD), Endpoint(ref=mcu, pin=mi["uart_tx_pin"])),
+        # Auto-reset coupling: DTR --100nF--> EN.
+        _passive_net("DTR", Endpoint(ref=cp.ref, pin=K.CP2102_DTR), Endpoint(ref=c_dtr.ref, pin="1")),
+    ]
+    # Join the EN / BOOT nets that mcu_straps created (pull-up resistors).
+    ex.joins += [
+        ("MCU_EN", Endpoint(ref=c_dtr.ref, pin="2")),     # DTR coupling cap
+        ("MCU_EN", Endpoint(ref=sw_rst.ref, pin="1")),    # RESET button
+        ("MCU_BOOT", Endpoint(ref=sw_boot.ref, pin="1")),  # BOOT button
+    ]
+    return ex
+
+
 _REGISTRY: list[tuple[str, Callable[[DesignIntent, RefAllocator], Expansion]]] = [
     ("power_tree", power_tree),
     ("decoupling", decoupling),
     ("i2c_pullups", i2c_pullups),
     ("mcu_straps", mcu_straps),
+    ("usb_programming", usb_programming),
     ("mcp23017_config", mcp23017_config),
 ]
 

--- a/tests/test_firmware_templates.py
+++ b/tests/test_firmware_templates.py
@@ -23,6 +23,7 @@ from kicad_mcp.utils.firmware.templates import (
     mcp23017_config,
     mcu_straps,
     power_tree,
+    usb_programming,
 )
 
 SPEEDCAL_CONFIG = Path(
@@ -120,6 +121,51 @@ def test_mcp23017_config_straps_for_0x27():
     assert {"A0", "A1", "A2", K.MCP23017_RESET_PIN} <= plus3_pins
 
 
+# --- CP2102 USB programming block (highest-landmine template) -----------------
+
+def test_usb_programming_parts():
+    ex = usb_programming(_intent(), RefAllocator(_intent()))
+    types = [c.type for c in ex.components]
+    assert types.count("CP2102") == 1 and types.count("USB_C") == 1
+    assert types.count("SW") == 2 and types.count("R") == 2 and types.count("C") == 3
+    assert all(c.footprint for c in ex.components)       # PCB-ready
+
+def test_usb_cp2102_vdd_isolated_not_3v3():
+    # LANDMINE: CP2102 VDD is the chip's LDO OUTPUT — must NOT join +3V3.
+    ex = usb_programming(_intent(), RefAllocator(_intent()))
+    cp = next(c for c in ex.components if c.type == "CP2102")
+    assert not any(ep.ref == cp.ref for rail, ep in ex.power if rail == "+3V3")
+    vdd = next(n for n in ex.new_nets if n.name == "CP2102_VDD")
+    assert any(e.ref == cp.ref and e.pin == "VDD" for e in vdd.endpoints)
+
+def test_usb_cp2102_dual_ground_pins():
+    # LANDMINE: GND is on pin 3 AND the EP pad pin 29 (both named "GND").
+    ex = usb_programming(_intent(), RefAllocator(_intent()))
+    cp = next(c for c in ex.components if c.type == "CP2102")
+    gnd = {(ep.ref, ep.pin) for rail, ep in ex.power if rail == "GND"}
+    assert (cp.ref, "3") in gnd and (cp.ref, "29") in gnd
+
+def test_usb_vbus_sources_5v():
+    ex = usb_programming(_intent(), RefAllocator(_intent()))
+    usb = next(c for c in ex.components if c.type == "USB_C")
+    p5 = {(ep.ref, ep.pin) for rail, ep in ex.power if rail == "+5V"}
+    assert all((usb.ref, vb) in p5 for vb in ("A4", "A9", "B4", "B9"))
+
+def test_usb_uart_crossover():
+    ex = usb_programming(_intent(), RefAllocator(_intent()))
+    cp = next(c for c in ex.components if c.type == "CP2102")
+    rx = next(n for n in ex.new_nets if n.name == "UART_RX")
+    tx = next(n for n in ex.new_nets if n.name == "UART_TX")
+    assert any(e.ref == cp.ref and e.pin == "TXD" for e in rx.endpoints)
+    assert any(e.ref == "U1" and e.pin == "RXD0/IO3" for e in rx.endpoints)
+    assert any(e.ref == cp.ref and e.pin == "RXD" for e in tx.endpoints)
+    assert any(e.ref == "U1" and e.pin == "TXD0/IO1" for e in tx.endpoints)
+
+def test_usb_joins_en_and_boot():
+    ex = usb_programming(_intent(), RefAllocator(_intent()))
+    assert {name for name, _ in ex.joins} == {"MCU_EN", "MCU_BOOT"}
+
+
 # --- expansion pass -----------------------------------------------------------
 
 def test_expand_grows_intent_and_resolves_gaps():
@@ -174,7 +220,7 @@ def test_generate_expanded_speedcal(tmp_path):
     out = tmp_path / "expanded.kicad_sch"
     res = generate_schematic(intent, str(out))
     assert res["status"] == "ok" and not res["unresolved_endpoints"]
-    assert res["components_placed"] >= 13               # 3 ICs + LDO + caps + R
+    assert res["components_placed"] >= 20               # 3 ICs + power + USB block
 
     nl = extract_netlist_via_cli(str(out))
     def members(name):
@@ -183,8 +229,15 @@ def test_generate_expanded_speedcal(tmp_path):
     p3, gnd, p5 = members("+3V3"), members("GND"), members("+5V")
     assert "U1.2" in p3                                  # ESP32 VDD on +3V3
     assert {"U1.1", "U1.15", "U1.38", "U1.39"} <= gnd   # all ESP32 GND pads
-    assert p5 == {"C1.1", "U4.3"}                        # +5V clean (LDO in + cap)
     # MCP 0x27 address straps + reset on +3V3 (pins 15/16/17/18)
     assert {"U3.15", "U3.16", "U3.17", "U3.18", "U3.9"} <= p3
     # the MCP_INT signal net is NOT polluted into a rail
     assert members("MCP23017_INT") == {"U1.16", "U3.20"}
+
+    # --- CP2102 programming block (U5=CP2102, J1=USB-C — deterministic refs) ---
+    assert {"J1.A4", "J1.A9", "J1.B4", "J1.B9", "U4.3"} <= p5  # +5V USB-sourced
+    assert "U5.6" not in p3                              # LANDMINE: CP2102 VDD not +3V3
+    assert "U5.6" in members("CP2102_VDD")              # ...it's on its own net
+    assert {"U5.3", "U5.29"} <= gnd                      # LANDMINE: both CP2102 GND pins
+    assert members("UART_RX") == {"U1.34", "U5.26"}     # CP2102 TXD -> ESP32 RX
+    assert members("UART_TX") == {"U1.35", "U5.25"}     # CP2102 RXD <- ESP32 TX


### PR DESCRIPTION
## What
Adds the **`usb_programming`** template — USB-C + CP2102 UART bridge + auto-reset + RESET/BOOT buttons — so the firmware-derived board is actually **flashable**. It also gives the `+5V` rail its **source**: USB VBUS → +5V → the Phase-2 AMS1117 LDO input, completing the power path from the USB port.

## Grounding
Built from v5's real programming block + the **verified** CP2102/USB-C symbol facts. (v5's netlist had the RXD/BOOT nets collapsed into GND by the power-merge extraction artifact, so it was used only for the clearly-correct parts.) Auto-reset is the v5 scheme — a 100nF couples DTR→EN with manual buttons, **no transistors**.

## Landmines (respected + asserted in tests)
- **CP2102 VDD (pin 6) is the chip's LDO OUTPUT** — bypass cap on its **own** net (`CP2102_VDD`), never tied to +3V3.
- **GND is on two pins** (3 + EP pad 29, both *named* `GND`) — wired by **number**.
- VREGIN(7)/VBUS(8) ← +5V; UART crossover (CP2102 TXD→ESP32 RX, RXD←ESP32 TX); USB-C CC pins → 5.1k → GND.

Also fixes `generate.resolve_pin`: a direct pin endpoint may be an **alphanumeric** pin number (USB-C `A4`, QFN `29`), not just a digit — now validated against the symbol's real pin numbers.

## Verification — the payoff
On the real speed-cal `config.h`: `import → expand → generate` yields a **23-component** schematic, and `build_pcb_from_schematic` **fully routes it** — **94 pads, 306 tracks, 25 vias, 0 unconnected**, 2 GND zones. `config.h` → a flashable, USB-powered, fully-routed ESP32 board.

- +6 template tests (parts, the VDD-isolation landmine, dual-GND landmine, USB-sourced +5V, UART crossover, EN/BOOT joins) + the KiCad-gated E2E extended with CP2102 net assertions.
- Full suite **1409 passing**, mypy clean. No tool-count change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)