### PR TITLE
test(integration): golden firmware→PCB harness (the meta-finding's CI gate)

### DIFF
--- a/tests/fixtures/firmware/config.h
+++ b/tests/fixtures/firmware/config.h
@@ -1,0 +1,29 @@
+#pragma once
+// Synthetic firmware-spec fixture for the firmware->PCB integration harness.
+// A representative ESP32 board: I2C bus with an MCP23017 GPIO expander (0x27)
+// and an HX711 load-cell ADC, plus a few orphan signals and deliberate
+// seam-guard non-pin macros. Committed so the harness needs no external tree.
+
+// --- I2C ---
+#define I2C_SDA       21
+#define I2C_SCL       22
+#define I2C_FREQ      400000   // not a pin (seam guard)
+
+// --- MCP23017 GPIO expander ---
+#define MCP23017_ADDR     0x27
+#define MCP23017_INT_PIN  13
+#define MCP_IODIRA        0x00 // a register, NOT an I2C address (seam guard)
+
+// --- HX711 load-cell ADC ---
+#define HX711_DOUT_PIN    16
+#define HX711_SCK_PIN     17
+
+// --- orphan signals (no declared peripheral) ---
+#define I2S_SCK_PIN       18
+#define I2S_WS_PIN        19
+#define I2S_SD_PIN        23
+#define PIEZO_ADC_PIN     35
+
+// --- counts/config in GPIO range (seam guards: must NOT classify as pins) ---
+#define NUM_SENSORS       6
+#define MAX_SENSORS       16

--- a/tests/fixtures/firmware/platformio.ini
+++ b/tests/fixtures/firmware/platformio.ini
@@ -1,0 +1,6 @@
+; Fixture platformio.ini for the firmware->PCB integration harness.
+; The board id drives MCU auto-detection in the importer.
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino

--- a/tests/integration/test_firmware_pcb_pipeline.py
+++ b/tests/integration/test_firmware_pcb_pipeline.py
@@ -1,0 +1,100 @@
+"""End-to-end firmware->PCB golden harness (the session meta-finding's fix).
+
+A flagship pipeline tool (`build_pcb_from_schematic`) was once 100% broken on
+KiCad 10 with ZERO integration coverage — test count != pipeline confidence.
+This gate runs the WHOLE arc on real KiCad (9 and 10):
+
+    config.h -> design intent -> expand templates -> generate schematic
+             -> build routed PCB
+
+and asserts **version-robust invariants** — component count, by-component-ref net
+membership, and 0-unconnected routing — NOT version-fragile pin numbers (which
+drift between KiCad symbol-library versions).
+"""
+import asyncio
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("KICAD_INTEGRATION") != "1",
+    reason="Integration tests require KICAD_INTEGRATION=1 and a real KiCad install",
+)
+
+FIXTURE = Path(__file__).parent.parent / "fixtures" / "firmware"
+CONFIG_H = FIXTURE / "config.h"
+
+_MINIMAL_PRO = {
+    "board": {"design_settings": {}},
+    "net_settings": {"classes": [{
+        "name": "Default", "clearance": 0.2, "track_width": 0.25,
+        "via_diameter": 0.6, "via_drill": 0.3, "microvia_diameter": 0.3,
+        "microvia_drill": 0.1, "diff_pair_gap": 0.25, "diff_pair_width": 0.2,
+    }], "meta": {"version": 3}},
+    "meta": {"filename": "board.kicad_pro", "version": 1},
+}
+
+
+@pytest.fixture(scope="module")
+def mcp_server():
+    from kicad_mcp.server import create_server
+    return create_server()
+
+
+def _tool(mcp, name):
+    return asyncio.run(mcp.get_tool(name)).fn
+
+
+def test_firmware_to_routed_pcb(mcp_server, tmp_path):
+    design = _tool(mcp_server, "design")
+    build = _tool(mcp_server, "build_pcb_from_schematic")
+    intent = tmp_path / "intent.yaml"
+    sch = tmp_path / "board.kicad_sch"
+    pro = tmp_path / "board.kicad_pro"
+
+    # 1) firmware -> design intent
+    r1 = design(operation="import_firmware", firmware_path=str(CONFIG_H),
+                out_path=str(intent))
+    assert r1["status"] == "ok"
+    assert r1["board"] == "esp32dev"
+    assert r1["summary"]["mcu"] == "ESP32-WROOM-32E"
+    assert {p["type"] for p in r1["summary"]["peripherals"]} == {"HX711", "MCP23017"}
+
+    # 2) expand templates (power/glue + USB programming block)
+    r2 = design(operation="expand_templates", intent_path=str(intent))
+    assert r2["status"] == "ok"
+    assert {"power_tree", "decoupling", "pullups"} <= set(r2["gaps_resolved"])
+
+    # 3) generate the now-complete schematic
+    r3 = design(operation="generate_schematic", intent_path=str(intent),
+                schematic_path=str(sch))
+    assert r3["status"] == "ok"
+    assert not r3["unresolved_endpoints"]
+    assert r3["components_placed"] == 23      # 3 ICs + power tree + USB block
+
+    # 4) build a routed PCB from it — the core gate
+    pro.write_text(json.dumps(_MINIMAL_PRO))
+    r4 = build(project_path=str(pro), board_width_mm=90, board_height_mm=75,
+               autoroute_passes=2, export_gerbers=False)
+    assert r4["status"] == "ok"
+    assert r4["pads_assigned"] > 0
+    assert r4["incomplete_nets"] == 0         # fully routed
+    assert r4["steps"]["zones"]["zones_added"] >= 1
+
+    # 5) golden connectivity invariants (by component REF — version-robust)
+    from kicad_mcp.utils.netlist_parser import extract_netlist_via_cli
+    nl = extract_netlist_via_cli(str(sch))
+    assert nl is not None
+
+    def refs_on(net):
+        return {x["component"] for x in nl["nets"].get(net, [])}
+
+    # MCU (U1) + LDO (U4) powered from +3V3; CP2102 (U5) VDD is an OUTPUT, so U5
+    # must NOT appear on +3V3 (the landmine the templates handle).
+    assert {"U1", "U4"} <= refs_on("+3V3")
+    assert "U5" not in refs_on("+3V3")
+    assert "U1" in refs_on("GND")
+    # I2C bus joins the ESP32 (U1) and the MCP23017 (U3).
+    assert {"U1", "U3"} <= refs_on("I2C_SDA")


