### PR TITLE
feat(design): data-driven device cards + offline auto-draft (Phase 6 + 7)

### DIFF
--- a/docs/SPEC_Firmware_Device_Cards.md
+++ b/docs/SPEC_Firmware_Device_Cards.md
@@ -1,0 +1,251 @@
+# SPEC — Firmware Front End: Data-Driven Device Cards (Phase 6)
+
+**Status:** Phase 6 (refactor) + Phase 7 (offline auto-draft) IMPLEMENTED; 6b (board.yaml sidecar) and Phase 8 (multi-user / pre-fetch) remain planned. Cold-reviewed pre-implementation (findings folded in below).
+**Author context:** written in the Phase-5 session (track-geometry I2C sensor-hub, PR #50), with full context on `kicad_mcp/utils/firmware/`.
+**Review note:** per the CLAUDE.md spec-review rule, the highest-risk item is the *card → symbol-pin* external-system assumption. It is verified in-session (§9) rather than deferred. If this spec is picked up in a later session, re-verify §9 against the then-current KiCad before implementing.
+
+---
+
+## 1. Problem
+
+Across Phases 1–5, every new board shape required a code change. Sorting those diffs by *kind*:
+
+| Kind | Examples | Really data or logic? |
+|---|---|---|
+| A. `knowledge.py` table edits | MPU6050/OLED/CP2102/MAX98357A/SPH0645 entries, S3 MCU, footprints, pin/role maps | **Data** in Python clothing |
+| B. per-device config template | `mcp23017_config`, `mpu6050_config` (strap pin→rail per address) | **Mostly data** (a strap rule) wearing a function |
+| C. classifier/seam tables | `_BUS_ROLES`, `BARE_PIN_ALIASES`, `address_base` shape | **Data** allow-lists + occasional logic |
+| D. cross-cutting parse/generate logic | `_name_or_number`, IO{n} mapping, preprocessor, typed-bus grouping | **Genuine logic** |
+
+A, B, and most of C are **data**, and they were the bulk of the Phase 3a/4/5 diffs. D is real code but **saturating** — each D fix is a one-time generalization that retires a whole class of future changes (Phase 4 retired "`_PIN`-only"; Phase 5's `_name_or_number` retired "roles must be pin names").
+
+**Thesis:** push the *data* out of Python so a new board is, in the common case, a *data* edit (new device card) — not a code change, not a test edit. Keep the honesty guarantees by moving the project's "verify pins / boundary-test straps" discipline to **load-time validation** plus the existing per-shape golden harness.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- A new *recognized* peripheral or MCU = adding/editing a YAML **device card**. No Python edit, no unit-test edit.
+- Collapse `mcp23017_config` + `mpu6050_config` (and any future `*_config`) into **one** data-driven `device_config` template.
+- Preserve every current behavior exactly (golden harness proves equivalence; speed-cal/audio-S3/track-geometry must stay byte-stable where asserted).
+- Preserve honesty-by-construction: an unknown device still becomes a gap, never an invention.
+
+**Non-goals (this phase)**
+- Auto-drafting cards from LCSC/datasheets (perception-bound; separate, fuzzy effort — §11).
+- Replacing the *cross-cutting logic* in D. That stays code.
+- The `board.yaml` non-firmware sidecar — specified at §7 but may ship as Phase 6b.
+
+## 3. Device-card schema
+
+Cards live in a packaged directory `src/kicad_mcp/utils/firmware/devices/` plus optional override dirs (§6.3). One file per device/MCU. The on-disk card is the **source**; the in-memory shape stays the existing `PeripheralInfo` / `McuInfo` TypedDicts (so `templates.py` and `generate.py` consumers do **not** change — only the data's origin does).
+
+**TypedDict extension (cold-review fix).** `PeripheralInfo` must gain two *optional* fields the cards add — `config` (strap/tie spec, §4) and `decoupling` (override list). Python floor is **3.10**, so `typing.NotRequired` (3.11+) is unavailable and `typing_extensions` is only transitive. Use the stdlib **inheritance pattern**: a required base `class _PeripheralInfoBase(TypedDict)` + `class PeripheralInfo(_PeripheralInfoBase, total=False): config: dict; decoupling: list[dict]`. Existing literals/cards that omit these stay valid and mypy-clean on all of 3.10/3.12/3.13.
+
+**Consumer audit (cold-review).** Every reader of the externalized data keeps working *unchanged* because return types are preserved — confirmed callers: `resolve_peripheral` (intent.py `build_intent`, templates.py `_ic_power_pins`/`device_config`), `resolve_mcu` + `resolve_mcu_by_part` (templates.py, 4 call sites), `role_to_pin_name` (generate.py:97, delegates to `resolve_peripheral`). The template-owned constants `MAX98357A`, `SPH0645`, `AMS1117`, `USB_C_*`, `CP2102_*`, `HDR_1X*`, `SW_PUSH_*` **stay as Python in knowledge.py** — they are not firmware-addressable peripherals (no `*_ADDR`/pin-hint names them); they are design knowledge owned by their templates. Out of card scope, by design.
+
+### 3.1 Peripheral card
+
+```yaml
+# devices/peripherals/mpu6050.yaml
+type: MPU6050                 # UPPER; matches address_base()/peripheral_hint
+lib_id: Connector_Generic:Conn_01x05
+value: GY-521 (MPU-6050)
+footprint: Connector_PinHeader_2.54mm:PinHeader_1x05_P2.54mm_Vertical
+bus: I2C                      # null for non-bus devices
+module: true                 # breakout-module-header representation (carrier-board)
+roles:                        # firmware signal-role (UPPER) -> symbol pin NAME or NUMBER
+  SDA: "4"
+  SCL: "3"
+supply_pins: ["2"]
+ground_pins: ["1"]
+decoupling:                   # optional; replaces the implicit "1x 100nF per IC"
+  - {value: 100nF}
+config:                       # optional; replaces the *_config TEMPLATE (see §4)
+  address_strap:
+    pin_bits: ["5"]           # LSB-first; one symbol pin per strappable address bit
+    base: 0x68                # address when all bits clear
+    rail_set: "+3V3"          # bit = 1
+    rail_clear: "GND"         # bit = 0
+  static_ties: []             # e.g. MCP23017: [{pin: "~{RESET}", rail: "+3V3"}]
+```
+
+`mcp23017.yaml` is the same schema with `pin_bits: ["A0","A1","A2"]`, `base: 0x20`, and `static_ties: [{pin: "~{RESET}", rail: "+3V3"}]`. **This single schema reproduces both existing strap functions exactly** (§8 equivalence).
+
+### 3.2 MCU card
+
+```yaml
+# devices/mcus/esp32-wroom-32e.yaml
+part: ESP32-WROOM-32E
+lib_id: RF_Module:ESP32-WROOM-32E
+value: ESP32-WROOM-32E
+footprint: RF_Module:ESP32-WROOM-32E
+board_match: ["esp32dev", "esp32"]   # board-id substrings (see §3.3)
+needs_3v3: true
+supply_pin: VDD
+ground_pin: GND
+en_pin: EN
+boot_pin: IO0
+uart_rx_pin: RXD0/IO3
+uart_tx_pin: TXD0/IO1
+native_usb: false
+```
+
+### 3.3 MCU resolution — removing a Rule-3 seam
+
+`resolve_mcu` today is an **ordered dict** where "more specific first" is enforced only by a comment (`esp32-s3` must precede `esp32`). That ordering is a silent-failure seam. Replace with explicit, order-independent resolution:
+
+1. Exact match on a card's `part`/`board_match` (lowercased).
+2. Else the card whose **longest** `board_match` substring occurs in the board-id (deterministic; ties broken by `part` for stability).
+
+This makes adding an MCU card order-independent — a logic improvement that *removes* a footgun, not just relocates data. **Equivalence caveat (cold-review):** this is behavior-identical to the current ordered-dict resolution for all 5 board IDs any test exercises (`esp32dev`, `esp32-s3-devkitc-1`, `esp32-s3`, and the substrings `esp32`/`esp32s3`); it differs from insertion-order tie-breaking *only* for a hypothetical board-id with two equal-length matching substrings, which nothing exercises. The §8 "zero assertion edits" claim holds.
+
+## 4. The generic `device_config` template
+
+Replace `mcp23017_config` and `mpu6050_config` with one template that reads each placed peripheral's card `config`:
+
+- For `address_strap`: `offset = address - base`; for each bit *i*, tie `pin_bits[i]` to `rail_set` if `(offset >> i) & 1` else `rail_clear`. If `offset` is outside `[0, 2**len(pin_bits) - 1]`, emit an `invalid_address` gap (never strap).
+- For `static_ties`: tie each `{pin, rail}` directly.
+
+The bit→rail math lives in **one** boundary-tested helper, `compute_address_straps(card_config, address) -> list[(pin, rail)] | None`, which is the single source of truth replacing both `mcp23017_address_straps` and `mpu6050_ad0_strap`.
+
+**No-op without a `config` (cold-review):** `device_config` produces nothing for a peripheral whose card lacks `config.address_strap`/`static_ties` (e.g. the OLED 4-pin header has no strappable pin) — identical to today's behavior where no `*_config` template matched. The template iterates placed peripherals and skips any with no `config`.
+
+A new addressable device then needs **no template at all** — just a `config.address_strap` stanza in its card.
+
+## 5. Loader
+
+`knowledge.py` gains:
+
+- `load_device_cards()` — discover + parse + validate all cards once (module-level cache). Returns `{type: PeripheralInfo}` and `{part: McuInfo}`.
+- `resolve_peripheral` / `resolve_mcu` / `resolve_mcu_by_part` read the cache instead of literals. Public signatures and return types are **unchanged**.
+- The strap helpers become thin wrappers over `compute_address_straps` (or are removed in favor of it; callers updated).
+
+Discovery precedence (later overrides earlier, like `ADDITIONAL_SEARCH_PATHS`):
+1. packaged `devices/` (shipped),
+2. `$KICAD_MCP_DEVICE_DIRS` (colon-list, optional),
+3. project-local `./firmware-devices/` if present.
+
+A malformed card **fails loudly** at load (see §6) — never silently ignored (data-capture rule: no `continue`-on-failure without surfacing).
+
+## 6. Validation — two tiers (the honesty backstop)
+
+Moving data out of Python forfeits mypy + unit coverage *of that data*. Recover it with validation, split by what each tier can see:
+
+### 6.1 Structural (no KiCad — runs in the 1465-test unit matrix)
+- Required fields present; types correct; `bus` ∈ known set or null.
+- `lib_id` well-formed (`Lib:Symbol`).
+- `config.address_strap`: `base` an int, `pin_bits` non-empty, rails ∈ `{+3V3,+5V,GND,VBUS,...}`.
+- **Strap math boundary-checked**: for a card with N bits, addresses `base-1`, `base`, `base+2**N-1`, `base+2**N` produce the expected strap/`None` (at/below/above — threshold rule).
+- No duplicate `type` / `part` across cards.
+
+### 6.2 Pin-existence (needs KiCad — runs in the integration / self-hosted matrix)
+**This is the constraint surfaced during spec review:** the unit matrix has no KiCad symbol libraries, so pin-existence can't be checked there.
+- For each card, load its symbol via the symbol cache and assert every referenced pin (`roles` values, `supply_pins`, `ground_pins`, `config` pins) resolves — **reusing `generate._name_or_number`** (name lookup OR number-in-valid-set), so the validator and the generator share one resolution rule (Rule 3).
+- Lives in a new `tests/integration/test_device_cards.py`, gated by `KICAD_INTEGRATION=1`, run on the self-hosted KiCad 9/10 matrix. A wrong pin in a card fails CI there.
+
+### 6.3 Why two tiers is correct, not a compromise
+The structural tier catches the *common* card mistake (typo, bad strap range) fast and KiCad-free, keeping the 17-second unit loop intact. The pin tier catches the *dangerous* mistake (pin doesn't exist on the symbol) where symbols are actually available. The per-shape **golden harness** (config.h → routed PCB, 0-unconnected) remains the end-to-end backstop that proved its worth catching the KiCad-10 dead-board bug 1300 unit tests missed.
+
+## 7. Board sidecar `board.yaml` (Phase 6b — optional)
+
+Firmware is structurally blind to connectors, power source, board dimensions, mechanical. Today those are perpetual gaps. A per-board sidecar (next to `config.h` or passed to `import_firmware`) supplies them as **data**, never invented in code:
+
+```yaml
+# board.yaml
+power_source: usb_c            # or barrel, header, battery — sources the +5V rail
+board_size_mm: [90, 75]
+extra_connectors:
+  - {ref: J_PWR, lib_id: Connector:Barrel_Jack, nets: {"1": "+5V", "2": "GND"}}
+```
+
+`build_intent` merges sidecar facts and marks the matching gaps `resolved_by: "board.yaml"`. Honest-by-construction extends cleanly: what firmware can't know comes from a data file, with provenance. **Deferred from the core phase** to keep the equivalence-preserving refactor separable from new behavior.
+
+## 8. Migration & equivalence
+
+1. Extract the 6 existing entries (2 MCUs in `_MCUS`, 4 peripherals in `_PERIPHERALS`) into cards. Byte-for-byte the same field values. **The S3 MCU card must carry all three board-id variants** `board_match: ["esp32-s3-devkitc-1", "esp32-s3", "esp32s3"]` and the WROOM-32 card `["esp32dev", "esp32"]` — omitting any is a regression (cold-review).
+2. Extract the 2 strap functions into card `config` stanzas + `compute_address_straps`.
+3. Replace `mcp23017_config`/`mpu6050_config` registry entries with one `device_config`.
+4. **Equivalence proof:** the full unit suite (1465) + all 3 integration shapes must pass unchanged. Because the in-memory `PeripheralInfo`/`McuInfo` shape and all public signatures are preserved, downstream code is untouched; only the data's *source* moves. Any diff in generated schematic/PCB is a migration bug.
+5. Keep `mcp23017_address_straps` / `mpu6050_ad0_strap` as thin wrappers over `compute_address_straps`, **preserving their exact return types** (cold-review): `mcp23017_address_straps` returns the `list[(pin,rail)]` directly; **`mpu6050_ad0_strap` must unpack the single-element list back to a bare `tuple`** (`r[0] if r else None`) so the 3 Phase-5 assertions (`== ("5","GND")`, etc.) stay green with no edit. "Zero assertion edits" means exactly this — all 18 existing references in `test_firmware_templates.py` keep working through the transparent wrappers; the only *registry* change is the two `*_config` entries → one `device_config`.
+
+## 9. External-system assumptions (verified in this session)
+
+| Assumption | Verified? | Evidence |
+|---|---|---|
+| Symbol pins expose `.number` and `.name` so card pins can be validated | **Yes** | `get_symbol_cache().get_symbol(lib).pins[i].number/.name` — `Conn_01x05` → `("1","Pin_1")…`; `MCP23017` → `("1","GPB0")…` |
+| A role may map to a pin NUMBER (header `"4"`) or NAME (`"SDA"`); validator must accept both | **Yes** | `generate._name_or_number` already does exactly this; validator reuses it |
+| Pin-existence validation cannot run in the no-KiCad unit matrix | **Yes** | the 1465-test matrix runs with no KiCad install; symbol cache can't resolve there → §6.2 lives in the integration tier |
+| One strap schema reproduces both existing functions | **Yes (by construction)** | MCP = `pin_bits:[A0,A1,A2], base:0x20`; MPU = `pin_bits:[AD0], base:0x68`; same `offset` math + range check |
+| Bare-IC symbols (e.g. `Sensor_Motion:MPU-6050`) often have many NC/support pins | **Yes** | MPU-6050 symbol = 24 pins (CLKIN, NC×4, AUX_DA…); reinforces that `module: true` header representation is a per-card choice the schema must support |
+
+## 10. What stays code (and why that's fine)
+
+The cross-cutting D logic — `_name_or_number`, `gpio_to_pin_number`/IO{n} mapping, `select_active_branches` preprocessor, `_build_buses` typed-bus grouping, the role-token classifier. These are *algorithms*, not tables, and they're **converging**: the set of board shapes that need a *new* one is shrinking each phase. Data-driving the tables is what removes the recurring effort; the algorithm surface doesn't need externalizing.
+
+## 11. Phase 7 — card auto-draft (drive Floor-1 effort toward zero)
+
+Once cards are the unit, the residual is "no card exists yet for this part." Auto-drafting closes most of it. On an unknown peripheral, synthesize a **draft card** from signals already present:
+
+- **Symbol-pin-name match.** For well-named parts the firmware role token *is* the symbol pin name (`SDA`→`SDA`). Reuse the extracted `resolve_pin_token` (§14 Step 0) to score role→pin matches against the candidate symbol. High score → auto-draft; the mismatches that needed hand-authoring before (MCP23017 `SCL`→`SCK`, HX711 `PD_SCK`, numbered module headers) score low → flagged for confirm.
+- **I2C address → identity table** (pure data): `0x68/0x69`→MPU-6xxx/ICM, `0x3C/0x3D`→SSD1306, `0x76/0x77`→BME280, `0x40`→INA219, `0x48`→ADS1115… The address space is a strong identity signal currently ignored. (track-geometry even carries a commented `// #define INA219_ADDR 0x40`.)
+- **Identity hints already parsed and dropped:** `*_WHO_AM_I_EXPECTED` sits in `provenance.unparsed` today — a free confirmation signal.
+
+**Confidence-tiered output, never a silent guess:** `draft` (auto, unconfirmed) < `confirmed` (human/agent approved) < `verified` (passed pin-existence + a golden-harness route). An unconfirmed draft is *offered as a resolved-pending gap*, not silently placed. **Confirm-once, reuse-forever:** a confirmed card is committed and never re-drafted — so per-design effort amortizes to zero as the card library saturates the user's recurring parts vocabulary.
+
+**"Clean bus" — a strict definition (cold-review).** Name-existence is not function-correctness: a symbol can have a pin literally named `SCL` that isn't an I2C clock, and `resolve_pin_token` would still resolve it. So `draft` confidence is **high only when ALL of**: (a) the firmware bus roles (e.g. SDA+SCL) resolve to symbol pins; (b) **every** remaining symbol I/O pin is *either* a recognized role token *or* in the supply/ground sets — i.e. nothing unexplained; (c) the symbol is single-unit (`pin_number_by_name` is ambiguous on multi-unit parts — a Phase-8 bulk-gen hazard, flagged not auto-shipped). Anything failing (a)–(c) → `draft-low` → surfaced for confirm, never auto-placed. For numbered-pin module headers there are no names to match, so auto-draft yields *no* output (safe), and they stay in the small hand-card set.
+
+## 12. Phase 8 — generalize beyond one user (local-first, NO phone-home)
+
+Phases 6–7 make *my* boards approach zero because my parts vocabulary is finite and saturates. A different user's vocabulary differs but is *also* finite and recurring. The naive way to share the saturating assets is a runtime registry — **rejected.** A large slice of this audience (privacy-conscious makers, industrial/defense, self-hosters — and the project's own local-first/AI-first ethos) will not run anything that "sends" at runtime; even a part-number lookup leaks what you're building. **Hard constraint: the tool MUST be fully functional air-gapped. No telemetry, no runtime network, no phone-home — ever, by default.**
+
+This is not a real cost, because the *dominant* amortization terms are already local:
+
+- **Single-user reuse** (your boards reuse your own confirmed cards) — the biggest term, 100% on-machine.
+- **A bundled card library** shipped *with* the tool — exactly the KiCad symbol/footprint-library model (also PlatformIO platforms, Arduino board packages). It covers the common parts on install; it's curated in the open-source repo and delivered by ordinary `git pull` / package update / re-running AGENT-INSTALL. **Contribution is out-of-band** (a maintainer merges a PR); the user's runtime never reaches out. People who *want* to share do so via normal OSS; everyone else just consumes the curated set on update.
+
+The only term that needed a service — a stranger's confirmation reaching you *automatically at runtime* — is the *smallest*, and is replaced by "it's in the next bundled-library update, if a maintainer curated it." Nobody is bothered by that; it is how KiCad libraries already work.
+
+Three asset types, all local, all versioned-in-repo, none requiring a runtime connection:
+
+1. **Device cards (parts) — a bundled, repo-curated library.** Cards ship with the tool and are discoverable offline by part / lib_id / I2C address / fuzzy name against the *local* set. The library maintains the one layer no existing source provides — the firmware-role → symbol-pin semantic map. Verification tiers + CI-gating apply at the **repo/PR** level (a maintainer's CI runs structural + pin-existence + golden route before merge), not at any user's runtime. **Sharing is file-copy, opt-in:** a card is a YAML file; drop it in a dir read via `KICAD_MCP_DEVICE_DIRS`, commit it to your own repo, paste it in a forum. Never automatic.
+
+   **Populating it — maintainer-time pre-fetch (so PRs reduce to "new or weird").** The bundled library is not seeded by hand one part at a time; it is *bulk-generated at build/curation time* (network + compute are fine for the maintainer — only the *user* must be air-gapped). The richest source is already on disk: the **KiCad symbol libraries** (thousands of symbols, each with named pins). A build-time job:
+   - **Enumerates** symbols filtered to device categories (`Sensor_*`, `Interface_Expansion`, `Display_*`, `Driver_*`, `Analog_ADC`, …) with a **clean bus signature** (pins naming SDA/SCL, MOSI/MISO, BCLK/LRCK) — *sensible*, not exhaustive (skip the passive/connector bulk).
+   - **Auto-drafts** a card per symbol via the Phase-7 logic (role→pin is identity wherever names match — the well-named majority), and **crosses it with the bundled I2C-address→part table** so address-only firmware declarations (`BME280_ADDR 0x76`) resolve to a pre-carded part with no PR.
+   - **Gates hard:** only the **high-confidence tier** (clean bus + identity name match, passes pin-existence, sample golden-route) auto-ships; medium/low are queued for human review. Mass generation without this gate ships subtly-wrong cards at scale.
+
+   This flips the model from "ship empty, PR as you go" to **"ship the auto-derivable universe, PR only the residual."** The residual that still needs a human is exactly the *interesting* set: **name-mismatched pins** (MCP23017 `SCL`→`SCK`, HX711 `PD_SCK` — flagged, not auto-shipped wrong), **numbered-pin module headers** (GY-521, OLED — no names to match; small finite hand-set), **parts with no KiCad symbol**, and **novel topologies** (a template, not a card). A fully-local, no-telemetry complement: the tool keeps a *local* "parts I hit that weren't carded" log — the user's own prioritized PR list; the maintainer prioritizes the pre-fetch from symbol-lib + popular-parts priors instead.
+
+2. **Firmware readers (ecosystems) — a pluggable front.** The `config.h` `#define` scanner encodes one ecosystem's dialect. STM32/CubeMX `.ioc`, Zephyr devicetree, Arduino `variant`, nRF SDK config are different inputs — and **richer ones**: a devicetree literally declares bus topology + device nodes, i.e. most of the DesignIntent already. The `#define` scan is the *worst-case* (least-structured) input; everything else is downhill. DesignIntent is already "the canonical editable seam," so this is purely *additive*: a reader plugin produces the intent's raw inputs (pins/addresses/buses/MCU); intent/templates/generate/cards downstream stay ecosystem-agnostic. All local.
+
+3. **MCU pin-naming scheme as card data.** `mcu_pinmap`'s `IO{n}` mapping is ESP32-specific; STM32 is `PA0`/`PB3`, nRF is `P0.04`. Make the firmware-GPIO → symbol-pin scheme a field on the MCU card, consumed by a generic mapper — so a new MCU family is a card + (occasionally) a scheme, not a code edit.
+
+**Auto-draft (§11) is already offline by construction** — local KiCad symbol-name matching + the *bundled* I2C-address table + `WHO_AM_I` hints from the firmware you already have. A user with zero internet and zero community coverage is still unblocked. Any network feature (e.g. an *optional* LCSC draft) must be **opt-in, explicitly flagged, and never a silent fallback**; the offline path is the complete default.
+
+**End state — effort ∝ *global* novelty, with zero runtime sharing:** the first user to hit a new part cards it (offline auto-draft); if they choose, they PR it to the bundled library and the next *release* carries it. New ecosystem → a reader plugin; new topology → a template plugin. Everyone inherits via ordinary updates, never via a live service. The honest-by-construction gap manifest matters *more* for strangers, not less: a non-you user can't be assumed to know the tool guessed, so unconfirmed drafts always surface as flagged, never silently placed.
+
+**Honest cost:** the bundled library still needs curation + maintainer-side CI (validate submitted cards before they ship). That is real but ordinary open-source maintenance — *not* a hosted service, *not* user-facing infrastructure, and it preserves the air-gapped guarantee.
+
+## 13. Test plan
+
+- **Unit (no KiCad):** `tests/test_device_cards.py` — schema validation, strap-math boundaries per card, duplicate-type detection, loader precedence, resolution parity (`resolve_peripheral`/`resolve_mcu` return the same dicts the literals did — a frozen snapshot of the 6 entries).
+- **Integration (KiCad):** `tests/integration/test_device_cards.py` — every card's pins exist on its symbol. Plus the 3 existing golden shapes unchanged.
+- **Equivalence gate:** full suite + 3 integration shapes green with zero assertion edits (except the 2 Phase-5 strap-fn imports → generic helper).
+- **Auto-draft (Phase 7):** address-table identity boundaries, role→pin match scoring (a known mismatch like MCP `SCL`→`SCK` must score *low* → flagged, never auto-placed), and that an unconfirmed draft surfaces as a pending gap rather than a placed part.
+
+## 14. Sequencing & effort (pairing units)
+
+0. **Precondition (cold-review):** extract `generate._name_or_number` (currently a nested closure inside `generate_schematic`) to a module-level `mcu_pinmap.resolve_pin_token(sym, token) -> Optional[str]`; update `generate.py` to call it. Both the §6.2 validator and the §11/§12 auto-draft *reuse* this — a closure can't be imported, so this must land first. Behavior-preserving; pin it with a unit test. **~20 min.**
+1. Card schema + loader + **structural validator** + migrate 6 entries + resolution-parity test — **~1 day**.
+2. `compute_address_straps` + generic `device_config` template, retire the two `*_config` — **~half a day**.
+3. Integration pin-existence validator — **~half a day**.
+4. (6b) `board.yaml` sidecar — **~half a day**, separable.
+5. (Phase 7) card auto-draft: address table + role→pin scoring + draft/confirm tiers — **~1–2 days**.
+6. (Phase 8) bundled, repo-curated card library + reader-plugin interface + MCU pin-scheme cards — **local-first, no runtime network**. The library is ordinary OSS curation + maintainer-side CI (validate cards before they ship), the KiCad-library model — *not* a hosted service. Reader plugins and MCU-scheme cards are additive code/data. Scope separately from the refactor.
+
+Steps 1–3 are a behavior-preserving refactor gated by the golden harness — low risk, high recurring payoff. 6b/7 add new behavior, shipped separately. Phase 8 generalizes across users **without any phone-home** — the tool stays fully functional air-gapped; sharing is bundled-library updates + opt-in file-copy, never a runtime connection.
+
+## 15. Open questions
+
+- Card format: YAML (consistent with intent docs) vs TOML. **Recommend YAML** — the project already uses it for intent.
+- Do we keep `PeripheralInfo`/`McuInfo` TypedDicts as the in-memory type (recommended, zero blast radius) or introduce a dataclass? Recommend TypedDict for this phase.
+- Override-dir precedence for a *project* that wants to pin a different footprint — confirm the `KICAD_MCP_DEVICE_DIRS` env name vs reusing an existing search-path mechanism.

--- a/src/kicad_mcp/tools/design.py
+++ b/src/kicad_mcp/tools/design.py
@@ -18,6 +18,10 @@ Operations:
       Materialize MCU + recognized peripherals + signal nets into a .kicad_sch.
   show_intent(intent_path) -> {status, summary, gaps}
       Validate + summarize an intent doc (facts vs gaps).
+  suggest_cards(firmware_path) -> {status, drafts, count}
+      Offline auto-draft: propose device cards for the firmware's UNCARDED
+      peripherals (I2C-address identity + WHO_AM_I hints + local symbol-name
+      matching). Drafts are returned for review — never placed, no network used.
 """
 from __future__ import annotations
 
@@ -26,14 +30,17 @@ from typing import Any, Optional
 
 from fastmcp import FastMCP
 
+from kicad_mcp.utils.firmware.autodraft import draft_card, extract_whoami
 from kicad_mcp.utils.firmware.generate import generate_schematic as _generate
 from kicad_mcp.utils.firmware.intent import (
     DesignIntent,
     build_intent,
+    candidate_devices,
     find_board_id,
     load_intent,
     save_intent,
 )
+from kicad_mcp.utils.firmware.knowledge import resolve_peripheral
 from kicad_mcp.utils.firmware.parse import (
     idf_target_defines,
     parse_defines,
@@ -98,10 +105,13 @@ def register_design_tools(mcp: FastMCP) -> None:
             return _op_generate(intent_path=intent_path, schematic_path=schematic_path)
         if operation == "show_intent":
             return _op_show(intent_path=intent_path)
+        if operation == "suggest_cards":
+            return _op_suggest_cards(firmware_path=firmware_path)
         return {
             "status": "error", "code": "unknown_operation",
             "message": (f"Unknown operation: {operation!r}. Valid: import_firmware, "
-                        "expand_templates, generate_schematic, show_intent."),
+                        "expand_templates, generate_schematic, show_intent, "
+                        "suggest_cards."),
         }
 
 
@@ -168,6 +178,46 @@ def _op_generate(*, intent_path: Optional[str], schematic_path: Optional[str]) -
                 "message": f"Intent doc not found: {intent_path}"}
     intent = load_intent(intent_path)
     return _generate(intent, schematic_path)
+
+
+def _op_suggest_cards(*, firmware_path: Optional[str]) -> dict:
+    """Offline auto-draft: propose device cards for the firmware's UNCARDED
+    peripherals (Phase 7). Drafts are returned for review — nothing is placed,
+    no network is used. Symbol-based high-confidence drafting happens once a
+    lib_id is supplied/confirmed; an address-only device gets a flagged skeleton."""
+    if not firmware_path:
+        return {"status": "error", "code": "missing_parameter",
+                "message": "firmware_path is required."}
+    cfg = _find_config_header(firmware_path)
+    if cfg is None:
+        return {"status": "error", "code": "config_not_found",
+                "message": f"No config.h found at or under {firmware_path!r}."}
+    board = find_board_id(str(cfg))
+    text = select_active_branches(cfg.read_text(errors="replace"),
+                                  idf_target_defines(board))
+    parsed = partition(parse_defines(text))
+    intent = build_intent(parsed, firmware_path=str(cfg), board_id=board)
+    whoami = extract_whoami(intent.provenance)
+
+    drafts: list[dict] = []
+    for t, address in candidate_devices(parsed):
+        if resolve_peripheral(t) is not None:
+            continue  # already carded -> placed by import, nothing to draft
+        bus = "I2C" if address is not None else None
+        roles = {"SDA": "SDA", "SCL": "SCL"} if bus == "I2C" else {}
+        d = draft_card(type_name=t, address=address, bus=bus, roles=roles,
+                       whoami=whoami)
+        if d is not None:
+            drafts.append({"confidence": d.confidence, "reasons": d.reasons,
+                           "card": d.card})
+    return {
+        "status": "ok",
+        "drafts": drafts,
+        "count": len(drafts),
+        "note": ("Drafts are proposals — review/confirm lib_id, footprint, roles, "
+                 "supply/ground pins, then drop the card in a devices dir "
+                 "(KICAD_MCP_DEVICE_DIRS) and re-run import_firmware."),
+    }
 
 
 def _op_show(*, intent_path: Optional[str]) -> dict:

--- a/src/kicad_mcp/utils/firmware/autodraft.py
+++ b/src/kicad_mcp/utils/firmware/autodraft.py
@@ -1,0 +1,189 @@
+"""Offline card auto-draft (Phase 7) — propose a device card for an unrecognized
+peripheral from signals ALREADY on the user's machine, with **no network, ever**:
+
+  * the bundled I2C-address → identity table (pure data),
+  * `*_WHO_AM_I_EXPECTED` hints already parsed into the intent's provenance,
+  * symbol-pin-name matching against the *locally installed* KiCad symbol
+    (role token == pin name → identity), reusing ``resolve_pin_token``.
+
+Honest-by-construction: a draft is **offered for review**, never silently placed.
+Confidence is conservative — `high` requires two independent signals agreeing
+(the address-identity AND a clean name-identity role match on a single-unit
+symbol); anything weaker is `low` and flagged. The cold-review false-confidence
+hazard (a pin *named* SCL that isn't an I2C clock) is mitigated by requiring
+address↔symbol corroboration, not name-existence alone.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from kicad_mcp.utils.firmware.mcu_pinmap import resolve_pin_token
+
+# --- bundled I2C address → canonical device type (curated, offline data) ------
+# The address space is a strong identity signal. A range/list per type; the most
+# common maker-firmware I2C parts. Extend by data, not code.
+ADDRESS_IDENTITY: dict[int, str] = {
+    0x68: "MPU6050", 0x69: "MPU6050",          # MPU-6xxx / ICM IMUs
+    0x3C: "OLED", 0x3D: "OLED",                # SSD1306/SSD1315 OLED
+    0x76: "BME280", 0x77: "BME280",            # BME/BMP280 env sensors
+    0x40: "INA219",                            # current/power monitor
+    0x48: "ADS1115",                           # 4-ch ADC
+    0x20: "MCP23017", 0x27: "MCP23017",        # GPIO expander (strap range 0x20-0x27)
+    0x29: "VL53L0X",                           # ToF distance
+    0x23: "BH1750",                            # ambient light
+}
+
+# Supply/ground pin-name signatures, so "explain every pin" can classify a
+# symbol's non-signal pins (used by the clean-bus gate).
+_SUPPLY_RE = re.compile(r"^(VDD|VCC|VBAT|VIN|3V3|V_?\{?DD\}?|AVDD|DVDD|VLOGIC)$", re.I)
+_GROUND_RE = re.compile(r"^(GND|VSS|AGND|DGND|V_?\{?SS\}?|EP)$", re.I)
+_WHOAMI_RE = re.compile(r"^(?P<type>[A-Z0-9]+?)_WHO_?AM_?I(_EXPECTED)?$")
+
+
+@dataclass
+class DraftCard:
+    """A proposed card + provenance. ``confidence`` is 'high' | 'low'. Never
+    auto-placed — the caller surfaces it for confirm."""
+    card: dict[str, Any]
+    confidence: str
+    reasons: list[str] = field(default_factory=list)
+
+
+def identify_by_address(address: Optional[int]) -> Optional[str]:
+    """Return the likely canonical device type for an I2C address, or None."""
+    if address is None:
+        return None
+    return ADDRESS_IDENTITY.get(address)
+
+
+def extract_whoami(provenance: dict[str, Any]) -> dict[str, int]:
+    """Pull ``<TYPE>_WHO_AM_I_EXPECTED`` (a free identity confirmation) out of the
+    intent's provenance ``unparsed`` macros. Returns ``{TYPE: expected_int}``."""
+    out: dict[str, int] = {}
+    for m in provenance.get("unparsed", []) or []:
+        mm = _WHOAMI_RE.match(str(m.get("name", "")))
+        if not mm:
+            continue
+        raw = str(m.get("value", "")).strip().rstrip("uUlL")
+        try:
+            out[mm.group("type")] = int(raw, 0)
+        except ValueError:
+            continue
+    return out
+
+
+def _symbol_pin_names(symbol: Any) -> list[str]:
+    return [str(getattr(p, "name", "") or "") for p in (getattr(symbol, "pins", None) or ())]
+
+
+def _symbol_unit_count(symbol: Any) -> int:
+    """Best-effort unit count; >1 means multi-unit (ambiguous pin lookup)."""
+    return int(getattr(symbol, "unit_count", 1) or 1)
+
+
+def score_roles(symbol: Any, roles: dict[str, str]) -> tuple[dict[str, str], list[str]]:
+    """Resolve each firmware role to a symbol pin NUMBER by NAME identity. Returns
+    ``(resolved_role->pin, unresolved_roles)``. Identity only: a role resolves
+    iff a pin is *named* exactly like the role (so module-header numbered pins do
+    NOT auto-resolve — they stay a hand-card, which is safe)."""
+    resolved: dict[str, str] = {}
+    unresolved: list[str] = []
+    names = set(_symbol_pin_names(symbol))
+    for role in roles:
+        if role in names:
+            num = resolve_pin_token(symbol, role)
+            if num is not None:
+                resolved[role] = role          # role == pin NAME (identity)
+                continue
+        unresolved.append(role)
+    return resolved, unresolved
+
+
+def _unexplained_pins(symbol: Any, resolved_roles: dict[str, str]) -> list[str]:
+    """Symbol I/O pins that are neither a matched role nor a supply/ground/NC pin
+    — i.e. nothing the draft can account for. A non-empty list weakens confidence
+    (the symbol does more than the firmware bus, so identity is uncertain)."""
+    out: list[str] = []
+    for nm in _symbol_pin_names(symbol):
+        if not nm or nm in resolved_roles:
+            continue
+        if _SUPPLY_RE.match(nm) or _GROUND_RE.match(nm) or nm.upper() in ("NC", "~"):
+            continue
+        out.append(nm)
+    return out
+
+
+def draft_card(
+    *,
+    type_name: str,
+    address: Optional[int],
+    bus: Optional[str],
+    roles: dict[str, str],
+    symbol: Any = None,
+    footprint: Optional[str] = None,
+    lib_id: Optional[str] = None,
+    whoami: Optional[dict[str, int]] = None,
+) -> Optional[DraftCard]:
+    """Synthesize a draft card for ``type_name``.
+
+    ``roles`` are the firmware bus roles seen for this device (e.g. {SDA, SCL}).
+    ``symbol`` (if provided — needs locally-installed KiCad) lets us name-match
+    roles to pins and classify the rest. Returns None if we can't even propose a
+    skeleton. Confidence is **high** only when the address-identity corroborates
+    the type AND every role name-matches a pin on a single-unit symbol with no
+    unexplained signal pins; otherwise **low** (flagged for review).
+    """
+    reasons: list[str] = []
+    addr_type = identify_by_address(address)
+    if addr_type:
+        reasons.append(f"I2C address {hex(address or 0)} → likely {addr_type}")
+    if whoami and type_name in whoami:
+        reasons.append(f"WHO_AM_I expects {hex(whoami[type_name])}")
+
+    role_map: dict[str, str] = dict(roles)
+    confidence = "low"
+
+    if symbol is not None and lib_id:
+        resolved, unresolved = score_roles(symbol, roles)
+        unexplained = _unexplained_pins(symbol, resolved)
+        multiunit = _symbol_unit_count(symbol) > 1
+        corroborated = addr_type is not None and addr_type.upper() == type_name.upper()
+        if resolved:
+            role_map = resolved
+        if (not unresolved and corroborated and not multiunit
+                and not unexplained and resolved):
+            confidence = "high"
+            reasons.append("all roles name-match a single-unit symbol; address corroborates")
+        else:
+            why = []
+            if unresolved:
+                why.append(f"roles without a name-matched pin: {unresolved}")
+            if not corroborated:
+                why.append("address does not corroborate the type")
+            if multiunit:
+                why.append("multi-unit symbol (ambiguous pins)")
+            if unexplained:
+                why.append(f"unexplained symbol pins: {unexplained[:8]}")
+            reasons.append("flagged: " + "; ".join(why))
+    else:
+        reasons.append("flagged: no local symbol available — skeleton only, "
+                       "confirm lib_id/footprint/roles before use")
+
+    if not role_map and not addr_type:
+        return None
+
+    card: dict[str, Any] = {
+        "type": type_name.upper(),
+        "lib_id": lib_id or "TODO:confirm",
+        "value": type_name,
+        "bus": bus,
+        "footprint": footprint or "TODO:confirm",
+        "roles": role_map,
+        "supply_pins": [],     # confirm against the symbol/datasheet
+        "ground_pins": [],
+        "module": False,
+        "_draft": {"confidence": confidence, "reasons": reasons},
+    }
+    return DraftCard(card=card, confidence=confidence, reasons=reasons)

--- a/src/kicad_mcp/utils/firmware/cards.py
+++ b/src/kicad_mcp/utils/firmware/cards.py
@@ -1,0 +1,208 @@
+"""Device-card loader, validator, and strap math — the data layer behind
+``knowledge.py`` (CLAUDE.md Rule 3: one source of truth for device facts).
+
+A *card* is a YAML file describing one MCU or peripheral: its symbol/footprint,
+firmware-role → symbol-pin map, supply/ground pins, and optional ``config``
+(address straps + static ties). Cards replace the hand-edited Python tables that
+used to live in ``knowledge.py`` — a new recognized device becomes a data file,
+not a code edit.
+
+This module is **pure data plumbing**: it imports nothing from ``knowledge.py``
+(avoids an import cycle) and returns plain dicts. ``knowledge.py`` casts those to
+its ``PeripheralInfo`` / ``McuInfo`` TypedDicts and exposes ``resolve_*``.
+
+Two validation tiers (the honesty backstop):
+  * **structural** — here, no KiCad needed: required fields, types, strap math.
+    Runs in the no-KiCad unit matrix.
+  * **pin-existence** — in the integration tier (needs the symbol cache); see
+    ``tests/integration/test_device_cards.py``.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+# Packaged seed library shipped with the tool (the KiCad-library model — no
+# runtime network, ever). Override/extend via KICAD_MCP_DEVICE_DIRS or a
+# project-local ./firmware-devices/ dir.
+_PACKAGED_DIR = Path(__file__).parent / "devices"
+_ENV_DIRS_VAR = "KICAD_MCP_DEVICE_DIRS"
+_PROJECT_DIR = Path("firmware-devices")
+
+_BUSES = frozenset({"I2C", "SPI", "I2S", "UART", None})
+_RAILS = frozenset({"+3V3", "+5V", "GND", "VBUS", "VCC"})
+
+
+class CardError(ValueError):
+    """A malformed card. Raised loudly at load — never silently skipped."""
+
+
+# --- strap math: single source of truth (replaces the two hand functions) ----
+
+def compute_address_straps(
+    strap: dict[str, Any], address: int
+) -> Optional[list[tuple[str, str]]]:
+    """Map an I2C address to ``[(pin, rail)]`` for an address-strap spec, or None
+    if the address is outside the strappable range.
+
+    ``strap`` = ``{pin_bits: [pin, …], base: int, rail_set, rail_clear}``. Bit
+    *i* (LSB-first) ties ``pin_bits[i]`` to ``rail_set`` when set, ``rail_clear``
+    when clear. ``offset = address - base`` must be in ``[0, 2**N - 1]``.
+
+    Reproduces both legacy functions exactly: MCP23017 (3 bits, base 0x20) and
+    MPU-6050 AD0 (1 bit, base 0x68). Boundary-tested.
+    """
+    pins = strap["pin_bits"]
+    base = strap["base"]
+    rail_set = strap.get("rail_set", "+3V3")
+    rail_clear = strap.get("rail_clear", "GND")
+    offset = address - base
+    if offset < 0 or offset > (1 << len(pins)) - 1:
+        return None
+    return [
+        (pin, rail_set if (offset >> i) & 1 else rail_clear)
+        for i, pin in enumerate(pins)
+    ]
+
+
+# --- structural validation (no KiCad) ----------------------------------------
+
+_PERIPHERAL_REQUIRED = ("type", "lib_id", "value", "footprint", "roles",
+                        "supply_pins", "ground_pins", "module")
+_MCU_REQUIRED = ("part", "lib_id", "value", "footprint", "board_match",
+                 "needs_3v3", "supply_pin", "ground_pin", "en_pin", "boot_pin",
+                 "uart_rx_pin", "uart_tx_pin", "native_usb")
+
+
+def _validate_lib_id(val: Any, where: str, errs: list[str]) -> None:
+    if not isinstance(val, str) or ":" not in val:
+        errs.append(f"{where}: lib_id {val!r} must be 'Library:Symbol'")
+
+
+def _validate_address_strap(strap: Any, where: str, errs: list[str]) -> None:
+    if not isinstance(strap, dict):
+        errs.append(f"{where}: address_strap must be a mapping")
+        return
+    pins = strap.get("pin_bits")
+    if not isinstance(pins, list) or not pins or not all(isinstance(p, str) for p in pins):
+        errs.append(f"{where}: address_strap.pin_bits must be a non-empty list of pin strings")
+    if not isinstance(strap.get("base"), int):
+        errs.append(f"{where}: address_strap.base must be an int")
+    for k in ("rail_set", "rail_clear"):
+        if k in strap and strap[k] not in _RAILS:
+            errs.append(f"{where}: address_strap.{k}={strap[k]!r} not a known rail {sorted(r for r in _RAILS)}")
+
+
+def _validate_config(cfg: Any, where: str, errs: list[str]) -> None:
+    if cfg is None:
+        return
+    if not isinstance(cfg, dict):
+        errs.append(f"{where}: config must be a mapping")
+        return
+    if "address_strap" in cfg:
+        _validate_address_strap(cfg["address_strap"], where, errs)
+    for tie in cfg.get("static_ties", []) or []:
+        if not (isinstance(tie, dict) and isinstance(tie.get("pin"), str)
+                and tie.get("rail") in _RAILS):
+            errs.append(f"{where}: static_ties entry {tie!r} needs pin:str + rail in {sorted(r for r in _RAILS)}")
+
+
+def validate_peripheral_card(card: dict[str, Any]) -> list[str]:
+    """Return a list of structural errors for a peripheral card (empty = ok)."""
+    where = f"peripheral card {card.get('type', '?')!r}"
+    errs: list[str] = []
+    for f in _PERIPHERAL_REQUIRED:
+        if f not in card:
+            errs.append(f"{where}: missing required field {f!r}")
+    if errs:
+        return errs
+    _validate_lib_id(card["lib_id"], where, errs)
+    if card["bus"] not in _BUSES:
+        errs.append(f"{where}: bus {card['bus']!r} not in {sorted(str(b) for b in _BUSES)}")
+    if not isinstance(card["roles"], dict):
+        errs.append(f"{where}: roles must be a mapping role->pin")
+    if not isinstance(card["module"], bool):
+        errs.append(f"{where}: module must be a bool")
+    _validate_config(card.get("config"), where, errs)
+    return errs
+
+
+def validate_mcu_card(card: dict[str, Any]) -> list[str]:
+    """Return a list of structural errors for an MCU card (empty = ok)."""
+    where = f"mcu card {card.get('part', '?')!r}"
+    errs: list[str] = []
+    for f in _MCU_REQUIRED:
+        if f not in card:
+            errs.append(f"{where}: missing required field {f!r}")
+    if errs:
+        return errs
+    _validate_lib_id(card["lib_id"], where, errs)
+    bm = card["board_match"]
+    if not isinstance(bm, list) or not bm or not all(isinstance(s, str) for s in bm):
+        errs.append(f"{where}: board_match must be a non-empty list of strings")
+    if not isinstance(card["native_usb"], bool) or not isinstance(card["needs_3v3"], bool):
+        errs.append(f"{where}: needs_3v3 and native_usb must be bools")
+    return errs
+
+
+# --- discovery + load --------------------------------------------------------
+
+def _card_dirs(extra_dirs: Optional[list[str]] = None) -> list[Path]:
+    """Discovery order (later overrides earlier on key collision): packaged seed,
+    then $KICAD_MCP_DEVICE_DIRS, then project-local ./firmware-devices, then any
+    explicit extra_dirs (used by tests)."""
+    dirs: list[Path] = [_PACKAGED_DIR]
+    env = os.environ.get(_ENV_DIRS_VAR, "")
+    dirs += [Path(p) for p in env.split(os.pathsep) if p.strip()]
+    if _PROJECT_DIR.is_dir():
+        dirs.append(_PROJECT_DIR)
+    dirs += [Path(p) for p in (extra_dirs or [])]
+    return dirs
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    try:
+        data = yaml.safe_load(path.read_text())
+    except yaml.YAMLError as e:
+        raise CardError(f"card {path} is not valid YAML: {e}") from e
+    if not isinstance(data, dict):
+        raise CardError(f"card {path} must contain a single YAML mapping")
+    return data
+
+
+def load_cards(
+    extra_dirs: Optional[list[str]] = None,
+) -> tuple[dict[str, dict[str, Any]], list[dict[str, Any]]]:
+    """Discover, parse, and structurally-validate every card.
+
+    Returns ``(peripherals_by_type_upper, mcus)``. A malformed card raises
+    ``CardError`` (loud — never silently dropped; data-capture rule). Later dirs
+    override earlier on a colliding ``type`` / ``part`` key, enabling project
+    pins without editing the packaged set.
+    """
+    peripherals: dict[str, dict[str, Any]] = {}
+    mcus_by_part: dict[str, dict[str, Any]] = {}
+    for d in _card_dirs(extra_dirs):
+        if not d.is_dir():
+            continue
+        for path in sorted(d.rglob("*.yaml")) + sorted(d.rglob("*.yml")):
+            card = _load_yaml(path)
+            if "part" in card and "board_match" in card:
+                errs = validate_mcu_card(card)
+                if errs:
+                    raise CardError(f"{path}:\n  " + "\n  ".join(errs))
+                mcus_by_part[card["part"]] = card
+            elif "type" in card:
+                errs = validate_peripheral_card(card)
+                if errs:
+                    raise CardError(f"{path}:\n  " + "\n  ".join(errs))
+                peripherals[str(card["type"]).strip().upper()] = card
+            else:
+                raise CardError(
+                    f"card {path} is neither a peripheral (needs 'type') nor an "
+                    f"MCU (needs 'part'+'board_match')"
+                )
+    return peripherals, list(mcus_by_part.values())

--- a/src/kicad_mcp/utils/firmware/devices/mcus/esp32-s3-wroom-1.yaml
+++ b/src/kicad_mcp/utils/firmware/devices/mcus/esp32-s3-wroom-1.yaml
@@ -1,0 +1,16 @@
+# ESP32-S3-WROOM-1. The KiCad symbol names GPIOs as IO{n} (same convention as
+# WROOM-32), so the IO{n} mapper works; UART0 pins are named RXD0/TXD0.
+# board_match carries ALL S3 board-id variants (omitting any is a regression).
+part: ESP32-S3-WROOM-1
+lib_id: RF_Module:ESP32-S3-WROOM-1
+value: ESP32-S3-WROOM-1
+footprint: RF_Module:ESP32-S3-WROOM-1
+board_match: ["esp32-s3-devkitc-1", "esp32-s3", "esp32s3"]
+needs_3v3: true
+supply_pin: 3V3
+ground_pin: GND
+en_pin: EN
+boot_pin: IO0
+uart_rx_pin: RXD0
+uart_tx_pin: TXD0
+native_usb: true       # S3 has native USB — no CP2102 bridge

--- a/src/kicad_mcp/utils/firmware/devices/mcus/esp32-wroom-32e.yaml
+++ b/src/kicad_mcp/utils/firmware/devices/mcus/esp32-wroom-32e.yaml
@@ -1,0 +1,15 @@
+# ESP32-WROOM-32E. GND is the symbol's MERGED pin (physical pads 1/15/38/39
+# collapsed) — resolve it by NAME, never by number.
+part: ESP32-WROOM-32E
+lib_id: RF_Module:ESP32-WROOM-32E
+value: ESP32-WROOM-32E
+footprint: RF_Module:ESP32-WROOM-32E
+board_match: ["esp32dev", "esp32"]   # board-id substrings (longest match wins)
+needs_3v3: true
+supply_pin: VDD
+ground_pin: GND
+en_pin: EN
+boot_pin: IO0
+uart_rx_pin: RXD0/IO3
+uart_tx_pin: TXD0/IO1
+native_usb: false      # WROOM-32 needs a CP2102 USB-UART bridge

--- a/src/kicad_mcp/utils/firmware/devices/peripherals/hx711.yaml
+++ b/src/kicad_mcp/utils/firmware/devices/peripherals/hx711.yaml
@@ -1,0 +1,11 @@
+# HX711 24-bit load-cell ADC (chip-down SOIC). Clock pin is named "PD_SCK".
+# No separate DGND — analog + digital ground share AGND.
+type: HX711
+lib_id: Analog_ADC:HX711
+value: HX711
+bus: null
+footprint: Package_SO:SOIC-16_3.9x9.9mm_P1.27mm
+roles: {DOUT: DOUT, SCK: PD_SCK, PD_SCK: PD_SCK}
+supply_pins: ["VSUP", "AVDD", "DVDD"]
+ground_pins: ["AGND"]
+module: false

--- a/src/kicad_mcp/utils/firmware/devices/peripherals/mcp23017.yaml
+++ b/src/kicad_mcp/utils/firmware/devices/peripherals/mcp23017.yaml
@@ -1,0 +1,20 @@
+# MCP23017 16-bit I2C GPIO expander (chip-down SOIC).
+# NB: the I2C clock pin is named "SCK" on this symbol, not "SCL".
+type: MCP23017
+lib_id: Interface_Expansion:MCP23017x-x-SO
+value: MCP23017
+bus: I2C
+footprint: Package_SO:SOIC-28W_7.5x17.9mm_P1.27mm
+roles: {SDA: SDA, SCL: SCK, INT: INTA, INTA: INTA}
+supply_pins: ["V_{DD}"]
+ground_pins: ["V_{SS}"]
+module: false
+config:
+  # A2 A1 A0 select 0x20..0x27 (LSB-first); RESET held high (active-low).
+  address_strap:
+    pin_bits: ["A0", "A1", "A2"]
+    base: 0x20
+    rail_set: "+3V3"
+    rail_clear: GND
+  static_ties:
+    - {pin: "~{RESET}", rail: "+3V3"}

--- a/src/kicad_mcp/utils/firmware/devices/peripherals/mpu6050.yaml
+++ b/src/kicad_mcp/utils/firmware/devices/peripherals/mpu6050.yaml
@@ -1,0 +1,19 @@
+# MPU-6050 6-axis IMU, modeled as its GY-521 breakout-MODULE header (we wire the
+# connection, not the bare QFN whose charge-pump/REGOUT support firmware can't
+# inform). Header pin convention: 1=GND 2=VCC 3=SCL 4=SDA 5=AD0.
+type: MPU6050
+lib_id: Connector_Generic:Conn_01x05
+value: GY-521 (MPU-6050)
+bus: I2C
+footprint: Connector_PinHeader_2.54mm:PinHeader_1x05_P2.54mm_Vertical
+roles: {SDA: "4", SCL: "3"}
+supply_pins: ["2"]
+ground_pins: ["1"]
+module: true
+config:
+  # A single AD0 pin selects the address LSB: low -> 0x68, high -> 0x69.
+  address_strap:
+    pin_bits: ["5"]
+    base: 0x68
+    rail_set: "+3V3"
+    rail_clear: GND

--- a/src/kicad_mcp/utils/firmware/devices/peripherals/oled.yaml
+++ b/src/kicad_mcp/utils/firmware/devices/peripherals/oled.yaml
@@ -1,0 +1,11 @@
+# I2C OLED module (SSD1306/SSD1315), modeled as its 4-pin breakout header.
+# Header pin convention: 1=GND 2=VCC 3=SCL 4=SDA. No strappable address pin.
+type: OLED
+lib_id: Connector_Generic:Conn_01x04
+value: OLED (SSD1306)
+bus: I2C
+footprint: Connector_PinHeader_2.54mm:PinHeader_1x04_P2.54mm_Vertical
+roles: {SDA: "4", SCL: "3"}
+supply_pins: ["2"]
+ground_pins: ["1"]
+module: true

--- a/src/kicad_mcp/utils/firmware/generate.py
+++ b/src/kicad_mcp/utils/firmware/generate.py
@@ -12,7 +12,10 @@ from typing import Any, Optional
 
 from kicad_mcp.utils.firmware.intent import DesignIntent
 from kicad_mcp.utils.firmware.knowledge import role_to_pin_name
-from kicad_mcp.utils.firmware.mcu_pinmap import gpio_to_pin_number, pin_number_by_name
+from kicad_mcp.utils.firmware.mcu_pinmap import (
+    gpio_to_pin_number,
+    resolve_pin_token,
+)
 
 _PITCH_MM = 63.5
 _COLS = 4
@@ -71,24 +74,12 @@ def generate_schematic(intent: DesignIntent, schematic_path: str) -> dict[str, A
 
     type_by_ref = {p.ref: p.type for p in intent.peripherals}
 
-    def _name_or_number(sym: Any, token: Any) -> Any:
-        """Resolve a pin token to its NUMBER. A token is either a pin NAME
-        (MCP23017 ``SDA``) or already a literal pin NUMBER (a header pin ``4``,
-        a USB-C/QFN pad ``A4``/``29``). Name lookup first; else validate the
-        token against the symbol's real numbers (alphanumeric, so not a digit
-        check)."""
-        num = pin_number_by_name(sym, token)
-        if num is not None:
-            return num
-        valid = {str(p.number) for p in (getattr(sym, "pins", None) or ())}
-        return str(token) if str(token) in valid else None
-
     def resolve_pin(ref: str, gpio: Any, role: Any, pin: Any) -> Any:
         sym = symbols.get(ref)
         if sym is None:
             return None
         if pin is not None:                        # direct pin NAME or number
-            return _name_or_number(sym, pin)
+            return resolve_pin_token(sym, pin)
         if gpio is not None:                       # MCU side
             return gpio_to_pin_number(sym, int(gpio))
         ptype = type_by_ref.get(ref)               # peripheral side
@@ -96,11 +87,11 @@ def generate_schematic(intent: DesignIntent, schematic_path: str) -> dict[str, A
         # NUMBER (a module-header device, ``SDA`` -> ``4``) — handle both.
         pin_name = role_to_pin_name(ptype, role) if ptype else None
         if pin_name is not None:
-            num = _name_or_number(sym, pin_name)
+            num = resolve_pin_token(sym, pin_name)
             if num is not None:
                 return num
         if role:                                   # last resort: role == pin name
-            return _name_or_number(sym, role)
+            return resolve_pin_token(sym, role)
         return None
 
     def wire_pin(comp: Any, pin_num: str, net_name: str) -> bool:

--- a/src/kicad_mcp/utils/firmware/intent.py
+++ b/src/kicad_mcp/utils/firmware/intent.py
@@ -187,6 +187,31 @@ def _build_buses(parsed: ParsedFirmware, known_types: set[str]) -> list[Bus]:
     return buses
 
 
+def candidate_devices(parsed: ParsedFirmware) -> list[tuple[str, Optional[int]]]:
+    """The devices a firmware references, as ``(type, address)`` pairs — the
+    single source of truth for "what's on this board" (consumed by ``build_intent``
+    to place known devices, and by auto-draft to propose cards for unknown ones).
+
+    Address-declared devices: ONE instance per ``*_ADDR`` macro (two MPU6050 at
+    0x68/0x69 are two chips). Pin-hint devices (named only by pin macros, no
+    address, e.g. HX711): one per type. Ordered by ``(type, address)`` so refs
+    are deterministic and stable; hint devices (no address) sort first per type.
+    """
+    addr_devices = [(_peripheral_type_from_addr(a.name), a.address or 0)
+                    for a in parsed.addresses]
+    addr_types = {t for t, _ in addr_devices}
+    hint_types = {
+        m.peripheral_hint for m in parsed.pins
+        if m.peripheral_hint and m.bus is None and m.peripheral_hint not in addr_types
+    }
+    out: list[tuple[str, Optional[int]]] = (
+        [(t, a) for t, a in addr_devices]
+        + [(t, None) for t in hint_types if t]
+    )
+    out.sort(key=lambda ta: (ta[0], -1 if ta[1] is None else ta[1]))
+    return out
+
+
 def build_intent(
     parsed: ParsedFirmware, *, firmware_path: str, board_id: Optional[str],
 ) -> DesignIntent:
@@ -204,27 +229,7 @@ def build_intent(
                                f"Could not resolve MCU from board id {board_id!r}."))
 
     # --- materialize peripherals we have a symbol for ---
-    # Address-declared devices: ONE instance per ``*_ADDR`` macro — two MPU6050
-    # at 0x68/0x69 are two chips on the shared bus, not one collapsed entry.
-    # Pin-hint devices (named only by pin macros, no address, e.g. HX711): one
-    # per type. Deterministic order: address devices by (type, address), then
-    # the remaining hint types.
-    addr_devices = [(_peripheral_type_from_addr(a.name), a.address or 0)
-                    for a in parsed.addresses]
-    addr_types = {t for t, _ in addr_devices}
-    hint_types = {
-        m.peripheral_hint for m in parsed.pins
-        if m.peripheral_hint and m.bus is None and m.peripheral_hint not in addr_types
-    }
-    # Combined, then ordered by (type, address) so refs are deterministic and
-    # stable: alphabetical by type, and within a type ascending by address (the
-    # two MPU6050 at 0x68/0x69 get consecutive refs). Hint devices (no address)
-    # sort first within their type.
-    to_place: list[tuple[str, Optional[int]]] = (
-        [(t, a) for t, a in addr_devices]
-        + [(t, None) for t in hint_types if t]
-    )
-    to_place.sort(key=lambda ta: (ta[0], -1 if ta[1] is None else ta[1]))
+    to_place = candidate_devices(parsed)
 
     peripherals: list[Peripheral] = []
     periph_by_type: dict[str, Peripheral] = {}

--- a/src/kicad_mcp/utils/firmware/knowledge.py
+++ b/src/kicad_mcp/utils/firmware/knowledge.py
@@ -1,22 +1,34 @@
-"""Seed knowledge base — the single source of truth (CLAUDE.md Rule 3) for:
+"""Knowledge base — the single source of truth (CLAUDE.md Rule 3) for:
 
   * MCU board-id  -> symbol/part        (``resolve_mcu``)
   * peripheral type -> symbol + bus + role→pin-name map (``resolve_peripheral``)
 
-Deliberately small and explicit. A firmware ``#define`` names a *role*
-(``HX711_SCK_PIN``, role ``SCK``); the device symbol names the *pin*. These are
-NOT always equal — e.g. the MCP23017 symbol's I2C-clock pin is named ``SCK`` and
-its data pin ``SDA``; the HX711 clock pin is named ``PD_SCK``. The ``roles`` map
-below captures that firmware-role → symbol-pin-name translation per peripheral,
-so no caller assumes identity. (Pin *names* verified against the symbols used in
-the speed-cal v5 netlist.)
+Device facts now live in **YAML device cards** under ``devices/`` (loaded by
+``cards.py``), not hand-edited Python tables — a new recognized device is a data
+file, not a code edit. This module keeps the public ``resolve_*`` API, the typed
+shapes, the template-owned constants (passives, AMS1117, USB/CP2102 block,
+headers — design knowledge no firmware names), and the back-compat strap
+helpers (now thin wrappers over the card data).
+
+A firmware ``#define`` names a *role* (``HX711_SCK_PIN``, role ``SCK``); the
+device symbol names the *pin*. These are NOT always equal — the MCP23017 symbol's
+I2C-clock pin is named ``SCK``, the HX711 clock ``PD_SCK``. Each card's ``roles``
+map captures that firmware-role → symbol-pin translation.
 
 Unknown MCUs / peripherals resolve to ``None`` — the importer turns that into an
 explicit gap rather than guessing.
 """
 from __future__ import annotations
 
-from typing import Optional, TypedDict
+from typing import Any, Optional, TypedDict, cast
+
+from kicad_mcp.utils.firmware.cards import compute_address_straps, load_cards
+
+__all__ = [
+    "McuInfo", "PeripheralInfo", "resolve_mcu", "resolve_mcu_by_part",
+    "resolve_peripheral", "role_to_pin_name", "compute_address_straps",
+    "mcp23017_address_straps", "mpu6050_ad0_strap",
+]
 
 
 class McuInfo(TypedDict):
@@ -34,45 +46,49 @@ class McuInfo(TypedDict):
     native_usb: bool     # True if the MCU has native USB (no CP2102 bridge needed)
 
 
-class PeripheralInfo(TypedDict):
+# Required fields + optional card extras (Python 3.10 has no typing.NotRequired,
+# so use the stdlib total=False inheritance pattern).
+class _PeripheralInfoBase(TypedDict):
     lib_id: str
     value: str
     bus: Optional[str]
     footprint: str
-    # firmware signal-role (upper-cased) -> symbol pin NAME
+    # firmware signal-role (upper-cased) -> symbol pin NAME or NUMBER
     roles: dict[str, str]
-    supply_pins: list[str]   # pin NAMES tied to +3V3
-    ground_pins: list[str]   # pin NAMES tied to GND
-    # True if this entry models the device as its breakout-MODULE header
-    # (e.g. a GY-521 / I2C OLED plugged onto a carrier) rather than a chip-down
-    # IC. Firmware names the device; "module vs chip-down" is a design choice we
-    # make explicit (build_intent flags it), same spirit as the AMS1117 default.
+    supply_pins: list[str]   # pin NAMES/NUMBERS tied to +3V3
+    ground_pins: list[str]   # pin NAMES/NUMBERS tied to GND
+    # True if modeled as a breakout-MODULE header (GY-521 / I2C OLED on a
+    # carrier) rather than a chip-down IC — build_intent flags the assumption.
     module: bool
 
 
-# ESP32-WROOM-32E facts. GND is the symbol's MERGED pin (physical pads
-# 1/15/38/39 collapsed) — resolve it by NAME, never by number.
-_ESP32: McuInfo = {
-    "part": "ESP32-WROOM-32E", "lib_id": "RF_Module:ESP32-WROOM-32E",
-    "value": "ESP32-WROOM-32E", "footprint": "RF_Module:ESP32-WROOM-32E",
-    "needs_3v3": True, "supply_pin": "VDD", "ground_pin": "GND",
-    "en_pin": "EN", "boot_pin": "IO0",
-    "uart_rx_pin": "RXD0/IO3", "uart_tx_pin": "TXD0/IO1",
-    "native_usb": False,   # WROOM-32 needs a CP2102 USB-UART bridge
-}
+class PeripheralInfo(_PeripheralInfoBase, total=False):
+    config: dict[str, Any]            # address_strap + static_ties (device_config)
+    decoupling: list[dict[str, Any]]  # optional per-IC bypass override
 
-# ESP32-S3-WROOM-1. The KiCad symbol names GPIOs as IO{n} (same convention as
-# WROOM-32), so the IO{n} mapper works; UART0 pins are named RXD0/TXD0.
-_ESP32S3: McuInfo = {
-    "part": "ESP32-S3-WROOM-1", "lib_id": "RF_Module:ESP32-S3-WROOM-1",
-    "value": "ESP32-S3-WROOM-1", "footprint": "RF_Module:ESP32-S3-WROOM-1",
-    "needs_3v3": True, "supply_pin": "3V3", "ground_pin": "GND",
-    "en_pin": "EN", "boot_pin": "IO0",
-    "uart_rx_pin": "RXD0", "uart_tx_pin": "TXD0",
-    "native_usb": True,    # S3 has native USB — no CP2102 bridge
-}
 
-# --- audio peripherals + headers (verified pins; audio-node ground-truth FPs) -
+# --- card cache (loaded once from the packaged + override dirs) ---------------
+
+_CACHE: Optional[tuple[dict[str, dict[str, Any]], list[dict[str, Any]]]] = None
+
+
+def _cards() -> tuple[dict[str, dict[str, Any]], list[dict[str, Any]]]:
+    global _CACHE
+    if _CACHE is None:
+        _CACHE = load_cards()
+    return _CACHE
+
+
+def reload_cards() -> None:
+    """Drop the card cache (tests / hot-reload). Next resolve_* reloads."""
+    global _CACHE
+    _CACHE = None
+
+
+# --- template-owned constants (NOT cards: design knowledge no firmware names) -
+# These are instantiated by templates, never by a firmware #define, so they stay
+# Python. Pins verified against the speed-cal v5 / audio-node ground-truth.
+
 MAX98357A: dict[str, str] = {
     "lib_id": "Audio:MAX98357A", "value": "MAX98357A",
     "footprint": "Package_DFN_QFN:HVQFN-16-1EP_3x3mm_P0.5mm_EP1.5x1.5mm",
@@ -94,69 +110,6 @@ HDR_1X4 = ("Connector_Generic:Conn_01x04",
            "Connector_PinHeader_2.54mm:PinHeader_1x04_P2.54mm_Vertical")
 HDR_1X5 = ("Connector_Generic:Conn_01x05",
            "Connector_PinHeader_2.54mm:PinHeader_1x05_P2.54mm_Vertical")
-
-# board-id substrings (from platformio.ini ``board =``) -> MCU. MORE-SPECIFIC
-# keys FIRST: resolve_mcu does substring matching, so `esp32-s3` must precede the
-# generic `esp32` or an S3 board would mis-resolve to WROOM-32.
-_MCUS: dict[str, McuInfo] = {
-    "esp32-s3-devkitc-1": _ESP32S3, "esp32-s3": _ESP32S3, "esp32s3": _ESP32S3,
-    "esp32dev": _ESP32, "esp32": _ESP32,
-}
-
-_PERIPHERALS: dict[str, PeripheralInfo] = {
-    "MCP23017": {
-        "lib_id": "Interface_Expansion:MCP23017x-x-SO",
-        "value": "MCP23017", "bus": "I2C",
-        "footprint": "Package_SO:SOIC-28W_7.5x17.9mm_P1.27mm",
-        # NB: I2C clock pin is named "SCK" on this symbol, not "SCL".
-        "roles": {"SDA": "SDA", "SCL": "SCK", "INT": "INTA", "INTA": "INTA"},
-        "supply_pins": ["V_{DD}"], "ground_pins": ["V_{SS}"], "module": False,
-    },
-    "HX711": {
-        "lib_id": "Analog_ADC:HX711",
-        "value": "HX711", "bus": None,
-        "footprint": "Package_SO:SOIC-16_3.9x9.9mm_P1.27mm",
-        "roles": {"DOUT": "DOUT", "SCK": "PD_SCK", "PD_SCK": "PD_SCK"},
-        # HX711 has no separate DGND — analog + digital ground share AGND.
-        "supply_pins": ["VSUP", "AVDD", "DVDD"], "ground_pins": ["AGND"],
-        "module": False,
-    },
-    # --- I2C breakout modules (carrier-board representation) ------------------
-    # A GY-521 (MPU-6050) module exposes a header; we model the connection, not
-    # the bare QFN (whose charge-pump/REGOUT support firmware can't inform).
-    # Header pin convention (matches i2c_device_header): 1=GND 2=VCC 3=SCL 4=SDA,
-    # plus 5=AD0 for I2C address selection.
-    "MPU6050": {
-        "lib_id": HDR_1X5[0], "value": "GY-521 (MPU-6050)", "bus": "I2C",
-        "footprint": HDR_1X5[1],
-        "roles": {"SDA": "4", "SCL": "3"},
-        "supply_pins": ["2"], "ground_pins": ["1"], "module": True,
-    },
-    # I2C OLED module (SSD1306/SSD1315). 4-pin module: 1=GND 2=VCC 3=SCL 4=SDA.
-    "OLED": {
-        "lib_id": HDR_1X4[0], "value": "OLED (SSD1306)", "bus": "I2C",
-        "footprint": HDR_1X4[1],
-        "roles": {"SDA": "4", "SCL": "3"},
-        "supply_pins": ["2"], "ground_pins": ["1"], "module": True,
-    },
-}
-
-# MPU-6050 I2C address strapping: a single AD0 pin selects the LSB of the
-# address — AD0=low -> base 0x68, AD0=high -> 0x69. (GY-521 header pin 5 = AD0.)
-# Single source of truth for the address->AD0-rail map (boundary-tested).
-MPU6050_AD0_PIN = "5"
-MPU6050_ADDR_BASE = 0x68
-
-
-def mpu6050_ad0_strap(address: int) -> Optional[tuple[str, str]]:
-    """Return ``(ad0_pin_name, rail)`` for an MPU-6050 I2C address, or None if
-    the address is outside the strappable pair 0x68/0x69. AD0 ties to "GND"
-    (0x68) or "+3V3" (0x69)."""
-    if address == MPU6050_ADDR_BASE:
-        return (MPU6050_AD0_PIN, "GND")
-    if address == MPU6050_ADDR_BASE + 1:
-        return (MPU6050_AD0_PIN, "+3V3")
-    return None
 
 # --- verified footprints (speed-cal v5 BOM) for template-placed passives ---
 LIB_C = "Device:C"
@@ -199,62 +152,84 @@ SW_PUSH_FP = "Button_Switch_SMD:SW_SPST_B3S-1000"
 # 5.1k = USB-C CC sink resistors.
 FP_R_0603_5K1 = FP_R_0603
 
-# MCP23017 I2C address strapping. Base 0x20; bits A2 A1 A0 select 0x20..0x27.
-MCP23017_ADDRESS_BASE = 0x20
-MCP23017_ADDRESS_PINS = ("A0", "A1", "A2")   # index = bit position
+# --- back-compat strap constants/helpers -------------------------------------
+# The card is now the source of truth for strap pins/base; these mirror the card
+# data for the few call sites/tests that reference them by name. A parity test
+# (test_device_cards) pins that they match the cards, so they can't drift.
 MCP23017_RESET_PIN = "~{RESET}"
+MPU6050_AD0_PIN = "5"
 
 
 def mcp23017_address_straps(address: int) -> Optional[list[tuple[str, str]]]:
-    """Return [(addr_pin_name, rail)] for an MCP23017 I2C address, or None if the
-    address is outside the strappable range 0x20..0x27. Each address pin ties to
-    "+3V3" (bit set) or "GND" (bit clear). This is the single source of truth for
-    the address→strap mapping (the silent-wrong hotspot — boundary-tested)."""
-    offset = address - MCP23017_ADDRESS_BASE
-    if offset < 0 or offset > 0b111:
+    """[(addr_pin, rail)] for an MCP23017 I2C address (0x20..0x27), else None.
+    Thin wrapper over the MCP23017 card's address-strap spec."""
+    info = resolve_peripheral("MCP23017")
+    if info is None or "config" not in info:
         return None
-    out: list[tuple[str, str]] = []
-    for bit, pin in enumerate(MCP23017_ADDRESS_PINS):
-        rail = "+3V3" if (offset >> bit) & 1 else "GND"
-        out.append((pin, rail))
-    return out
+    return compute_address_straps(info["config"]["address_strap"], address)
 
+
+def mpu6050_ad0_strap(address: int) -> Optional[tuple[str, str]]:
+    """(ad0_pin, rail) for an MPU-6050 I2C address (0x68/0x69), else None. Thin
+    wrapper over the MPU6050 card; unpacks the single-bit list back to a tuple."""
+    info = resolve_peripheral("MPU6050")
+    if info is None or "config" not in info:
+        return None
+    straps = compute_address_straps(info["config"]["address_strap"], address)
+    return straps[0] if straps else None
+
+
+# --- resolution --------------------------------------------------------------
 
 def resolve_mcu(board_id: Optional[str]) -> Optional[McuInfo]:
-    """Map a platformio ``board =`` id to an MCU. Exact match first, then
-    substring (so ``esp32dev`` and ``esp32-s3-...`` both resolve)."""
+    """Map a platformio ``board =`` id to an MCU card. Exact ``board_match`` /
+    ``part`` first, then the card with the LONGEST ``board_match`` substring in
+    the id (deterministic; no hand-ordered precedence — removes the Rule-3 seam
+    where ``esp32-s3`` had to precede ``esp32``)."""
     if not board_id:
         return None
     key = board_id.strip().lower()
-    if key in _MCUS:
-        return _MCUS[key]
-    for sub, info in _MCUS.items():
-        if sub in key:
-            return info
-    return None
+    _, mcus = _cards()
+    best: Optional[dict[str, Any]] = None
+    best_len = -1
+    for card in mcus:
+        matches = [str(s).lower() for s in card["board_match"]] + [str(card["part"]).lower()]
+        if key in matches:
+            return cast(McuInfo, card)
+        for sub in matches:
+            if sub and sub in key and len(sub) > best_len:
+                best, best_len = card, len(sub)
+            elif sub and sub in key and len(sub) == best_len and best is not None:
+                # deterministic tie-break by part, for stability
+                if str(card["part"]) < str(best["part"]):
+                    best = card
+    return cast(McuInfo, best) if best is not None else None
 
 
 def resolve_mcu_by_part(part: Optional[str]) -> Optional[McuInfo]:
     """Look up MCU facts by part string (templates have ``intent.mcu.part``)."""
     if not part:
         return None
-    for info in _MCUS.values():
-        if info["part"] == part:
-            return info
+    _, mcus = _cards()
+    for card in mcus:
+        if card["part"] == part:
+            return cast(McuInfo, card)
     return None
 
 
 def resolve_peripheral(type_name: Optional[str]) -> Optional[PeripheralInfo]:
     """Map a peripheral type (e.g. ``MCP23017``, derived from ``MCP23017_ADDR``
-    or a pin macro's name prefix) to its symbol + role map."""
+    or a pin macro's name prefix) to its card."""
     if not type_name:
         return None
-    return _PERIPHERALS.get(type_name.strip().upper())
+    peris, _ = _cards()
+    card = peris.get(type_name.strip().upper())
+    return cast(PeripheralInfo, card) if card is not None else None
 
 
 def role_to_pin_name(type_name: str, role: Optional[str]) -> Optional[str]:
-    """Translate a firmware signal-role to the device symbol's pin NAME, or
-    None if unknown (caller flags it)."""
+    """Translate a firmware signal-role to the device symbol's pin NAME/NUMBER,
+    or None if unknown (caller flags it)."""
     info = resolve_peripheral(type_name)
     if info is None or role is None:
         return None

--- a/src/kicad_mcp/utils/firmware/mcu_pinmap.py
+++ b/src/kicad_mcp/utils/firmware/mcu_pinmap.py
@@ -45,3 +45,22 @@ def pin_number_by_name(symbol: Any, pin_name: Optional[str]) -> Optional[str]:
         if (pin.name or "") == pin_name:
             return str(pin.number)
     return None
+
+
+def resolve_pin_token(symbol: Any, token: Any) -> Optional[str]:
+    """Resolve a pin token to its NUMBER. A token is either a pin NAME
+    (MCP23017 ``SDA``) or already a literal pin NUMBER (a header pin ``4``, a
+    USB-C/QFN pad ``A4``/``29``). Name lookup first; else validate the token
+    against the symbol's real pin numbers (alphanumeric, so not a digit check).
+
+    Single source of truth for name-or-number pin resolution — consumed by the
+    generator (wiring), the card validator (pin-existence), and auto-draft
+    (role→pin scoring), so none re-encode the rule (CLAUDE.md Rule 3).
+    """
+    if symbol is None or token is None:
+        return None
+    num = pin_number_by_name(symbol, str(token))
+    if num is not None:
+        return num
+    valid = {str(p.number) for p in (getattr(symbol, "pins", None) or ())}
+    return str(token) if str(token) in valid else None

--- a/src/kicad_mcp/utils/firmware/templates.py
+++ b/src/kicad_mcp/utils/firmware/templates.py
@@ -38,6 +38,7 @@ class Expansion:
     joins: list[tuple[str, Endpoint]] = field(default_factory=list)
     new_nets: list[Net] = field(default_factory=list)
     resolved: list[str] = field(default_factory=list)
+    gaps: list[Gap] = field(default_factory=list)   # new gaps a template surfaces
 
 
 class RefAllocator:
@@ -183,40 +184,35 @@ def mcu_straps(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
     return ex
 
 
-def mcp23017_config(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
-    """Strap each MCP23017's A0/A1/A2 per its I2C address, and tie RESET high.
-    Direct ties (no resistors) — correct for a fixed address. The bit→rail map is
-    knowledge.mcp23017_address_straps (the boundary-tested single source)."""
+def device_config(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
+    """Data-driven device configuration — strap each placed peripheral's address
+    pins + apply its static ties, ALL read from the device card's ``config``
+    (CLAUDE.md Rule 3: the card is the single source). Replaces the former
+    per-device ``mcp23017_config`` / ``mpu6050_config`` templates: a new
+    addressable device needs only a ``config.address_strap`` stanza in its card,
+    no new template. Direct ties (no resistors) — correct for a fixed address.
+    An out-of-range address is flagged as a gap, never silently strapped."""
     ex = Expansion()
     for p in intent.peripherals:
-        if p.type.upper() != "MCP23017" or p.address is None:
+        info = K.resolve_peripheral(p.type)
+        if info is None or "config" not in info:
             continue
-        straps = K.mcp23017_address_straps(p.address)
-        if straps is None:
-            ex.resolved.append("__invalid_address")  # surfaced as a gap below
-            continue
-        for addr_pin, rail in straps:
-            ex.power.append((rail, Endpoint(ref=p.ref, pin=addr_pin)))
-        # RESET is active-low — hold high.
-        ex.power.append(("+3V3", Endpoint(ref=p.ref, pin=K.MCP23017_RESET_PIN)))
-    return ex
-
-
-def mpu6050_config(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
-    """Strap each MPU-6050's AD0 pin per its I2C address (0x68→GND, 0x69→+3V3).
-    Direct tie (no resistor) — correct for a fixed address. The address→rail map
-    is knowledge.mpu6050_ad0_strap (the boundary-tested single source). An
-    out-of-range address is surfaced as a gap, never silently strapped."""
-    ex = Expansion()
-    for p in intent.peripherals:
-        if p.type.upper() != "MPU6050" or p.address is None:
-            continue
-        strap = K.mpu6050_ad0_strap(p.address)
-        if strap is None:
-            ex.resolved.append("__invalid_mpu_address")  # surfaced as a gap below
-            continue
-        ad0_pin, rail = strap
-        ex.power.append((rail, Endpoint(ref=p.ref, pin=ad0_pin)))
+        cfg = info["config"]
+        strap = cfg.get("address_strap")
+        if strap is not None and p.address is not None:
+            straps = K.compute_address_straps(strap, p.address)
+            if straps is None:
+                ex.gaps.append(Gap(
+                    "invalid_address",
+                    f"{p.type} I2C address {hex(p.address)} is outside its "
+                    f"strappable range; address pins not strapped.",
+                ))
+            else:
+                for addr_pin, rail in straps:
+                    ex.power.append((rail, Endpoint(ref=p.ref, pin=addr_pin)))
+        # Fixed ties (e.g. MCP23017 RESET held high) — address-independent.
+        for tie in cfg.get("static_ties", []) or []:
+            ex.power.append((tie["rail"], Endpoint(ref=p.ref, pin=tie["pin"])))
     return ex
 
 
@@ -468,8 +464,7 @@ _REGISTRY: list[tuple[str, Callable[[DesignIntent, RefAllocator], Expansion]]] =
     ("i2s_mic", i2s_mic),
     ("i2c_device_header", i2c_device_header),
     ("uart_device_header", uart_device_header),
-    ("mcp23017_config", mcp23017_config),
-    ("mpu6050_config", mpu6050_config),
+    ("device_config", device_config),
 ]
 
 
@@ -506,15 +501,10 @@ def expand_intent(intent: DesignIntent) -> DesignIntent:
             intent.nets.append(n)
             nets_by_name[n.name] = n
 
+        for g in ex.gaps:               # new gaps a template surfaces directly
+            intent.gaps.append(g)
+
         for kind in ex.resolved:
-            if kind == "__invalid_address":
-                intent.gaps.append(Gap("invalid_address",
-                                       "MCP23017 I2C address outside 0x20–0x27; not strapped."))
-                continue
-            if kind == "__invalid_mpu_address":
-                intent.gaps.append(Gap("invalid_address",
-                                       "MPU-6050 I2C address is not 0x68/0x69; AD0 not strapped."))
-                continue
             gap = gaps_by_kind.get(kind)
             if gap is not None and not gap.resolved:
                 gap.resolved = True

--- a/tests/integration/test_device_cards.py
+++ b/tests/integration/test_device_cards.py
@@ -1,0 +1,58 @@
+"""Integration tier of card validation (needs KiCad symbol libraries).
+
+The unit tier (tests/test_device_cards.py) checks structure with no KiCad. This
+tier loads each card's actual symbol and asserts every pin the card references
+(roles, supply/ground, address-strap bits, static ties; MCU supply/ground/strap/
+uart pins) exists on that symbol — the "verify pins against the real symbol"
+discipline, enforced mechanically. A wrong pin name in a card fails here.
+
+Gated by KICAD_INTEGRATION=1; runs on the self-hosted KiCad 9/10 matrix.
+"""
+import os
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("KICAD_INTEGRATION") != "1",
+    reason="Integration tests require KICAD_INTEGRATION=1 and a real KiCad install",
+)
+
+
+def _pins_for_peripheral(card):
+    pins = list(card["roles"].values()) + list(card["supply_pins"]) + list(card["ground_pins"])
+    cfg = card.get("config") or {}
+    strap = cfg.get("address_strap")
+    if strap:
+        pins += list(strap["pin_bits"])
+    pins += [t["pin"] for t in cfg.get("static_ties", []) or []]
+    return pins
+
+
+def _pins_for_mcu(card):
+    return [card[k] for k in ("supply_pin", "ground_pin", "en_pin", "boot_pin",
+                              "uart_rx_pin", "uart_tx_pin")]
+
+
+def _all_cards():
+    from kicad_mcp.utils.firmware.cards import load_cards
+    peris, mcus = load_cards()
+    items = [("peripheral", t, c, _pins_for_peripheral(c)) for t, c in peris.items()]
+    items += [("mcu", c["part"], c, _pins_for_mcu(c)) for c in mcus]
+    return items
+
+
+@pytest.mark.parametrize("kind,name,card,pins",
+                         _all_cards(),
+                         ids=lambda v: v if isinstance(v, str) else "")
+def test_card_pins_exist_on_symbol(kind, name, card, pins):
+    from kicad_sch_api.library.cache import get_symbol_cache
+
+    from kicad_mcp.utils.firmware.mcu_pinmap import resolve_pin_token
+
+    sym = get_symbol_cache().get_symbol(card["lib_id"])
+    assert sym is not None, f"{kind} {name}: symbol {card['lib_id']!r} not found"
+    missing = [p for p in pins if resolve_pin_token(sym, p) is None]
+    assert not missing, (
+        f"{kind} {name} ({card['lib_id']}): pins not on symbol: {missing}. "
+        f"Available names={[getattr(p, 'name', None) for p in (sym.pins or [])][:40]}"
+    )

--- a/tests/test_device_cards.py
+++ b/tests/test_device_cards.py
@@ -1,0 +1,207 @@
+"""Tests for the device-card layer (loader, structural validator, strap math,
+resolution parity). No KiCad needed — pin-existence against real symbols is the
+integration tier (tests/integration/test_device_cards.py).
+
+Boundary-focused per CLAUDE.md: the strap math and the validator's accept/reject
+edges are pinned at/below/above, and the migration's equivalence is frozen by a
+snapshot of the 6 entries' exact field values.
+"""
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from kicad_mcp.utils.firmware import knowledge as K
+from kicad_mcp.utils.firmware.cards import (
+    CardError,
+    compute_address_straps,
+    load_cards,
+    validate_mcu_card,
+    validate_peripheral_card,
+)
+
+
+# --- compute_address_straps: single source, reproduces both legacy fns --------
+
+_MCP_STRAP = {"pin_bits": ["A0", "A1", "A2"], "base": 0x20,
+              "rail_set": "+3V3", "rail_clear": "GND"}
+_MPU_STRAP = {"pin_bits": ["5"], "base": 0x68, "rail_set": "+3V3", "rail_clear": "GND"}
+
+
+@pytest.mark.parametrize("addr,expected", [
+    (0x20, [("A0", "GND"), ("A1", "GND"), ("A2", "GND")]),        # base
+    (0x27, [("A0", "+3V3"), ("A1", "+3V3"), ("A2", "+3V3")]),     # max
+    (0x24, [("A0", "GND"), ("A1", "GND"), ("A2", "+3V3")]),       # mixed
+    (0x21, [("A0", "+3V3"), ("A1", "GND"), ("A2", "GND")]),       # lsb only
+    (0x1F, None),                                                 # one below base
+    (0x28, None),                                                 # one above max
+])
+def test_strap_mcp_3bit(addr, expected):
+    assert compute_address_straps(_MCP_STRAP, addr) == expected
+
+
+@pytest.mark.parametrize("addr,expected", [
+    (0x68, [("5", "GND")]),     # base
+    (0x69, [("5", "+3V3")]),    # base + 1 (max for 1 bit)
+    (0x67, None),               # one below
+    (0x6A, None),               # one above
+])
+def test_strap_mpu_1bit(addr, expected):
+    assert compute_address_straps(_MPU_STRAP, addr) == expected
+
+
+def test_strap_matches_backcompat_wrappers():
+    # the knowledge.py wrappers must reproduce the helper exactly
+    for a in (0x20, 0x24, 0x27, 0x1F, 0x28):
+        assert K.mcp23017_address_straps(a) == compute_address_straps(_MCP_STRAP, a)
+    for a in (0x68, 0x69, 0x67, 0x6A):
+        helper = compute_address_straps(_MPU_STRAP, a)
+        assert K.mpu6050_ad0_strap(a) == (helper[0] if helper else None)
+
+
+# --- structural validation ----------------------------------------------------
+
+_GOOD_PERIPHERAL = {
+    "type": "FOO", "lib_id": "Lib:Foo", "value": "Foo", "bus": "I2C",
+    "footprint": "FP:Foo", "roles": {"SDA": "4"}, "supply_pins": ["2"],
+    "ground_pins": ["1"], "module": True,
+}
+_GOOD_MCU = {
+    "part": "FOO-MCU", "lib_id": "Lib:Foo", "value": "Foo", "footprint": "FP:Foo",
+    "board_match": ["foo"], "needs_3v3": True, "supply_pin": "VDD",
+    "ground_pin": "GND", "en_pin": "EN", "boot_pin": "IO0",
+    "uart_rx_pin": "RX", "uart_tx_pin": "TX", "native_usb": False,
+}
+
+
+def test_good_cards_validate_clean():
+    assert validate_peripheral_card(_GOOD_PERIPHERAL) == []
+    assert validate_mcu_card(_GOOD_MCU) == []
+
+
+@pytest.mark.parametrize("mutate,needle", [
+    (lambda c: c.pop("lib_id"), "missing required"),
+    (lambda c: c.update(lib_id="NoColon"), "lib_id"),
+    (lambda c: c.update(bus="SDIO"), "bus"),
+    (lambda c: c.update(module="yes"), "module must be a bool"),
+])
+def test_bad_peripheral_rejected(mutate, needle):
+    card = dict(_GOOD_PERIPHERAL)
+    mutate(card)
+    errs = validate_peripheral_card(card)
+    assert errs and any(needle in e for e in errs)
+
+
+@pytest.mark.parametrize("strap,ok", [
+    ({"pin_bits": ["A0"], "base": 0x20}, True),
+    ({"pin_bits": [], "base": 0x20}, False),          # empty pin_bits
+    ({"pin_bits": ["A0"], "base": "0x20"}, False),    # base not int
+    ({"pin_bits": ["A0"], "base": 1, "rail_set": "+9V"}, False),  # bad rail
+])
+def test_address_strap_validation(strap, ok):
+    card = dict(_GOOD_PERIPHERAL, config={"address_strap": strap})
+    errs = validate_peripheral_card(card)
+    assert (errs == []) is ok
+
+
+# --- packaged library loads + the migrated 6 entries are present --------------
+
+def test_packaged_cards_load():
+    peris, mcus = load_cards()
+    assert set(peris) >= {"MCP23017", "HX711", "MPU6050", "OLED"}
+    assert {m["part"] for m in mcus} >= {"ESP32-WROOM-32E", "ESP32-S3-WROOM-1"}
+
+
+# Frozen snapshot — the migration must reproduce the old literals EXACTLY.
+_EXPECTED = {
+    "MCP23017": {
+        "lib_id": "Interface_Expansion:MCP23017x-x-SO", "value": "MCP23017",
+        "bus": "I2C", "footprint": "Package_SO:SOIC-28W_7.5x17.9mm_P1.27mm",
+        "roles": {"SDA": "SDA", "SCL": "SCK", "INT": "INTA", "INTA": "INTA"},
+        "supply_pins": ["V_{DD}"], "ground_pins": ["V_{SS}"], "module": False,
+    },
+    "HX711": {
+        "lib_id": "Analog_ADC:HX711", "value": "HX711", "bus": None,
+        "footprint": "Package_SO:SOIC-16_3.9x9.9mm_P1.27mm",
+        "roles": {"DOUT": "DOUT", "SCK": "PD_SCK", "PD_SCK": "PD_SCK"},
+        "supply_pins": ["VSUP", "AVDD", "DVDD"], "ground_pins": ["AGND"],
+        "module": False,
+    },
+    "MPU6050": {
+        "lib_id": "Connector_Generic:Conn_01x05", "value": "GY-521 (MPU-6050)",
+        "bus": "I2C",
+        "footprint": "Connector_PinHeader_2.54mm:PinHeader_1x05_P2.54mm_Vertical",
+        "roles": {"SDA": "4", "SCL": "3"}, "supply_pins": ["2"],
+        "ground_pins": ["1"], "module": True,
+    },
+    "OLED": {
+        "lib_id": "Connector_Generic:Conn_01x04", "value": "OLED (SSD1306)",
+        "bus": "I2C",
+        "footprint": "Connector_PinHeader_2.54mm:PinHeader_1x04_P2.54mm_Vertical",
+        "roles": {"SDA": "4", "SCL": "3"}, "supply_pins": ["2"],
+        "ground_pins": ["1"], "module": True,
+    },
+}
+
+
+@pytest.mark.parametrize("ptype", sorted(_EXPECTED))
+def test_resolution_parity(ptype):
+    info = K.resolve_peripheral(ptype)
+    assert info is not None
+    for k, v in _EXPECTED[ptype].items():
+        assert info[k] == v, f"{ptype}.{k}"
+
+
+def test_backcompat_constants_match_cards():
+    # the mirror constants must equal the card data (so they can't drift)
+    mcp = K.resolve_peripheral("MCP23017")
+    mpu = K.resolve_peripheral("MPU6050")
+    assert K.MCP23017_RESET_PIN == mcp["config"]["static_ties"][0]["pin"]
+    assert K.MPU6050_AD0_PIN == mpu["config"]["address_strap"]["pin_bits"][0]
+
+
+# --- MCU resolution (longest board_match, no hand-ordered precedence) ---------
+
+@pytest.mark.parametrize("board,part", [
+    ("esp32dev", "ESP32-WROOM-32E"),
+    ("esp32", "ESP32-WROOM-32E"),
+    ("esp32-s3-devkitc-1", "ESP32-S3-WROOM-1"),
+    ("esp32-s3", "ESP32-S3-WROOM-1"),
+    ("esp32s3", "ESP32-S3-WROOM-1"),
+    ("esp32-s3-wroom", "ESP32-S3-WROOM-1"),   # substring: longest 'esp32-s3' wins
+    ("nonsense", None),
+])
+def test_resolve_mcu(board, part):
+    info = K.resolve_mcu(board)
+    assert (info["part"] if info else None) == part
+
+
+# --- loader precedence + malformed handling -----------------------------------
+
+def test_override_dir_takes_precedence(tmp_path):
+    (tmp_path / "mpu_override.yaml").write_text(textwrap.dedent("""\
+        type: MPU6050
+        lib_id: Lib:Custom
+        value: custom
+        bus: I2C
+        footprint: FP:Custom
+        roles: {SDA: "4", SCL: "3"}
+        supply_pins: ["2"]
+        ground_pins: ["1"]
+        module: true
+    """))
+    peris, _ = load_cards(extra_dirs=[str(tmp_path)])
+    assert peris["MPU6050"]["lib_id"] == "Lib:Custom"   # override wins
+
+
+def test_malformed_card_raises(tmp_path):
+    (tmp_path / "bad.yaml").write_text("type: BAD\nlib_id: no_colon\n")
+    with pytest.raises(CardError):
+        load_cards(extra_dirs=[str(tmp_path)])
+
+
+def test_neither_peripheral_nor_mcu_raises(tmp_path):
+    (tmp_path / "huh.yaml").write_text("foo: bar\n")
+    with pytest.raises(CardError):
+        load_cards(extra_dirs=[str(tmp_path)])

--- a/tests/test_firmware_autodraft.py
+++ b/tests/test_firmware_autodraft.py
@@ -1,0 +1,153 @@
+"""Tests for offline card auto-draft (Phase 7). Fully offline — symbol access is
+via lightweight stubs, so the false-confidence gate (cold-review hazard) is
+exercised without KiCad: a pin merely *named* like a role, a mismatch (SCL→SCK),
+an uncorroborated address, and a multi-unit symbol must all yield `low`, never
+`high`. A draft is returned for review, never placed.
+"""
+from __future__ import annotations
+
+import pytest
+
+from kicad_mcp.utils.firmware.autodraft import (
+    draft_card,
+    extract_whoami,
+    identify_by_address,
+    score_roles,
+)
+
+
+class _Pin:
+    def __init__(self, number: str, name: str) -> None:
+        self.number, self.name = number, name
+
+
+class _Sym:
+    def __init__(self, pins: list[tuple[str, str]], unit_count: int = 1) -> None:
+        self.pins = [_Pin(n, nm) for n, nm in pins]
+        self.unit_count = unit_count
+
+
+# --- address identity ---------------------------------------------------------
+
+@pytest.mark.parametrize("addr,expected", [
+    (0x68, "MPU6050"), (0x69, "MPU6050"),
+    (0x3C, "OLED"), (0x76, "BME280"), (0x40, "INA219"),
+    (0x55, None),       # not a known device address
+    (None, None),
+])
+def test_identify_by_address(addr, expected):
+    assert identify_by_address(addr) == expected
+
+
+# --- WHO_AM_I extraction from provenance --------------------------------------
+
+def test_extract_whoami():
+    prov = {"unparsed": [
+        {"name": "MPU6050_WHO_AM_I_EXPECTED", "value": "0x68"},
+        {"name": "MPU6050_REG_CONFIG", "value": "0x1A"},     # not a whoami
+        {"name": "SOME_STRING", "value": '"hi"'},
+    ]}
+    assert extract_whoami(prov) == {"MPU6050": 0x68}
+
+
+# --- role scoring (name identity only) ----------------------------------------
+
+def test_score_roles_clean_identity():
+    sym = _Sym([("1", "SDA"), ("2", "SCL"), ("3", "VDD"), ("4", "GND")])
+    resolved, unresolved = score_roles(sym, {"SDA": "SDA", "SCL": "SCL"})
+    assert resolved == {"SDA": "SDA", "SCL": "SCL"} and unresolved == []
+
+
+def test_score_roles_mismatch_flags_unresolved():
+    # MCP-style: the I2C clock pin is named SCK, so role SCL does NOT name-match
+    sym = _Sym([("13", "SDA"), ("12", "SCK"), ("9", "V_{DD}")])
+    resolved, unresolved = score_roles(sym, {"SDA": "SDA", "SCL": "SCL"})
+    assert "SDA" in resolved and unresolved == ["SCL"]
+
+
+# --- draft confidence gate ----------------------------------------------------
+
+def test_draft_high_requires_corroboration_clean_symbol():
+    # address 0x76 corroborates BME280; symbol's only signal pins are SDA/SCL
+    sym = _Sym([("1", "SDA"), ("2", "SCL"), ("3", "VDD"), ("4", "GND")])
+    d = draft_card(type_name="BME280", address=0x76, bus="I2C",
+                   roles={"SDA": "SDA", "SCL": "SCL"}, symbol=sym,
+                   lib_id="Sensor:BME280", footprint="FP:BME280")
+    assert d is not None and d.confidence == "high"
+    assert d.card["roles"] == {"SDA": "SDA", "SCL": "SCL"}
+
+
+def test_draft_low_on_mismatch():
+    sym = _Sym([("13", "SDA"), ("12", "SCK"), ("9", "V_{DD}")])
+    d = draft_card(type_name="MCP23017", address=0x20, bus="I2C",
+                   roles={"SDA": "SDA", "SCL": "SCL"}, symbol=sym,
+                   lib_id="Interface_Expansion:MCP23017x-x-SO", footprint="FP:x")
+    assert d is not None and d.confidence == "low"   # SCL unresolved
+
+
+def test_draft_low_when_address_uncorroborated():
+    # clean symbol, but address unknown -> only one signal, stay low
+    sym = _Sym([("1", "SDA"), ("2", "SCL"), ("3", "VDD"), ("4", "GND")])
+    d = draft_card(type_name="MYSENSOR", address=0x55, bus="I2C",
+                   roles={"SDA": "SDA", "SCL": "SCL"}, symbol=sym,
+                   lib_id="X:Y", footprint="FP:Y")
+    assert d is not None and d.confidence == "low"
+
+
+def test_draft_low_on_unexplained_pins():
+    # extra signal pins the firmware bus can't explain -> identity uncertain
+    sym = _Sym([("1", "SDA"), ("2", "SCL"), ("3", "VDD"), ("4", "GND"),
+                ("5", "INT"), ("6", "FIFO_WM")])
+    d = draft_card(type_name="MPU6050", address=0x68, bus="I2C",
+                   roles={"SDA": "SDA", "SCL": "SCL"}, symbol=sym,
+                   lib_id="Sensor_Motion:MPU-6050", footprint="FP:x")
+    assert d is not None and d.confidence == "low"
+
+
+def test_draft_low_multiunit():
+    sym = _Sym([("1", "SDA"), ("2", "SCL"), ("3", "VDD"), ("4", "GND")], unit_count=2)
+    d = draft_card(type_name="BME280", address=0x76, bus="I2C",
+                   roles={"SDA": "SDA", "SCL": "SCL"}, symbol=sym,
+                   lib_id="Sensor:BME280", footprint="FP:BME280")
+    assert d is not None and d.confidence == "low"
+
+
+def test_draft_skeleton_without_symbol_is_low():
+    d = draft_card(type_name="MPU6050", address=0x68, bus="I2C",
+                   roles={"SDA": "SDA", "SCL": "SCL"})
+    assert d is not None and d.confidence == "low"
+    assert any("no local symbol" in r for r in d.reasons)
+    # honest placeholders, never a fabricated lib_id
+    assert d.card["lib_id"] == "TODO:confirm"
+
+
+def test_draft_none_when_nothing_to_go_on():
+    assert draft_card(type_name="MYSTERY", address=None, bus=None, roles={}) is None
+
+
+# --- suggest_cards design op (offline, drafts uncarded devices only) ----------
+
+def test_suggest_cards_drafts_uncarded_not_carded(tmp_path):
+    from kicad_mcp.tools.design import _op_suggest_cards
+
+    inc = tmp_path / "include"
+    inc.mkdir()
+    (inc / "config.h").write_text(
+        "#define I2C_SDA_PIN 21\n"
+        "#define I2C_SCL_PIN 22\n"
+        "#define MPU6050_ADDR 0x68\n"        # carded -> placed, NOT drafted
+        "#define BME280_ADDR 0x76\n"         # uncarded -> drafted
+        "#define BME280_WHO_AM_I_EXPECTED 0x60\n"
+    )
+    (tmp_path / "platformio.ini").write_text("[env:esp32dev]\nboard = esp32dev\n")
+
+    r = _op_suggest_cards(firmware_path=str(tmp_path))
+    assert r["status"] == "ok"
+    types = {d["card"]["type"] for d in r["drafts"]}
+    assert types == {"BME280"}                       # MPU6050 is carded -> skipped
+    bme = next(d for d in r["drafts"] if d["card"]["type"] == "BME280")
+    assert bme["confidence"] == "low"                # no symbol -> flagged
+    assert bme["card"]["bus"] == "I2C"
+    assert bme["card"]["roles"] == {"SDA": "SDA", "SCL": "SCL"}
+    assert any("0x76" in r_ or "BME280" in r_ for r_ in bme["reasons"])
+    assert any("WHO_AM_I" in r_ for r_ in bme["reasons"])   # 0x60 hint surfaced

--- a/tests/test_firmware_templates.py
+++ b/tests/test_firmware_templates.py
@@ -24,9 +24,8 @@ from kicad_mcp.utils.firmware.templates import (
     i2c_pullups,
     i2s_mic,
     i2s_output_amps,
-    mcp23017_config,
+    device_config,
     mcu_straps,
-    mpu6050_config,
     power_tree,
     uart_device_header,
     usb_programming,
@@ -134,7 +133,7 @@ def test_mcu_straps_en_and_boot():
     assert any(e.ref == "U1" and e.pin == "EN" for e in en.endpoints)
 
 def test_mcp23017_config_straps_for_0x27():
-    ex = mcp23017_config(_intent(), RefAllocator(_intent()))
+    ex = device_config(_intent(), RefAllocator(_intent()))
     assert not ex.components                             # direct ties, no parts
     # all three address pins on +3V3 (0x27) + RESET high
     plus3_pins = {ep.pin for rail, ep in ex.power if rail == "+3V3"}
@@ -160,7 +159,7 @@ def _hub():
 
 def test_mpu6050_config_straps_each_instance_by_address():
     i = _hub()
-    ex = mpu6050_config(i, RefAllocator(i))
+    ex = device_config(i, RefAllocator(i))
     assert not ex.components                             # direct ties, no parts
     # the 0x68 MPU's AD0 -> GND, the 0x69 MPU's AD0 -> +3V3 (per-instance)
     mpus = {p.ref: p.address for p in i.peripherals if p.type == "MPU6050"}


### PR DESCRIPTION
## Phases 6 + 7 — make the firmware front end data-driven (and air-gapped)

Goal: turn **"a new board needs a code change" into "a new board needs a data edit"** — without losing the honesty guarantees. Implements the device-cards spec (`docs/SPEC_Firmware_Device_Cards.md`), which was **cold-reviewed in a fresh-context pass before implementation** (per the CLAUDE.md spec-review rule); all findings are folded in.

### Phase 6 — device cards (behavior-preserving refactor)

- **`cards.py`** — pure YAML card loader + two-tier validator + the single `compute_address_straps` helper. Imports nothing from `knowledge.py` (no cycle); returns plain dicts.
- The 6 hand-coded `knowledge.py` tables (2 MCUs + 4 peripherals) move to **`devices/**.yaml`**. A new recognized device is now a data file, not a code edit.
- `knowledge.py` keeps the public API (`resolve_mcu` / `resolve_peripheral` / `resolve_mcu_by_part` / `role_to_pin_name`), the template-owned constants (AMS1117, USB-C/CP2102 block, MAX98357A, headers — design knowledge no firmware names), and **back-compat strap wrappers**. `PeripheralInfo` gains optional `config`/`decoupling` via the stdlib `total=False` inheritance pattern (Python 3.10 has no `NotRequired`).
- **`resolve_mcu`**: longest `board_match`-substring (deterministic) — removes the comment-enforced "`esp32-s3` before `esp32`" ordering seam (Rule 3).
- **One generic `device_config` template** replaces `mcp23017_config` + `mpu6050_config`; a new addressable device needs only a `config.address_strap` stanza, no template. New `Expansion.gaps` channel replaces the invalid-address sentinel hack.
- **Two-tier validation**: structural (no-KiCad, unit matrix) + pin-existence against real symbols (KiCad, integration), both reusing `mcu_pinmap.resolve_pin_token` (extracted from `generate._name_or_number` — the cold-review Step-0 precondition).

**Equivalence proven**: all 3 golden integration shapes (speed-cal, audio-S3, track-geometry) route **identically** on real KiCad; every migrated card's pins validate against its symbol; full unit suite green with no assertion edits beyond the two `*_config` → `device_config` references.

### Phase 7 — offline card auto-draft (strictly additive)

- **`autodraft.py`** — propose a card for an **uncarded** peripheral from the bundled I2C-address→identity table, `WHO_AM_I` hints already in provenance, and local symbol-name matching. **No network, ever.**
- **Conservative confidence**: `high` requires *two independent signals agreeing* (the address corroborates the type **and** a clean name-identity role match on a single-unit symbol with no unexplained pins); otherwise `low`, flagged. This mitigates the cold-review false-confidence hazard (a pin merely *named* `SCL` that isn't an I2C clock). Drafts are **surfaced for review, never auto-placed** (honest-by-construction).
- New `design` operation **`suggest_cards(firmware_path)`** (an operation, not a new tool — count stays 17). `intent.candidate_devices` extracted as the single source for "what devices this firmware references" (shared by `build_intent` and auto-draft).

### Scope / non-goals

- **Local-first, air-gapped by default** — cards ship as package data (hatchling includes them automatically, like the existing `data/*.yaml`); there is no runtime network anywhere. Sharing is opt-in file-copy via `KICAD_MCP_DEVICE_DIRS`.
- **Deferred (still planned in the spec):** `board.yaml` non-firmware sidecar (6b); the maintainer-time **pre-fetch** that bulk-generates the bundled library from the KiCad symbol libs, and the multi-user distribution model (Phase 8).

### Verification

- **1519 unit tests** (+54: `test_device_cards` 36, `test_firmware_autodraft` 18), **mypy clean (67 files)**, **9/9 integration** on real KiCad (3 golden shapes + 6 card-pin validations). Tool count unchanged at 17.

### Reviewer notes

- The migration's safety rests on the golden harness: the routed boards are byte-stable, so any behavior change would fail CI. `test_device_cards.py::test_resolution_parity` additionally freezes the exact field values of the 6 entries; `test_backcompat_constants_match_cards` pins that the mirror constants can't drift from the cards.
- Auto-draft's confidence gate is unit-tested with stub symbols (no KiCad), exercising every `low` path: mismatch, uncorroborated address, unexplained pins, multi-unit, no-symbol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)