### PR TITLE
feat(design): I2C sensor-hub class — multiple address-declared I2C devices (Phase 5)

### DIFF
--- a/src/kicad_mcp/utils/firmware/generate.py
+++ b/src/kicad_mcp/utils/firmware/generate.py
@@ -71,27 +71,37 @@ def generate_schematic(intent: DesignIntent, schematic_path: str) -> dict[str, A
 
     type_by_ref = {p.ref: p.type for p in intent.peripherals}
 
+    def _name_or_number(sym: Any, token: Any) -> Any:
+        """Resolve a pin token to its NUMBER. A token is either a pin NAME
+        (MCP23017 ``SDA``) or already a literal pin NUMBER (a header pin ``4``,
+        a USB-C/QFN pad ``A4``/``29``). Name lookup first; else validate the
+        token against the symbol's real numbers (alphanumeric, so not a digit
+        check)."""
+        num = pin_number_by_name(sym, token)
+        if num is not None:
+            return num
+        valid = {str(p.number) for p in (getattr(sym, "pins", None) or ())}
+        return str(token) if str(token) in valid else None
+
     def resolve_pin(ref: str, gpio: Any, role: Any, pin: Any) -> Any:
         sym = symbols.get(ref)
         if sym is None:
             return None
         if pin is not None:                        # direct pin NAME or number
-            num = pin_number_by_name(sym, pin)
-            if num is not None:
-                return num
-            # else: pin may already be a literal pin NUMBER (e.g. "3", "A4").
-            # Validate against the symbol's real numbers — USB-C/QFN numbers are
-            # alphanumeric, so a digit check is not enough.
-            valid = {str(p.number) for p in (getattr(sym, "pins", None) or ())}
-            return str(pin) if str(pin) in valid else None
+            return _name_or_number(sym, pin)
         if gpio is not None:                       # MCU side
             return gpio_to_pin_number(sym, int(gpio))
         ptype = type_by_ref.get(ref)               # peripheral side
+        # The roles map may point at a pin NAME (MCP23017 ``SDA``) or a pin
+        # NUMBER (a module-header device, ``SDA`` -> ``4``) — handle both.
         pin_name = role_to_pin_name(ptype, role) if ptype else None
-        num = pin_number_by_name(sym, pin_name) if pin_name else None
-        if num is None and role:                   # last resort: role == pin name
-            num = pin_number_by_name(sym, role)
-        return num
+        if pin_name is not None:
+            num = _name_or_number(sym, pin_name)
+            if num is not None:
+                return num
+        if role:                                   # last resort: role == pin name
+            return _name_or_number(sym, role)
+        return None
 
     def wire_pin(comp: Any, pin_num: str, net_name: str) -> bool:
         """Add a wire stub + net label at a pin (the connectivity primitive)."""

--- a/src/kicad_mcp/utils/firmware/intent.py
+++ b/src/kicad_mcp/utils/firmware/intent.py
@@ -20,7 +20,7 @@ import yaml
 logger = logging.getLogger(__name__)
 
 from kicad_mcp.utils.firmware.knowledge import resolve_mcu, resolve_peripheral
-from kicad_mcp.utils.firmware.parse import ParsedFirmware
+from kicad_mcp.utils.firmware.parse import ParsedFirmware, address_base
 
 SCHEMA_VERSION = 3  # v3: typed buses (I2S/I2C/UART) for bus-driven templates
 
@@ -143,10 +143,9 @@ def _strip_pin_suffix(name: str) -> str:
 
 
 def _peripheral_type_from_addr(name: str) -> str:
-    for suf in ("_ADDRESS", "_ADDR"):
-        if name.endswith(suf):
-            return name[: -len(suf)]
-    return name
+    # Delegates to parse.address_base — the single source of truth for the
+    # addr-macro name shape (incl. the multi-instance ``_2`` qualifier).
+    return address_base(name) or name
 
 
 def _bus_type(roles: set[str]) -> Optional[str]:
@@ -204,37 +203,62 @@ def build_intent(
         intent.gaps.append(Gap("mcu_unknown",
                                f"Could not resolve MCU from board id {board_id!r}."))
 
-    # --- collect candidate peripheral types (addresses + pin hints) ---
-    addr_by_type: dict[str, int] = {}
-    for a in parsed.addresses:
-        addr_by_type.setdefault(_peripheral_type_from_addr(a.name), a.address or 0)
+    # --- materialize peripherals we have a symbol for ---
+    # Address-declared devices: ONE instance per ``*_ADDR`` macro — two MPU6050
+    # at 0x68/0x69 are two chips on the shared bus, not one collapsed entry.
+    # Pin-hint devices (named only by pin macros, no address, e.g. HX711): one
+    # per type. Deterministic order: address devices by (type, address), then
+    # the remaining hint types.
+    addr_devices = [(_peripheral_type_from_addr(a.name), a.address or 0)
+                    for a in parsed.addresses]
+    addr_types = {t for t, _ in addr_devices}
     hint_types = {
         m.peripheral_hint for m in parsed.pins
-        if m.peripheral_hint and m.bus is None
+        if m.peripheral_hint and m.bus is None and m.peripheral_hint not in addr_types
     }
-    candidate_types = sorted(set(addr_by_type) | {h for h in hint_types if h})
+    # Combined, then ordered by (type, address) so refs are deterministic and
+    # stable: alphabetical by type, and within a type ascending by address (the
+    # two MPU6050 at 0x68/0x69 get consecutive refs). Hint devices (no address)
+    # sort first within their type.
+    to_place: list[tuple[str, Optional[int]]] = (
+        [(t, a) for t, a in addr_devices]
+        + [(t, None) for t in hint_types if t]
+    )
+    to_place.sort(key=lambda ta: (ta[0], -1 if ta[1] is None else ta[1]))
 
-    # --- materialize peripherals we have a symbol for ---
     peripherals: list[Peripheral] = []
     periph_by_type: dict[str, Peripheral] = {}
+    unknown_types: set[str] = set()
+    placed_module = False
     next_ref = 2
-    for t in candidate_types:
+    for t, address in to_place:
         info = resolve_peripheral(t)
         if info is None:
-            intent.gaps.append(Gap(
-                "unknown_peripheral",
-                f"Peripheral {t!r} is referenced by firmware but has no known "
-                f"symbol; not placed.",
-            ))
+            if t not in unknown_types:   # one gap per unknown type, not per instance
+                unknown_types.add(t)
+                intent.gaps.append(Gap(
+                    "unknown_peripheral",
+                    f"Peripheral {t!r} is referenced by firmware but has no known "
+                    f"symbol; not placed.",
+                ))
             continue
+        placed_module = placed_module or info["module"]
         p = Peripheral(
             ref=f"U{next_ref}", type=t, lib_id=info["lib_id"], value=info["value"],
-            footprint=info["footprint"], bus=info["bus"], address=addr_by_type.get(t),
+            footprint=info["footprint"], bus=info["bus"], address=address,
         )
         next_ref += 1
         peripherals.append(p)
-        periph_by_type[t] = p
+        periph_by_type.setdefault(t, p)   # first instance anchors the non-bus net path
     intent.peripherals = peripherals
+
+    if placed_module:
+        intent.gaps.append(Gap(
+            "module_assumption",
+            "One or more I2C devices are modeled as breakout-module headers "
+            "(carrier-board assumption); for chip-down placement supply the bare "
+            "IC symbol + its support passives.",
+        ))
 
     by_bus: dict[str, list[Peripheral]] = {}
     for p in peripherals:

--- a/src/kicad_mcp/utils/firmware/knowledge.py
+++ b/src/kicad_mcp/utils/firmware/knowledge.py
@@ -43,6 +43,11 @@ class PeripheralInfo(TypedDict):
     roles: dict[str, str]
     supply_pins: list[str]   # pin NAMES tied to +3V3
     ground_pins: list[str]   # pin NAMES tied to GND
+    # True if this entry models the device as its breakout-MODULE header
+    # (e.g. a GY-521 / I2C OLED plugged onto a carrier) rather than a chip-down
+    # IC. Firmware names the device; "module vs chip-down" is a design choice we
+    # make explicit (build_intent flags it), same spirit as the AMS1117 default.
+    module: bool
 
 
 # ESP32-WROOM-32E facts. GND is the symbol's MERGED pin (physical pads
@@ -87,6 +92,8 @@ HDR_1X2 = ("Connector_Generic:Conn_01x02",
            "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical")
 HDR_1X4 = ("Connector_Generic:Conn_01x04",
            "Connector_PinHeader_2.54mm:PinHeader_1x04_P2.54mm_Vertical")
+HDR_1X5 = ("Connector_Generic:Conn_01x05",
+           "Connector_PinHeader_2.54mm:PinHeader_1x05_P2.54mm_Vertical")
 
 # board-id substrings (from platformio.ini ``board =``) -> MCU. MORE-SPECIFIC
 # keys FIRST: resolve_mcu does substring matching, so `esp32-s3` must precede the
@@ -103,7 +110,7 @@ _PERIPHERALS: dict[str, PeripheralInfo] = {
         "footprint": "Package_SO:SOIC-28W_7.5x17.9mm_P1.27mm",
         # NB: I2C clock pin is named "SCK" on this symbol, not "SCL".
         "roles": {"SDA": "SDA", "SCL": "SCK", "INT": "INTA", "INTA": "INTA"},
-        "supply_pins": ["V_{DD}"], "ground_pins": ["V_{SS}"],
+        "supply_pins": ["V_{DD}"], "ground_pins": ["V_{SS}"], "module": False,
     },
     "HX711": {
         "lib_id": "Analog_ADC:HX711",
@@ -112,8 +119,44 @@ _PERIPHERALS: dict[str, PeripheralInfo] = {
         "roles": {"DOUT": "DOUT", "SCK": "PD_SCK", "PD_SCK": "PD_SCK"},
         # HX711 has no separate DGND — analog + digital ground share AGND.
         "supply_pins": ["VSUP", "AVDD", "DVDD"], "ground_pins": ["AGND"],
+        "module": False,
+    },
+    # --- I2C breakout modules (carrier-board representation) ------------------
+    # A GY-521 (MPU-6050) module exposes a header; we model the connection, not
+    # the bare QFN (whose charge-pump/REGOUT support firmware can't inform).
+    # Header pin convention (matches i2c_device_header): 1=GND 2=VCC 3=SCL 4=SDA,
+    # plus 5=AD0 for I2C address selection.
+    "MPU6050": {
+        "lib_id": HDR_1X5[0], "value": "GY-521 (MPU-6050)", "bus": "I2C",
+        "footprint": HDR_1X5[1],
+        "roles": {"SDA": "4", "SCL": "3"},
+        "supply_pins": ["2"], "ground_pins": ["1"], "module": True,
+    },
+    # I2C OLED module (SSD1306/SSD1315). 4-pin module: 1=GND 2=VCC 3=SCL 4=SDA.
+    "OLED": {
+        "lib_id": HDR_1X4[0], "value": "OLED (SSD1306)", "bus": "I2C",
+        "footprint": HDR_1X4[1],
+        "roles": {"SDA": "4", "SCL": "3"},
+        "supply_pins": ["2"], "ground_pins": ["1"], "module": True,
     },
 }
+
+# MPU-6050 I2C address strapping: a single AD0 pin selects the LSB of the
+# address — AD0=low -> base 0x68, AD0=high -> 0x69. (GY-521 header pin 5 = AD0.)
+# Single source of truth for the address->AD0-rail map (boundary-tested).
+MPU6050_AD0_PIN = "5"
+MPU6050_ADDR_BASE = 0x68
+
+
+def mpu6050_ad0_strap(address: int) -> Optional[tuple[str, str]]:
+    """Return ``(ad0_pin_name, rail)`` for an MPU-6050 I2C address, or None if
+    the address is outside the strappable pair 0x68/0x69. AD0 ties to "GND"
+    (0x68) or "+3V3" (0x69)."""
+    if address == MPU6050_ADDR_BASE:
+        return (MPU6050_AD0_PIN, "GND")
+    if address == MPU6050_ADDR_BASE + 1:
+        return (MPU6050_AD0_PIN, "+3V3")
+    return None
 
 # --- verified footprints (speed-cal v5 BOM) for template-placed passives ---
 LIB_C = "Device:C"

--- a/src/kicad_mcp/utils/firmware/parse.py
+++ b/src/kicad_mcp/utils/firmware/parse.py
@@ -39,7 +39,21 @@ GPIO_MAX = 48
 BARE_PIN_ALIASES = frozenset({"I2C_SDA", "I2C_SCL"})
 
 _PIN_SUFFIXES = ("_PIN", "_GPIO")
-_ADDR_SUFFIXES = ("_ADDR", "_ADDRESS")
+
+# An I2C device-address macro name: ``<TYPE>_ADDR[ESS][ _<n> | <n> ]``. The
+# optional trailing instance qualifier distinguishes multiple chips of the SAME
+# type on one bus (``MPU6050_ADDR`` 0x68, ``MPU6050_ADDR_2`` 0x69). This is the
+# SINGLE SOURCE OF TRUTH (CLAUDE.md Rule 3) for "is this an address-macro name,
+# and what base type does it name" — both the classifier here and the importer
+# (intent._peripheral_type_from_addr) consume it, so neither re-encodes the rule.
+_ADDR_NAME_RE = re.compile(r"(?P<base>.+?)_(?:ADDRESS|ADDR)(?:_?\d+)?$")
+
+
+def address_base(name: str) -> Optional[str]:
+    """Return the base peripheral type if ``name`` is an address-macro name
+    (``MPU6050_ADDR`` / ``MPU6050_ADDR_2`` -> ``MPU6050``), else None."""
+    m = _ADDR_NAME_RE.match(name)
+    return m.group("base") if m else None
 
 # Bus prefixes recognized in a pin macro's name -> canonical bus id.
 _BUS_PREFIXES = {
@@ -219,7 +233,7 @@ def classify(name: str, value: str, args: Optional[str]) -> Macro:
         return Macro(name=name, raw_value="", line_no=0, kind=MacroKind.EMPTY)
 
     # ADDRESS: name says address AND value is an int.
-    if name.endswith(_ADDR_SUFFIXES):
+    if address_base(name) is not None:
         ival = _as_int(value)
         if ival is not None:
             return Macro(name=name, raw_value=value, line_no=0,

--- a/src/kicad_mcp/utils/firmware/templates.py
+++ b/src/kicad_mcp/utils/firmware/templates.py
@@ -202,6 +202,24 @@ def mcp23017_config(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
     return ex
 
 
+def mpu6050_config(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
+    """Strap each MPU-6050's AD0 pin per its I2C address (0x68→GND, 0x69→+3V3).
+    Direct tie (no resistor) — correct for a fixed address. The address→rail map
+    is knowledge.mpu6050_ad0_strap (the boundary-tested single source). An
+    out-of-range address is surfaced as a gap, never silently strapped."""
+    ex = Expansion()
+    for p in intent.peripherals:
+        if p.type.upper() != "MPU6050" or p.address is None:
+            continue
+        strap = K.mpu6050_ad0_strap(p.address)
+        if strap is None:
+            ex.resolved.append("__invalid_mpu_address")  # surfaced as a gap below
+            continue
+        ad0_pin, rail = strap
+        ex.power.append((rail, Endpoint(ref=p.ref, pin=ad0_pin)))
+    return ex
+
+
 def _passive_net(name: str, *endpoints: Endpoint) -> Net:
     return Net(name=name, kind="passive", confidence="high", origin="template",
                endpoints=list(endpoints))
@@ -451,6 +469,7 @@ _REGISTRY: list[tuple[str, Callable[[DesignIntent, RefAllocator], Expansion]]] =
     ("i2c_device_header", i2c_device_header),
     ("uart_device_header", uart_device_header),
     ("mcp23017_config", mcp23017_config),
+    ("mpu6050_config", mpu6050_config),
 ]
 
 
@@ -491,6 +510,10 @@ def expand_intent(intent: DesignIntent) -> DesignIntent:
             if kind == "__invalid_address":
                 intent.gaps.append(Gap("invalid_address",
                                        "MCP23017 I2C address outside 0x20–0x27; not strapped."))
+                continue
+            if kind == "__invalid_mpu_address":
+                intent.gaps.append(Gap("invalid_address",
+                                       "MPU-6050 I2C address is not 0x68/0x69; AD0 not strapped."))
                 continue
             gap = gaps_by_kind.get(kind)
             if gap is not None and not gap.resolved:

--- a/tests/fixtures/firmware/track_geometry/config.h
+++ b/tests/fixtures/firmware/track_geometry/config.h
@@ -1,0 +1,246 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include <Arduino.h>
+
+// ===== VERSION INFORMATION =====
+#define FIRMWARE_VERSION_BASE "0.5.0"
+
+#ifndef BUILD_GIT_HASH
+#define BUILD_GIT_HASH "dev"
+#endif
+#ifndef BUILD_TIME
+#define BUILD_TIME __DATE__ " " __TIME__
+#endif
+
+#define FIRMWARE_VERSION FIRMWARE_VERSION_BASE "-" BUILD_GIT_HASH
+
+// ===== I2C CONFIGURATION =====
+// ESP32-WROOM default I2C pins (differs from ESP32-C3 which uses GPIO 8/9)
+#define I2C_SDA_PIN         21
+#define I2C_SCL_PIN         22
+#define I2C_CLOCK_HZ        400000   // 400 kHz Fast Mode
+
+// ===== I2C DEVICE ADDRESSES =====
+#define MPU6050_ADDR        0x68     // IMU #1 (AD0=LOW, required)
+#define MPU6050_ADDR_2      0x69     // IMU #2 (AD0=HIGH, optional)
+#define OLED_ADDR           0x3C
+// #define INA219_ADDR      0x40     // Phase 3: track power monitor
+
+// ===== MPU-6050 REGISTERS =====
+#define MPU6050_REG_SMPLRT_DIV      0x19
+#define MPU6050_REG_CONFIG          0x1A
+#define MPU6050_REG_GYRO_CONFIG     0x1B
+#define MPU6050_REG_ACCEL_CONFIG    0x1C
+#define MPU6050_REG_ACCEL_XOUT_H   0x3B   // Start of 14-byte burst read
+#define MPU6050_REG_TEMP_OUT_H      0x41
+#define MPU6050_REG_PWR_MGMT_1     0x6B
+#define MPU6050_REG_WHO_AM_I       0x75
+
+// MPU-6050 configuration values
+#define MPU6050_ACCEL_RANGE_2G      0x00   // +-2g  (16384 LSB/g)
+#define MPU6050_GYRO_RANGE_250      0x00   // +-250 deg/s (131 LSB/deg/s)
+#define MPU6050_DLPF_20HZ           0x04   // ~20 Hz bandwidth, ~8.5ms delay
+#define MPU6050_SMPLRT_DIV_100HZ    0x09   // 1000/(9+1) = 100 Hz
+#define MPU6050_CLOCK_PLL_XGYRO     0x01   // PLL with X-axis gyro reference
+#define MPU6050_WHO_AM_I_EXPECTED   0x68
+
+// Conversion factors
+#define ACCEL_LSB_PER_G     16384.0f
+#define GYRO_LSB_PER_DPS    131.0f
+#define TEMP_LSB_PER_DEG    340.0f
+#define TEMP_OFFSET_DEG     36.53f
+
+// ===== MQTT CONFIGURATION =====
+#define MQTT_DEFAULT_PREFIX     "/cova"
+#define MQTT_DEFAULT_NAME       "geometry-car"
+#define MQTT_NVS_NAMESPACE      "mqtt"
+#define MQTT_PORT               1883
+#define MQTT_BUFFER_SIZE        2048
+#define MQTT_HEALTH_INTERVAL_MS 300000UL  // 5 minutes
+
+// ===== WIFI CONFIGURATION =====
+#define WIFI_AP_SSID        "GeometryCar"
+#define WIFI_AP_CHANNEL     1
+#define WIFI_AP_MAX_CONN    4
+#define WIFI_STA_CONNECT_TIMEOUT_MS  10000   // 10s to connect in STA mode
+#define WIFI_NVS_NAMESPACE  "wifi"
+#define WIFI_NVS_KEY_SSID   "ssid"
+#define WIFI_NVS_KEY_PASS   "pass"
+
+// ===== WEBSOCKET CONFIGURATION =====
+#define WS_PATH             "/ws"
+#define WS_SEND_INTERVAL_MS     100     // 100 ms = 10 Hz raw sample batches
+#define WS_SUMMARY_INTERVAL_MS  1000    // 1000 ms = 1 Hz summary frames
+#define WS_CLEANUP_INTERVAL_MS  2000    // 2 sec = cleanup dead connections
+#define WS_SAMPLE_BATCH_SIZE    10      // Samples per WebSocket frame
+
+// WebSocket frame types (server -> client)
+#define WS_FRAME_RAW_SAMPLES    0x01
+#define WS_FRAME_SUMMARY        0x02
+#define WS_FRAME_REC_STATUS     0x03    // Recording state notification
+
+// WebSocket command types (client -> server)
+#define WS_CMD_START_RECORDING  0x10
+#define WS_CMD_STOP_RECORDING   0x11
+#define WS_CMD_CALIBRATE        0x12
+
+// Wire format: 30 bytes per sample (no struct padding)
+// IMU1: timestamp(4) + accel(6) + gyro(6) + temp(2) = 18
+// IMU2: accel(6) + gyro(6) = 12  (no timestamp, no temp)
+#define WS_SAMPLE_WIRE_SIZE     30
+
+// ===== DUAL-CORE IMU TASK (ESP32 only, not C3/single-core) =====
+#define IMU_TASK_STACK_SIZE     4096
+#define IMU_TASK_PRIORITY       5       // Above Arduino loop (1), below WiFi (23)
+#define IMU_TASK_CORE           0
+#define I2C_MUTEX_TIMEOUT_MS    50      // Max wait for I2C bus
+
+// ===== TIMING CONSTANTS =====
+#define IMU_SAMPLE_INTERVAL_US      10000   // 10 ms = 100 Hz
+#define OLED_UPDATE_INTERVAL_MS     200     // 200 ms = 5 Hz
+#define SERIAL_OUTPUT_INTERVAL_MS   100     // 100 ms = 10 Hz
+#define STATS_REPORT_INTERVAL_MS    10000   // 10 sec = sample rate reporting
+#define SUMMARY_INTERVAL_MS         1000    // 1 sec = 1 Hz summary computation
+
+// ===== RING BUFFER =====
+#define RING_BUFFER_SIZE    1024            // 1024 samples = 10.24 sec at 100Hz
+
+// ===== DATA STRUCTURES =====
+
+struct imu_sample_t {
+    uint32_t timestamp_ms;
+    // IMU #1 (front truck, 0x68)
+    int16_t accel_x;
+    int16_t accel_y;
+    int16_t accel_z;
+    int16_t gyro_x;
+    int16_t gyro_y;
+    int16_t gyro_z;
+    int16_t temperature;
+    // IMU #2 (rear truck, 0x69) — zero-filled when single IMU
+    int16_t accel_x2;
+    int16_t accel_y2;
+    int16_t accel_z2;
+    int16_t gyro_x2;
+    int16_t gyro_y2;
+    int16_t gyro_z2;
+};
+
+struct summary_1s_t {
+    uint32_t timestamp_ms;
+    // IMU #1
+    float accel_x_rms;
+    float accel_y_rms;
+    float accel_z_rms;
+    float accel_x_peak;
+    float accel_y_peak;
+    float accel_z_peak;
+    float gyro_x_rms;
+    float gyro_y_rms;
+    float gyro_z_rms;
+    float gyro_x_mean;
+    float gyro_y_mean;
+    float gyro_z_mean;
+    float temperature;
+    uint32_t sample_count;
+    float sample_rate;
+    // IMU #2 — zero when single IMU
+    float accel_x2_rms;
+    float accel_y2_rms;
+    float accel_z2_rms;
+    float accel_x2_peak;
+    float accel_y2_peak;
+    float accel_z2_peak;
+    float gyro_x2_rms;
+    float gyro_y2_rms;
+    float gyro_z2_rms;
+    float gyro_x2_mean;
+    float gyro_y2_mean;
+    float gyro_z2_mean;
+    // Accel means (for grade/tilt computation) — appended to preserve layout
+    float accel_x_mean;      // IMU #1 longitudinal (grade)
+    float accel_y_mean;      // IMU #1 lateral (superelevation)
+    float accel_z_mean;      // IMU #1 vertical (near 1.0g on level)
+};
+
+// ===== FLASH LOGGING =====
+#define SURVEY_DIR              "/surveys"
+#define SURVEY_HEADER_SIZE      64
+#define SURVEY_SAMPLE_SIZE      30      // Same as WS_SAMPLE_WIRE_SIZE (no padding)
+#define SURVEY_MAGIC            "GEOM"
+#define SURVEY_VERSION_SINGLE   1       // Version 1: single IMU (18 bytes/sample)
+#define SURVEY_VERSION_DUAL     2       // Version 2: dual IMU (30 bytes/sample)
+#define FLASH_MIN_FREE_BYTES    32768   // Reserve 32KB for web UI + overhead
+
+struct __attribute__((packed)) survey_header_t {
+    char     magic[4];           // "GEOM"
+    uint8_t  version;            // SURVEY_VERSION_SINGLE or _DUAL
+    uint8_t  sample_size;        // SURVEY_SAMPLE_SIZE (30)
+    uint16_t sample_rate_hz;     // 100
+    uint8_t  accel_range_g;      // 2 (±2g)
+    uint8_t  gyro_range_dps;     // 250 (stored as uint8_t, 250 fits)
+    uint8_t  imu_count;          // 1 or 2
+    uint8_t  reserved1[1];
+    uint32_t start_time_ms;      // millis() at recording start
+    char     car_id[16];         // "GeometryCar\0..."
+    uint8_t  reserved2[32];      // Pad to 64 bytes total
+};
+
+// ===== TRUCK CONFIGURATION =====
+// Default values for standard Bettendorf trucks on 55' flat car.
+// Stored in NVS, overridable from browser Car Setup UI.
+#define TRUCK_NVS_NAMESPACE     "truck"
+#define TRUCK_NVS_KEY_AXLES     "axles"     // uint8_t: axles per truck
+#define TRUCK_NVS_KEY_AXLE_SP   "axle_sp"   // float: axle spacing in mm
+#define TRUCK_NVS_KEY_TRUCK_SP  "truck_sp"  // float: truck spacing in mm
+
+#define TRUCK_DEFAULT_AXLES       2       // 2 axles per truck (standard)
+#define TRUCK_DEFAULT_AXLE_SP     16.5f   // mm (~4.7' prototype in HO)
+#define TRUCK_DEFAULT_TRUCK_SP    54.0f   // mm (bolster-to-bolster, 55' flat car)
+
+// ===== BUZZER CONFIGURATION =====
+// Audible speed indicator: blips to guide hand-push survey speed
+#define BUZZER_PIN              25      // GPIO 25 (DAC1 + LEDC capable)
+#define BUZZER_LEDC_CHANNEL     0       // LEDC channel (0-15, no conflict with U8g2)
+#define BUZZER_LEDC_RESOLUTION  8       // 8-bit duty resolution
+
+// Tone frequencies (Hz)
+#define BUZZER_FREQ_SLOW        800     // Below target speed — low tone
+#define BUZZER_FREQ_FAST        2400    // Above target speed — high tone
+
+// Speed tolerance
+#define BUZZER_SPEED_DEADBAND   1.0f    // +/- 1 scale mph = silent (on target)
+#define BUZZER_SPEED_MAX_ERR    5.0f    // Error clamp for blip rate scaling
+
+// Blip timing (milliseconds)
+#define BUZZER_BLIP_DURATION_MS 40      // Length of each tone blip
+#define BUZZER_MIN_INTERVAL_MS  100     // Fastest blip rate (far from target)
+#define BUZZER_MAX_INTERVAL_MS  1000    // Slowest blip rate (near target)
+
+// Motion detection threshold
+#define BUZZER_MOTION_AZ_RMS_MIN  1.005f  // Below this = stationary, buzzer silent
+
+// Speed estimation (method 0: azRms proxy)
+#define BUZZER_AZRMS_STATIONARY   1.005f  // Below = 0 mph
+#define BUZZER_AZRMS_MAX_SPEED    1.05f   // Maps to ~20 mph
+#define BUZZER_AZRMS_SPEED_RANGE  20.0f   // Scale mph at AZRMS_MAX_SPEED
+
+// Speed estimation (method 1: leaky accel integration)
+#define BUZZER_ACCEL_DECAY        0.8f    // Per-second velocity decay factor
+#define BUZZER_GRAVITY_MMS2       9810.0f // mm/s^2
+
+// NVS storage
+#define BUZZER_NVS_NAMESPACE    "buzzer"
+#define BUZZER_NVS_KEY_ENABLED  "enabled"   // bool
+#define BUZZER_NVS_KEY_SPEED    "speed"     // float: target speed in scale mph
+#define BUZZER_NVS_KEY_MUTE     "mute"      // bool
+#define BUZZER_NVS_KEY_METHOD   "method"    // uint8_t: 0=azRms, 1=accel integration
+
+// WebSocket command
+#define WS_CMD_BUZZER_MUTE      0x13
+
+// HO scale speed conversion: mph * 447.04 / 87.0 = model mm/s
+#define SCALE_MPH_TO_MODEL_MMS  (447.04f / 87.0f)
+
+#endif // CONFIG_H

--- a/tests/fixtures/firmware/track_geometry/platformio.ini
+++ b/tests/fixtures/firmware/track_geometry/platformio.ini
@@ -1,0 +1,47 @@
+; PlatformIO Project Configuration File
+;
+; Track Geometry Car
+; ESP32-WROOM + MPU-6050 IMU + SSD1315 OLED + WiFi AP + WebSocket
+
+[platformio]
+default_envs = esp32dev
+
+[env:esp32dev]
+platform = espressif32@6.9.0
+board = esp32dev
+framework = arduino
+monitor_speed = 115200
+monitor_filters = send_on_enter
+upload_speed = 921600
+
+lib_deps =
+    olikraus/U8g2@^2.36.5
+    ArduinoJson@7.3.0
+    PubSubClient@2.8.0
+    ayushsharma82/ElegantOTA@^3.1.0
+    e32sl=symlink://../../shared
+; Note: ESPAsyncWebServer + AsyncTCP provided by ElegantOTA (esp32async fork)
+
+board_build.filesystem = littlefs
+extra_scripts = pre:version_build.py
+
+build_flags =
+    -DCORE_DEBUG_LEVEL=0
+    -DBOARD_HAS_PSRAM=0
+    -DELEGANTOTA_USE_ASYNC_WEBSERVER=1
+    ; BUILD_GIT_HASH and BUILD_TIME are injected by version_build.py
+
+; ===== Native test environment (runs on host, no ESP32 needed) =====
+[env:native]
+platform = native
+test_framework = unity
+
+; Don't compile project src — test files #include the .cpp directly
+; to avoid hardware-dependent modules pulling in Wire.h etc.
+build_src_filter = -<*>
+
+; Mock Arduino.h: put mock dir first on include path so it shadows
+; the real Arduino.h. Also include the project headers.
+build_flags =
+    -I test/mock
+    -I include

--- a/tests/integration/test_firmware_pcb_pipeline.py
+++ b/tests/integration/test_firmware_pcb_pipeline.py
@@ -26,6 +26,7 @@ pytestmark = pytest.mark.skipif(
 FIXTURE = Path(__file__).parent.parent / "fixtures" / "firmware"
 CONFIG_H = FIXTURE / "config.h"
 AUDIO_CONFIG_H = FIXTURE / "audio_s3" / "config.h"
+TRACK_GEOM_CONFIG_H = FIXTURE / "track_geometry" / "config.h"
 
 _MINIMAL_PRO = {
     "board": {"design_settings": {}},
@@ -142,3 +143,56 @@ def test_audio_s3_to_routed_pcb(mcp_server, tmp_path):
         return {x["component"] for x in nl["nets"].get(net, [])}
     assert "U1" in refs_on("+3V3")                       # S3 powered
     assert len(refs_on("I2S0_BCLK")) == 3               # MCU + 2 amps share the clock
+
+
+def test_track_geometry_to_routed_pcb(mcp_server, tmp_path):
+    """The THIRD board shape: an I2C sensor-hub (track-geometry car). Exercises
+    the generalization that matters here — MULTIPLE address-declared devices,
+    INCLUDING TWO OF THE SAME TYPE (dual MPU-6050 at 0x68/0x69), sharing one I2C
+    bus, plus an OLED. Devices are modeled as breakout-module headers; AD0 is
+    strapped per address. The buzzer GPIO stays a flagged orphan (no driver
+    template yet) — which must NOT break routing."""
+    design = _tool(mcp_server, "design")
+    build = _tool(mcp_server, "build_pcb_from_schematic")
+    intent = tmp_path / "intent.yaml"
+    sch = tmp_path / "tg.kicad_sch"
+    pro = tmp_path / "tg.kicad_pro"
+
+    r1 = design(operation="import_firmware", firmware_path=str(TRACK_GEOM_CONFIG_H),
+                out_path=str(intent))
+    assert r1["status"] == "ok"
+    assert r1["board"] == "esp32dev"
+    assert r1["summary"]["mcu"] == "ESP32-WROOM-32E"
+    # Two MPU6050 instances + one OLED, all recognized off their *_ADDR macros.
+    types = [p["type"] for p in r1["summary"]["peripherals"]]
+    assert types.count("MPU6050") == 2 and types.count("OLED") == 1
+
+    r2 = design(operation="expand_templates", intent_path=str(intent))
+    assert r2["status"] == "ok"
+    assert {"power_tree", "decoupling", "pullups"} <= set(r2["gaps_resolved"])
+
+    r3 = design(operation="generate_schematic", intent_path=str(intent),
+                schematic_path=str(sch))
+    assert r3["status"] == "ok" and not r3["unresolved_endpoints"]
+
+    pro.write_text(json.dumps(_MINIMAL_PRO))
+    r4 = build(project_path=str(pro), board_width_mm=90, board_height_mm=75,
+               autoroute_passes=2, export_gerbers=False)
+    assert r4["status"] == "ok"
+    assert r4["pads_assigned"] > 0
+    assert r4["incomplete_nets"] == 0                    # buzzer orphan must not break routing
+    assert r4["steps"]["zones"]["zones_added"] >= 1
+
+    from kicad_mcp.utils.netlist_parser import extract_netlist_via_cli
+    nl = extract_netlist_via_cli(str(sch))
+    assert nl is not None
+    vals = [c.get("value") for c in nl["components"].values()]
+    assert vals.count("GY-521 (MPU-6050)") == 2         # dual same-type I2C device
+    assert vals.count("OLED (SSD1306)") == 1
+
+    def refs_on(net):
+        return {x["component"] for x in nl["nets"].get(net, [])}
+    # The shared I2C bus joins the ESP32 (U1) + both MPU6050 (U2/U3) + OLED (U4).
+    assert {"U1", "U2", "U3", "U4"} <= refs_on("I2C_SDA")
+    assert {"U1", "U2", "U3", "U4"} <= refs_on("I2C_SCL")
+    assert "U1" in refs_on("+3V3")

--- a/tests/test_firmware_intent.py
+++ b/tests/test_firmware_intent.py
@@ -189,3 +189,62 @@ def test_find_board_id_real_speedcal():
     if not SPEEDCAL_CONFIG.exists():
         return
     assert find_board_id(str(SPEEDCAL_CONFIG)) == "esp32dev"
+
+
+# --- I2C sensor-hub: multiple address-declared devices, incl. same-type pair --
+# The track-geometry generalization: two MPU-6050 at 0x68/0x69 + an OLED at 0x3C,
+# all on one bare I2C bus (bare I2C_SDA/SCL pins + *_ADDR device declarations).
+
+_HUB = """\
+#define I2C_SDA_PIN 21
+#define I2C_SCL_PIN 22
+#define MPU6050_ADDR 0x68
+#define MPU6050_ADDR_2 0x69
+#define OLED_ADDR 0x3C
+#define BUZZER_PIN 25
+#define MPU6050_REG_PWR_MGMT_1 0x6B
+"""
+
+
+def _hub_intent():
+    return build_intent(partition(parse_defines(_HUB)),
+                        firmware_path="config.h", board_id="esp32dev")
+
+
+def test_hub_two_mpu_instances_plus_oled():
+    peris = _hub_intent().peripherals
+    mpus = [p for p in peris if p.type == "MPU6050"]
+    oled = [p for p in peris if p.type == "OLED"]
+    # two distinct MPU instances at distinct addresses, distinct refs
+    assert len(mpus) == 2 and len(oled) == 1
+    assert {p.address for p in mpus} == {0x68, 0x69}
+    assert len({p.ref for p in mpus}) == 2
+    # deterministic order: lower address gets the lower ref
+    by_ref = sorted(mpus, key=lambda p: p.ref)
+    assert by_ref[0].address == 0x68 and by_ref[1].address == 0x69
+
+
+def test_hub_all_devices_share_one_i2c_bus():
+    i = _hub_intent()
+    sda = _net(i, "I2C_SDA")
+    refs = {e.ref for e in sda.endpoints}
+    # MCU + both MPU + OLED all sit on the shared SDA line
+    dev_refs = {p.ref for p in i.peripherals if p.type in ("MPU6050", "OLED")}
+    assert dev_refs <= refs and i.mcu.ref in refs
+    assert sda.kind == "bus"
+
+
+def test_hub_register_macro_is_not_a_device():
+    # MPU6050_REG_PWR_MGMT_1 (0x6B) must NOT become an address/peripheral.
+    types = {p.type for p in _hub_intent().peripherals}
+    assert "MPU6050_REG_PWR_MGMT_1" not in types and "MPU6050_REG" not in types
+
+
+def test_hub_buzzer_stays_flagged_orphan():
+    i = _hub_intent()
+    assert _net(i, "BUZZER").kind == "orphan"
+    assert any(g.kind == "unknown_peripheral" and "BUZZER" in g.detail for g in i.gaps)
+
+
+def test_hub_module_assumption_flagged():
+    assert any(g.kind == "module_assumption" for g in _hub_intent().gaps)

--- a/tests/test_firmware_parse.py
+++ b/tests/test_firmware_parse.py
@@ -103,6 +103,32 @@ def test_address_with_non_int_value_is_other():
     assert m.kind is MacroKind.OTHER and "address" in m.note
 
 
+# --- address_base: the single source of truth for addr-macro names -----------
+# Including the multi-instance qualifier (two chips of the same type on a bus).
+
+@pytest.mark.parametrize("name,base", [
+    ("MPU6050_ADDR", "MPU6050"),
+    ("MPU6050_ADDR_2", "MPU6050"),       # instance qualifier: _<n>
+    ("MPU6050_ADDRESS_2", "MPU6050"),    # long form + instance
+    ("BME280_ADDR0", "BME280"),          # qualifier with no underscore
+    ("OLED_ADDR", "OLED"),
+    ("INA219_ADDRESS", "INA219"),
+    # NOT address macros:
+    ("MPU6050_REG_CONFIG", None),        # the register-table seam trap
+    ("BASE_ADDRESS_OFFSET", None),       # trailing non-digit after ADDRESS
+    ("BUZZER_PIN", None),
+])
+def test_address_base(name, base):
+    from kicad_mcp.utils.firmware.parse import address_base
+    assert address_base(name) == base
+
+def test_second_instance_addr_is_classified_as_address():
+    # The whole reason the dual-MPU was previously lost: a strict endswith("_ADDR")
+    # check skipped MPU6050_ADDR_2 entirely. It must classify as an ADDRESS.
+    m = classify("MPU6050_ADDR_2", "0x69", None)
+    assert m.kind is MacroKind.ADDRESS and m.address == 0x69
+
+
 # --- GPIO range boundaries (at / below / above) ------------------------------
 
 @pytest.mark.parametrize("value,valid", [

--- a/tests/test_firmware_templates.py
+++ b/tests/test_firmware_templates.py
@@ -26,6 +26,7 @@ from kicad_mcp.utils.firmware.templates import (
     i2s_output_amps,
     mcp23017_config,
     mcu_straps,
+    mpu6050_config,
     power_tree,
     uart_device_header,
     usb_programming,
@@ -71,6 +72,20 @@ def test_address_strap_lsb_only():
 @pytest.mark.parametrize("addr", [0x1F, 0x28, 0x00, 0x50])
 def test_address_strap_out_of_range_is_none(addr):
     assert K.mcp23017_address_straps(addr) is None
+
+
+# --- MPU-6050 AD0 strap: the same silent-wrong hotspot, single-bit version ----
+
+def test_mpu_ad0_low_is_gnd():
+    assert K.mpu6050_ad0_strap(0x68) == ("5", "GND")     # AD0 low -> base addr
+
+def test_mpu_ad0_high_is_3v3():
+    assert K.mpu6050_ad0_strap(0x69) == ("5", "+3V3")    # AD0 high -> base+1
+
+@pytest.mark.parametrize("addr", [0x67, 0x6A, 0x00, 0x70])
+def test_mpu_ad0_out_of_range_is_none(addr):
+    # exactly one below, one above, and far-off addresses are NOT strappable
+    assert K.mpu6050_ad0_strap(addr) is None
 
 
 # --- ref allocation -----------------------------------------------------------
@@ -124,6 +139,54 @@ def test_mcp23017_config_straps_for_0x27():
     # all three address pins on +3V3 (0x27) + RESET high
     plus3_pins = {ep.pin for rail, ep in ex.power if rail == "+3V3"}
     assert {"A0", "A1", "A2", K.MCP23017_RESET_PIN} <= plus3_pins
+
+
+# --- MPU-6050 AD0 strapping (dual same-type devices on the bus) ---------------
+
+_HUB = """\
+#define I2C_SDA_PIN 21
+#define I2C_SCL_PIN 22
+#define MPU6050_ADDR 0x68
+#define MPU6050_ADDR_2 0x69
+#define OLED_ADDR 0x3C
+#define BUZZER_PIN 25
+"""
+
+
+def _hub():
+    return build_intent(partition(parse_defines(_HUB)),
+                        firmware_path="c.h", board_id="esp32dev")
+
+
+def test_mpu6050_config_straps_each_instance_by_address():
+    i = _hub()
+    ex = mpu6050_config(i, RefAllocator(i))
+    assert not ex.components                             # direct ties, no parts
+    # the 0x68 MPU's AD0 -> GND, the 0x69 MPU's AD0 -> +3V3 (per-instance)
+    mpus = {p.ref: p.address for p in i.peripherals if p.type == "MPU6050"}
+    ref_68 = next(r for r, a in mpus.items() if a == 0x68)
+    ref_69 = next(r for r, a in mpus.items() if a == 0x69)
+    straps = {(ep.ref, ep.pin, rail) for rail, ep in ex.power}
+    assert (ref_68, K.MPU6050_AD0_PIN, "GND") in straps
+    assert (ref_69, K.MPU6050_AD0_PIN, "+3V3") in straps
+
+def test_mpu6050_config_invalid_address_flagged_not_strapped():
+    # an MPU at an un-strappable address must be flagged, never silently tied.
+    i = build_intent(partition(parse_defines(
+        "#define I2C_SDA_PIN 21\n#define I2C_SCL_PIN 22\n#define MPU6050_ADDR 0x55\n")),
+        firmware_path="c.h", board_id="esp32dev")
+    expand_intent(i)
+    assert any(g.kind == "invalid_address" and "MPU" in g.detail for g in i.gaps)
+
+def test_hub_expand_routes_bus_and_pullups():
+    # full expand on the hub: power tree resolved, I2C pull-ups joined, AD0 straps
+    # present, board grows well past the bare import.
+    i = _hub()
+    n_before = len(i.peripherals)
+    expand_intent(i)
+    assert len(i.peripherals) > n_before
+    resolved = {g.kind for g in i.gaps if g.resolved}
+    assert {"power_tree", "decoupling", "pullups"} <= resolved
 
 
 # --- CP2102 USB programming block (highest-landmine template) -----------------


### PR DESCRIPTION
## Phase 5 — I2C sensor-hub class (firmware front end)

Generalizes the firmware-spec front end (`config.h → design intent → routed PCB`) to a **third, distinct board shape**: the **track-geometry car** (`mr-esp32/track-geometry`) — ESP32-WROOM + **dual MPU-6050 @ 0x68/0x69** + OLED @ 0x3C + buzzer.

The genuinely new capability is an I2C bus carrying **multiple address-declared devices, including two of the same type** (the shared-bus + list-of-addresses idiom that most simple I2C sensor boards use — unlike speed-cal's per-peripheral-named MCP23017).

### What the new shape exposed (and how it's fixed)

1. **The 2nd IMU was silently lost.** `parse.classify` recognized address macros by strict `name.endswith("_ADDR")`, so `MPU6050_ADDR_2` (ends in `_2`) was never an address. This was a CLAUDE.md **Rule-3 two-sources-of-truth** (parse.py and intent.py each encoded "address-macro name"). Unified into one canonical **`parse.address_base()`** (regex `<TYPE>_ADDR[ESS][_n]`); `intent._peripheral_type_from_addr` now delegates to it.
2. **Same-type multi-instance was collapsed.** Materialization was keyed per-type (one device per type). Now **one peripheral per `*_ADDR` macro**, ordered by `(type, address)` for stable refs (speed-cal U2/U3 unchanged).
3. **knowledge.py**: MPU-6050 / OLED modeled as **breakout-module headers** (`Conn_01x05` / `Conn_01x04`) — the honest carrier-board representation, which avoids fabricating bare-QFN charge-pump/REGOUT support firmware can't inform. New boundary-tested `mpu6050_ad0_strap` (0x68→GND, 0x69→+3V3), `HDR_1X5`, and a `module` flag on `PeripheralInfo`. `build_intent` emits a `module_assumption` gap flagging the carrier choice.
4. **templates.py**: new **`mpu6050_config`** straps each instance's AD0 pin per its address (direct tie, mirroring `mcp23017_config`). Existing `i2c_pullups` / `power_tree` / `decoupling` already cover the headers.
5. **generate.py**: `_name_or_number` helper — a device role may resolve to a pin **number** (module header `"4"`) or a pin **name** (MCP23017 `"SDA"`). Applies the same name-or-number logic Phase-3a added for direct pins to the role path.

### Scope / honesty

- The **buzzer GPIO is intentionally a flagged orphan** (no driver template yet — a clean follow-up; symbols already verified). A 1-endpoint net doesn't affect routing.
- Every KiCad-10 symbol pin was **verified against the installed libraries** before encoding (per the project's discipline + the spec-review external-assumption rule).

### Verification

- **Third golden-harness fixture** `tests/fixtures/firmware/track_geometry/` gates this shape in integration CI alongside speed-cal and audio-S3.
- End-to-end on **real KiCad**: config.h → intent → expand → generate → **routed PCB, 0 unconnected, GND zone**, with both MPU-6050s + OLED on the shared I2C bus and AD0 strapped per address.
- **1465 unit tests** (+24), **mypy clean** (65 files), **3/3 integration tests** on real KiCad. No new tool (tool count unchanged at 17).

### Reviewer notes

- New unit coverage follows the threshold-boundary rule: `address_base` (incl. the `_2`/`_ADDR0` qualifiers and register-table seam traps), `mpu6050_ad0_strap` (0x68/0x69/just-outside), multi-instance materialization, and the `mpu6050_config` template (per-instance strap + invalid-address gap).
- Speed-cal ref ordering is preserved by sorting placements by `(type, address)`; the two pre-existing speed-cal generate tests still pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)