### PR TITLE
fix(autoroute): FreeRouter offline + headless hygiene (analytics opt-out, macOS no-Dock)

### DIFF
--- a/src/kicad_mcp/tools/pcb_autoroute.py
+++ b/src/kicad_mcp/tools/pcb_autoroute.py
@@ -299,6 +299,29 @@ print(json.dumps({"status": "ok", "unconnected": unconnected}))
     return None
 
 
+def _freerouter_cmd(
+    java_path: str, jar_path: str, dsn_path: str, ses_path: str,
+) -> list[str]:
+    """Build the headless FreeRouter (Freerouting v2) invocation.
+
+    ``-Djava.awt.headless=true`` keeps the JVM from initializing AWT on macOS
+    (which otherwise creates a dock icon and steals window focus every run);
+    ``--gui.enabled=false`` suppresses FreeRouter's own UI.
+
+    ``--usage_and_diagnostic_data.disable_analytics=true`` is mandatory for an
+    air-gapped/offline design: Freerouting v2 otherwise POSTs usage analytics to
+    ``api.freerouting.app`` on every run. Verified on v2.2.3 — the flag silences
+    the analytics call entirely (it also quiets the version-check phone-home).
+    """
+    return [
+        java_path, "-Djava.awt.headless=true", "-jar", jar_path,
+        "-de", dsn_path,
+        "-do", ses_path,
+        "--gui.enabled=false",
+        "--usage_and_diagnostic_data.disable_analytics=true",
+    ]
+
+
 def _run_freerouter_pass(
     java_path: str,
     jar_path: str,
@@ -313,12 +336,7 @@ def _run_freerouter_pass(
     If *job_id* is given, the subprocess PID is stored in
     ``_autoroute_jobs[job_id]["pid"]`` so cancel_autoroute can kill it.
     """
-    cmd = [
-        java_path, "-Djava.awt.headless=true", "-jar", jar_path,
-        "-de", dsn_path,
-        "-do", ses_path,
-        "--gui.enabled=false",
-    ]
+    cmd = _freerouter_cmd(java_path, jar_path, dsn_path, ses_path)
 
     proc = subprocess.Popen(
         cmd,

--- a/src/kicad_mcp/tools/pcb_autoroute.py
+++ b/src/kicad_mcp/tools/pcb_autoroute.py
@@ -304,9 +304,13 @@ def _freerouter_cmd(
 ) -> list[str]:
     """Build the headless FreeRouter (Freerouting v2) invocation.
 
-    ``-Djava.awt.headless=true`` keeps the JVM from initializing AWT on macOS
-    (which otherwise creates a dock icon and steals window focus every run);
-    ``--gui.enabled=false`` suppresses FreeRouter's own UI.
+    Three layers keep it from grabbing the screen, because ``--gui.enabled=false``
+    alone (FreeRouter's own UI switch) is not enough — the JVM still inits AWT:
+      * ``-Djava.awt.headless=true`` — no AWT windows.
+      * ``-Dapple.awt.UIElement=true`` — macOS LSUIElement: run as a background
+        accessory with NO Dock icon and NO focus steal. ``headless=true`` alone
+        does not stop the Cocoa app delegate from claiming a Dock slot + focus
+        on every run; this does. (A no-op on non-macOS.)
 
     ``--usage_and_diagnostic_data.disable_analytics=true`` is mandatory for an
     air-gapped/offline design: Freerouting v2 otherwise POSTs usage analytics to
@@ -314,7 +318,10 @@ def _freerouter_cmd(
     the analytics call entirely (it also quiets the version-check phone-home).
     """
     return [
-        java_path, "-Djava.awt.headless=true", "-jar", jar_path,
+        java_path,
+        "-Djava.awt.headless=true",
+        "-Dapple.awt.UIElement=true",
+        "-jar", jar_path,
         "-de", dsn_path,
         "-do", ses_path,
         "--gui.enabled=false",

--- a/tests/test_pcb_autoroute.py
+++ b/tests/test_pcb_autoroute.py
@@ -54,8 +54,13 @@ class TestFreerouterCmd:
         assert "--gui.enabled=false" in self._cmd()
 
     def test_headless_awt(self):
-        # Keeps the JVM from stealing window focus on macOS every run.
+        # Keeps the JVM from initializing AWT windows.
         assert "-Djava.awt.headless=true" in self._cmd()
+
+    def test_macos_background_accessory(self):
+        # LSUIElement: no Dock icon / no focus steal on macOS (headless alone
+        # doesn't stop the Cocoa delegate claiming a Dock slot every run).
+        assert "-Dapple.awt.UIElement=true" in self._cmd()
 
     def test_passes_dsn_and_ses_paths(self):
         cmd = self._cmd()

--- a/tests/test_pcb_autoroute.py
+++ b/tests/test_pcb_autoroute.py
@@ -19,6 +19,7 @@ from kicad_mcp.tools.pcb_autoroute import (
     _autoroute_lock,
     _cleanup_stale_jobs,
     _select_best_pass,
+    _freerouter_cmd,
     MAX_CONCURRENT_JOBS,
 )
 
@@ -37,6 +38,34 @@ def pcb_file(tmp_path):
     pcb = tmp_path / "test.kicad_pcb"
     pcb.write_text('(kicad_pcb (version 20240108) (generator "test"))\n')
     return str(pcb)
+
+
+class TestFreerouterCmd:
+    """The FreeRouter invocation must disable analytics — Freerouting v2 phones
+    home to api.freerouting.app on every run, which an air-gapped design forbids."""
+
+    def _cmd(self):
+        return _freerouter_cmd("/usr/bin/java", "/x/fr.jar", "/x/b.dsn", "/x/b.ses")
+
+    def test_disables_analytics(self):
+        assert "--usage_and_diagnostic_data.disable_analytics=true" in self._cmd()
+
+    def test_headless_gui(self):
+        assert "--gui.enabled=false" in self._cmd()
+
+    def test_headless_awt(self):
+        # Keeps the JVM from stealing window focus on macOS every run.
+        assert "-Djava.awt.headless=true" in self._cmd()
+
+    def test_passes_dsn_and_ses_paths(self):
+        cmd = self._cmd()
+        assert cmd[cmd.index("-de") + 1] == "/x/b.dsn"
+        assert cmd[cmd.index("-do") + 1] == "/x/b.ses"
+
+    def test_runs_the_jar(self):
+        cmd = self._cmd()
+        assert cmd[0] == "/usr/bin/java"
+        assert cmd[cmd.index("-jar") + 1] == "/x/fr.jar"
 
 
 class TestSelectBestPass:


### PR DESCRIPTION
Two follow-on fixes to the FreeRouter invocation that were pushed to the
#54 branch *after* it had already rebase-merged, so they were stranded.
Both touch only `pcb_autoroute.py` + its test.

The FreeRouter command is now built by a pure, unit-tested `_freerouter_cmd()`
helper so these flags can't silently drift or get dropped in a refactor.

## Analytics opt-out (air-gap)
Freerouting v2.2.3 POSTs usage analytics to `api.freerouting.app` on every
run (surfaces as a WARN when it 501s). An offline/air-gapped-by-design tool
must not do that. Add `--usage_and_diagnostic_data.disable_analytics=true`
— verified on v2.2.3 it silences the analytics POST entirely (and also
quiets the version-check phone-home).

## macOS no-Dock / no-focus-steal (completes the headless fix on main)
`-Djava.awt.headless=true` (already on main) is necessary but **not
sufficient** on macOS: even headless, the Freerouting JVM's Cocoa app
delegate claims a Dock slot and steals window focus every run. Add
`-Dapple.awt.UIElement=true` (LSUIElement) so it runs as a background
accessory — no Dock icon, no focus steal. No-op off macOS.

Pinned by `TestFreerouterCmd` (analytics flag, both headless flags, jar +
DSN/SES paths). Verified routing still works (autoroute smoke) with all
flags, and the run no longer surfaces on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)