### PR DESCRIPTION
## What
An end-to-end **integration** test that runs the whole firmware→PCB arc on real KiCad and asserts it produces a *routed* board:

```
config.h → design intent → expand templates → generate schematic → build_pcb_from_schematic (routed)
```

## Why
This is the fix for the session's meta-finding. `build_pcb_from_schematic` was once **100% broken on KiCad 10 with zero integration coverage** — 1300+ unit tests all green while the flagship pipeline produced electrically-dead boards. **Test count ≠ pipeline confidence.** This gate would have caught it, and now guards the whole front-end arc we built (PRs #45–#47).

## Design
- **Committed fixture** `tests/fixtures/firmware/{config.h,platformio.ini}` — a representative ESP32 board (MCP23017@0x27 + HX711 + I2C + orphans + seam-guard non-pin macros), so the harness is self-contained (no dependency on a local firmware tree).
- **Version-robust assertions**: it runs on **both KiCad 9.0 and 10.0**, so it asserts invariants that don't drift between symbol-library versions — component count, **by-component-ref** net membership, **0-unconnected** routing, zones added — *not* exact pin numbers. Includes the CP2102-`VDD`-not-on-+3V3 landmine check by ref.

## Routing into the right job
Lives in `tests/integration/` → module-skipped unless `KICAD_INTEGRATION=1`, and excluded from the no-KiCad matrix by `norecursedirs`. **No `src` changes**; the regular matrix is unchanged at **1409**. The new test only executes in the `integration / kicad-9.0` and `kicad-10.0` jobs.

Verified locally on KiCad 10 — full arc, 0 unconnected, ~19s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)