### PR TITLE
feat(firmware): placement locus — remote devices as screw terminals

### DIFF
--- a/src/kicad_mcp/tools/design.py
+++ b/src/kicad_mcp/tools/design.py
@@ -44,6 +44,7 @@ from kicad_mcp.utils.firmware.intent import (
 from kicad_mcp.utils.firmware.knowledge import resolve_peripheral
 from kicad_mcp.utils.firmware.sidecar import (
     SidecarError,
+    advise_unspecified_placement,
     apply_sidecar,
     find_sidecar,
     load_sidecar,
@@ -71,18 +72,45 @@ def _find_config_header(firmware_path: str) -> Optional[Path]:
     return None
 
 
+def _peripheral_entry(intent: DesignIntent, p: Any) -> dict[str, Any]:
+    """One manifest row. ``locus`` is carried only when a peripheral is NOT a
+    plain on-board part, so the BOM distinguishes placed parts, documented
+    off-board devices, and the terminals they land on (§8)."""
+    pl = intent.placements.get(p.ref)
+    locus = pl.locus if pl is not None else p.locus
+    entry: dict[str, Any] = {"ref": p.ref, "type": p.type}
+    if locus != "on_board":
+        entry["locus"] = locus
+    return entry
+
+
 def _summary(intent: DesignIntent) -> dict[str, Any]:
     by_kind: dict[str, int] = {}
     for n in intent.nets:
         by_kind[n.kind] = by_kind.get(n.kind, 0) + 1
-    return {
+    # Field-wired devices: documented off-board, with the terminal they land on
+    # (from the remote_device gaps the templates emit) — honest BOM (§8).
+    remote_devices = [
+        {"detail": g.detail,
+         "terminal": g.resolved_components[0] if g.resolved_components else None}
+        for g in intent.gaps if g.kind == "remote_device"
+    ]
+    out: dict[str, Any] = {
         "mcu": intent.mcu.part if intent.mcu else None,
-        "peripherals": [{"ref": p.ref, "type": p.type} for p in intent.peripherals],
+        "peripherals": [_peripheral_entry(intent, p) for p in intent.peripherals],
         "net_count": len(intent.nets),
         "nets_by_kind": by_kind,
         "gap_count": len(intent.gaps),
         "unmodeled_macros": intent.provenance.get("unparsed_count", 0),
     }
+    if remote_devices:
+        out["remote_devices"] = remote_devices
+    if intent.connector_legends:
+        out["terminals"] = [
+            {"ref": L.ref, "device": L.device, "positions": L.positions}
+            for L in intent.connector_legends
+        ]
+    return out
 
 
 def _gaps_list(intent: DesignIntent) -> list[dict[str, str]]:
@@ -151,6 +179,9 @@ def _op_import(*, firmware_path: Optional[str], out_path: Optional[str]) -> dict
             return {"status": "error", "code": "invalid_sidecar",
                     "message": f"Malformed {sidecar_path}: {e}"}
         sidecar_applied = sidecar_path
+
+    # Nudge (don't assume): list commonly-field-wired buses with no locus set.
+    advise_unspecified_placement(intent)
 
     dest = Path(out_path) if out_path else cfg.parent / "design_intent.yaml"
     try:

--- a/src/kicad_mcp/tools/pcb_pipeline.py
+++ b/src/kicad_mcp/tools/pcb_pipeline.py
@@ -10,6 +10,8 @@ from typing import Any, Dict, List
 
 from fastmcp import FastMCP
 
+from kicad_mcp.tools.pcb_silkscreen import _op_auto_fix_silkscreen
+from kicad_mcp.utils.firmware.intent import load_intent
 from kicad_mcp.utils.keepout_helpers import KEEPOUT_HELPER, LIB_SEARCH_HELPER
 from kicad_mcp.utils.kicad_cli import KiCadCLIError, get_kicad_cli_path
 from kicad_mcp.utils.net_injection import existing_net_codes, inject_net_definitions
@@ -970,6 +972,77 @@ print(json.dumps({
     }, timeout=60.0)
 
 
+def _step_silkscreen_legends(
+    pcb_path: str, legends: List[Dict[str, Any]], offset_mm: float = 2.0,
+) -> Dict[str, Any]:
+    """Add a per-position silk legend to each synthesized connector/terminal.
+
+    For a field-wired terminal the silk legend IS the wiring documentation, so a
+    connector is not complete without it (placement-locus §7.1). For each
+    ``ConnectorLegend`` (``{ref, positions, device}``): label every pad
+    ``i`` (1-indexed) with ``positions[i-1]`` placed ``offset_mm`` above the pad
+    centre, and set the footprint value to the device identity. After labelling,
+    the existing silk overlap auto-fixer nudges any silk-over-pad clear (shared
+    single source — same machinery the audit router uses)."""
+    if not legends:
+        return {"status": "ok", "labels_added": 0, "skipped": "no connector legends"}
+
+    script = r"""
+import pcbnew, json, sys
+
+params = json.loads(open(sys.argv[1]).read())
+board = pcbnew.LoadBoard(params["pcb_path"])
+offset = pcbnew.FromMM(params["offset_mm"])
+size = pcbnew.FromMM(1.0)
+thick = pcbnew.FromMM(0.15)
+silk = board.GetLayerID("F.SilkS")
+
+by_ref = {fp.GetReference(): fp for fp in board.GetFootprints()}
+labels_added = 0
+missing = []
+for leg in params["legends"]:
+    fp = by_ref.get(leg["ref"])
+    if fp is None:
+        missing.append(leg["ref"])
+        continue
+    fp.SetValue(leg["device"])
+    positions = leg["positions"]
+    for pad in fp.Pads():
+        num = pad.GetNumber()
+        if not num.isdigit():
+            continue
+        idx = int(num) - 1
+        if idx < 0 or idx >= len(positions) or not positions[idx]:
+            continue
+        p = pad.GetPosition()
+        txt = pcbnew.PCB_TEXT(board)
+        txt.SetText(positions[idx])
+        txt.SetPosition(pcbnew.VECTOR2I(p.x, p.y - offset))
+        txt.SetLayer(silk)
+        txt.SetTextSize(pcbnew.VECTOR2I(size, size))
+        txt.SetTextThickness(thick)
+        board.Add(txt)
+        labels_added += 1
+
+board.Save(params["pcb_path"])
+print(json.dumps({"status": "ok", "labels_added": labels_added,
+                  "missing_refs": missing}))
+"""
+    res = run_pcbnew_script(script, params={
+        "pcb_path": pcb_path, "legends": legends, "offset_mm": offset_mm,
+    }, timeout=60.0)
+    # Tidy footprint refdes/value silk the new labels may crowd (best-effort).
+    # NOTE: the auto-fixer relocates footprint FIELDS, not the free-text legend
+    # labels themselves — those are placed clear of the pad by construction.
+    if res.get("status") == "ok" and res.get("labels_added", 0) > 0:
+        fix = _op_auto_fix_silkscreen(pcb_path)
+        res["overlap_autofix"] = {
+            "moved": fix.get("moved"), "hidden": fix.get("hidden"),
+            "error": fix.get("error"),
+        }
+    return res
+
+
 def _step_export_gerbers(pcb_path: str) -> Dict[str, Any]:
     """Step 8 (optional): Export Gerber + drill files and create ZIP."""
     try:
@@ -1060,12 +1133,14 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
         ground_net: str = "GND",
         autoroute_passes: int = 1,
         export_gerbers: bool = False,
+        intent_path: str = "",
     ) -> Dict[str, Any]:
         """Build a complete routed PCB from a KiCad schematic in one step.
 
         Runs the full pipeline: extract netlist → create PCB → load
         footprints → assign nets → smart placement → autoroute →
-        add ground planes → fill zones → (optionally) export Gerbers.
+        add ground planes → fill zones → silk legends → (optionally)
+        export Gerbers.
 
         Requires a KiCad project with a schematic (.kicad_sch) that has
         footprints assigned to all components.  Creates the PCB file
@@ -1083,6 +1158,10 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
                 non-deterministic; best result is kept.
             export_gerbers: Generate Gerber/drill files and ZIP for
                 fabrication upload (default False).
+            intent_path: Optional path to the design-intent YAML. When given,
+                its connector legends drive a silk-legend pass that labels each
+                synthesized terminal's positions (the field-wiring documentation)
+                — the firmware front end passes the same intent it generated from.
         """
         if not os.path.exists(project_path):
             return {"error": f"Project file not found: {project_path}"}
@@ -1185,6 +1264,23 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
         step = _step_add_zones_and_fill(pcb_path, ground_net)
         _record("zones", step)
         # Non-fatal
+
+        # Step 7.5: Silk legends for synthesized terminals (firmware front end).
+        # Field-wired terminals carry their wiring documentation on the silk.
+        if intent_path and os.path.exists(intent_path):
+            try:
+                _intent = load_intent(intent_path)
+                _legends = [
+                    {"ref": L.ref, "positions": L.positions, "device": L.device}
+                    for L in _intent.connector_legends
+                ]
+            except Exception as e:  # noqa: BLE001 — a bad intent must not abort the build
+                _record("silkscreen_legends",
+                        {"error": f"could not read intent {intent_path}: {e}"})
+            else:
+                step = _step_silkscreen_legends(pcb_path, _legends)
+                _record("silkscreen_legends", step)
+                # Non-fatal — silk is documentation, never blocks fabrication.
 
         # Step 8: Export gerbers (optional)
         if export_gerbers:

--- a/src/kicad_mcp/tools/pcb_pipeline.py
+++ b/src/kicad_mcp/tools/pcb_pipeline.py
@@ -973,17 +973,19 @@ print(json.dumps({
 
 
 def _step_silkscreen_legends(
-    pcb_path: str, legends: List[Dict[str, Any]], offset_mm: float = 2.0,
+    pcb_path: str, legends: List[Dict[str, Any]], margin_mm: float = 0.5,
 ) -> Dict[str, Any]:
     """Add a per-position silk legend to each synthesized connector/terminal.
 
     For a field-wired terminal the silk legend IS the wiring documentation, so a
     connector is not complete without it (placement-locus §7.1). For each
-    ``ConnectorLegend`` (``{ref, positions, device}``): label every pad
-    ``i`` (1-indexed) with ``positions[i-1]`` placed ``offset_mm`` above the pad
-    centre, and set the footprint value to the device identity. After labelling,
-    the existing silk overlap auto-fixer nudges any silk-over-pad clear (shared
-    single source — same machinery the audit router uses)."""
+    ``ConnectorLegend`` (``{ref, positions, device}``): label every pad ``i``
+    (1-indexed) with ``positions[i-1]`` placed ``margin_mm`` above that pad's TOP
+    EDGE (adaptive — terminal-block pads are large, so a fixed centre-offset would
+    sit on the pad), and set the footprint value to the device identity. After
+    labelling, the existing silk overlap auto-fixer tidies footprint fields the
+    new text may crowd (shared single source — same machinery the audit router
+    uses)."""
     if not legends:
         return {"status": "ok", "labels_added": 0, "skipped": "no connector legends"}
 
@@ -992,8 +994,8 @@ import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
 board = pcbnew.LoadBoard(params["pcb_path"])
-offset = pcbnew.FromMM(params["offset_mm"])
-size = pcbnew.FromMM(1.0)
+margin = pcbnew.FromMM(params["margin_mm"])
+size = pcbnew.FromMM(0.8)
 thick = pcbnew.FromMM(0.15)
 silk = board.GetLayerID("F.SilkS")
 
@@ -1015,9 +1017,13 @@ for leg in params["legends"]:
         if idx < 0 or idx >= len(positions) or not positions[idx]:
             continue
         p = pad.GetPosition()
+        bb = pad.GetBoundingBox()
+        # Place the text CENTRE above the pad's top edge so its bbox is y-disjoint
+        # from the pad (touching counts as overlap, so include half the glyph).
+        ty = bb.GetTop() - margin - size // 2
         txt = pcbnew.PCB_TEXT(board)
         txt.SetText(positions[idx])
-        txt.SetPosition(pcbnew.VECTOR2I(p.x, p.y - offset))
+        txt.SetPosition(pcbnew.VECTOR2I(p.x, ty))
         txt.SetLayer(silk)
         txt.SetTextSize(pcbnew.VECTOR2I(size, size))
         txt.SetTextThickness(thick)
@@ -1029,7 +1035,7 @@ print(json.dumps({"status": "ok", "labels_added": labels_added,
                   "missing_refs": missing}))
 """
     res = run_pcbnew_script(script, params={
-        "pcb_path": pcb_path, "legends": legends, "offset_mm": offset_mm,
+        "pcb_path": pcb_path, "legends": legends, "margin_mm": margin_mm,
     }, timeout=60.0)
     # Tidy footprint refdes/value silk the new labels may crowd (best-effort).
     # NOTE: the auto-fixer relocates footprint FIELDS, not the free-text legend

--- a/src/kicad_mcp/tools/pcb_pipeline.py
+++ b/src/kicad_mcp/tools/pcb_pipeline.py
@@ -1273,6 +1273,10 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
 
         # Step 7.5: Silk legends for synthesized terminals (firmware front end).
         # Field-wired terminals carry their wiring documentation on the silk.
+        # Strictly NON-FATAL: silk is documentation, never blocks fabrication —
+        # so a bad intent OR a pcbnew failure inside the step (run_pcbnew_script
+        # RAISES on subprocess error/timeout) is recorded, never propagated, so it
+        # cannot abort an already-routed board.
         if intent_path and os.path.exists(intent_path):
             try:
                 _intent = load_intent(intent_path)
@@ -1280,13 +1284,11 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
                     {"ref": L.ref, "positions": L.positions, "device": L.device}
                     for L in _intent.connector_legends
                 ]
-            except Exception as e:  # noqa: BLE001 — a bad intent must not abort the build
-                _record("silkscreen_legends",
-                        {"error": f"could not read intent {intent_path}: {e}"})
-            else:
                 step = _step_silkscreen_legends(pcb_path, _legends)
                 _record("silkscreen_legends", step)
-                # Non-fatal — silk is documentation, never blocks fabrication.
+            except Exception as e:  # noqa: BLE001 — documentation step, never fatal
+                _record("silkscreen_legends",
+                        {"error": f"silk legend step failed (non-fatal): {e}"})
 
         # Step 8: Export gerbers (optional)
         if export_gerbers:

--- a/src/kicad_mcp/utils/firmware/connectors.py
+++ b/src/kicad_mcp/utils/firmware/connectors.py
@@ -1,0 +1,216 @@
+"""Unified terminal/connector synthesis — ONE helper for every "place a connector
+and route its nets to numbered positions" operation.
+
+Three pre-existing fragments each re-encoded this structural job a different way
+(module-card headers, the I2S speaker header, the board.yaml ``extra_connectors``)
+— exactly the single-source-of-truth violation CLAUDE.md's Syntactic-Semantic
+Seam rule warns about. ``synthesize_connector`` owns the mechanics they share:
+
+  * **symbol sizing** — pick ``Screw_Terminal_01x{N}`` / ``Conn_01x{N}`` for N
+    positions (pins numbered ``"1"``..``"N"``),
+  * **pin-count validation** — N must fit the symbol (a check none of the three
+    fragments did — a latent bug),
+  * **ref allocation** — through ONE caller-supplied allocator,
+  * **net retargeting** — each position contributes an ``Endpoint`` onto its net,
+  * **legend emission** — a ``ConnectorLegend`` so the field-wiring silk legend is
+    generated identically for every connector.
+
+What it does NOT conflate: the symbol *family* (a field-wiring screw terminal vs
+an on-board socket) stays a caller choice via ``connector_type`` — see §4 of
+SPEC_Firmware_Placement_Locus.md.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+from kicad_mcp.utils.firmware.intent import (
+    ConnectorLegend,
+    Endpoint,
+    Peripheral,
+)
+
+# --- symbol / footprint families (verified present on KiCad 10) --------------
+# Pins are numbered "1".."N"; the "01x{NN}" token encodes the position count.
+_SCREW_SYM = "Connector:Screw_Terminal_01x{n:02d}"
+_HEADER_SYM = "Connector_Generic:Conn_01x{n:02d}"
+
+# Phoenix MKDS-1,5 5.08 mm screw-terminal block — the field-wiring default
+# (Open Decision 4). The "-{n}-" series segment is NOT zero-padded; the
+# "1x{n:02d}" footprint segment IS. Present for N = 2..16.
+_PHOENIX_FP = ("TerminalBlock_Phoenix:TerminalBlock_Phoenix_MKDS-1,5-{n}-5.08_"
+               "1x{n:02d}_P5.08mm_Horizontal")
+_PHOENIX_RANGE = range(2, 17)
+# Universal fallback (lower quality for field wiring, but always present) — used
+# when Phoenix has no part for N (e.g. a 1-position terminal).
+_PIN_HEADER_FP = "Connector_PinHeader_2.54mm:PinHeader_1x{n:02d}_P2.54mm_Vertical"
+
+# connector_type -> (symbol template, ref prefix, screw?). ``screw`` selects the
+# Phoenix terminal-block footprint default; the others use the pin-header default.
+_CONNECTOR_TYPES: dict[str, tuple[str, str, bool]] = {
+    "screw_terminal": (_SCREW_SYM, "J", True),
+    "pin_header":     (_HEADER_SYM, "J", False),
+    "pluggable":      (_HEADER_SYM, "J", False),
+}
+
+# Type tag stored on the synthesized Peripheral (informational; not a symbol).
+_TYPE_TAG = {
+    "screw_terminal": "TERM",
+    "pin_header": "HDR",
+    "pluggable": "CONN",
+}
+
+_SYMBOL_PIN_RE = re.compile(r"_01x(\d+)\b")
+
+
+def symbol_pin_count(lib_id: str) -> Optional[int]:
+    """Position count encoded in a ``…_01x{NN}`` symbol id, or None if the id does
+    not encode one (an arbitrary lib_id such as ``Connector:Barrel_Jack``)."""
+    m = _SYMBOL_PIN_RE.search(lib_id)
+    return int(m.group(1)) if m else None
+
+
+def default_footprint(connector_type: str, n: int) -> str:
+    """The series-default footprint for ``n`` positions of ``connector_type``."""
+    spec = _CONNECTOR_TYPES.get(connector_type)
+    screw = spec[2] if spec else False
+    if screw and n in _PHOENIX_RANGE:
+        return _PHOENIX_FP.format(n=n)
+    return _PIN_HEADER_FP.format(n=n)
+
+
+@dataclass
+class ConnectorPosition:
+    """One boundary-crossing signal landing on a connector position.
+
+    ``net_name`` is the net this position joins (an existing signal/power net, or
+    a new one). ``label`` is the short silk-legend text (signal/role/rail name).
+    ``pin`` pins the pad number explicitly (an arbitrary-pinout connector such as
+    a barrel jack); left None, positions are assigned pads ``1..N`` in order.
+    """
+    net_name: str
+    label: str
+    pin: Optional[str] = None
+
+
+class ConnectorError(ValueError):
+    """A connector that cannot be synthesized (too many positions for the symbol,
+    duplicate pads, …). Raised loudly — never silently truncated."""
+
+
+def synthesize_connector(
+    positions: list[ConnectorPosition],
+    *,
+    alloc: Callable[[str], str],
+    device: str,
+    connector_type: str = "screw_terminal",
+    lib_id: Optional[str] = None,
+    footprint: Optional[str] = None,
+    value: Optional[str] = None,
+    origin: str = "template",
+) -> tuple[Peripheral, list[tuple[str, Endpoint]], ConnectorLegend]:
+    """Synthesize a connector for ``positions`` and return
+    ``(connector_peripheral, [(net_name, Endpoint), …], ConnectorLegend)``.
+
+    The caller appends each ``(net_name, Endpoint)`` onto that net (the same
+    "join" channel templates already use), adds the Peripheral, and appends the
+    legend to ``intent.connector_legends``.
+
+    ``alloc(prefix) -> ref`` is the caller's collision-free ref allocator (the
+    ONE allocator the §4 consolidation routes every fragment through).
+    """
+    if not positions:
+        raise ConnectorError(f"connector for {device!r}: needs at least one position")
+    if connector_type not in _CONNECTOR_TYPES:
+        raise ConnectorError(
+            f"connector for {device!r}: unknown connector_type {connector_type!r}; "
+            f"valid: {sorted(_CONNECTOR_TYPES)}"
+        )
+    n = len(positions)
+    sym_tmpl, prefix, _ = _CONNECTOR_TYPES[connector_type]
+    chosen_lib = lib_id if lib_id is not None else sym_tmpl.format(n=n)
+
+    # Pin-count validation — N must fit the symbol when the symbol encodes a count.
+    cap = symbol_pin_count(chosen_lib)
+    if cap is not None and n > cap:
+        raise ConnectorError(
+            f"connector for {device!r}: {n} positions exceed symbol "
+            f"{chosen_lib!r} pin count {cap}"
+        )
+
+    ref = alloc(prefix)
+    chosen_fp = (footprint if footprint is not None
+                 else default_footprint(connector_type, n))
+
+    # Assign pad numbers: explicit ``pin`` is honored; the rest fill the lowest
+    # free integers 1..N in order. Duplicate pads are an error, not a silent
+    # collapse (two signals onto one pad would short them).
+    taken: set[str] = {p.pin for p in positions if p.pin is not None}
+    if len(taken) != len([p for p in positions if p.pin is not None]):
+        raise ConnectorError(f"connector for {device!r}: duplicate explicit pad numbers")
+    joins: list[tuple[str, Endpoint]] = []
+    assigned: list[tuple[str, str, str]] = []   # (pad, label, net_name)
+    auto = 1
+    for p in positions:
+        if p.pin is not None:
+            pad = str(p.pin)
+        else:
+            while str(auto) in taken:
+                auto += 1
+            pad = str(auto)
+            taken.add(pad)
+            auto += 1
+        joins.append((p.net_name, Endpoint(ref=ref, pin=pad)))
+        assigned.append((pad, p.label, p.net_name))
+
+    if cap is not None:
+        for pad, _label, _net in assigned:
+            ip = int(pad) if pad.isdigit() else None
+            if ip is not None and ip > cap:
+                raise ConnectorError(
+                    f"connector for {device!r}: pad {pad} exceeds symbol "
+                    f"{chosen_lib!r} pin count {cap}"
+                )
+
+    legend = _build_legend(ref, device, assigned)
+
+    conn = Peripheral(
+        ref=ref,
+        type=_TYPE_TAG.get(connector_type, "CONN"),
+        lib_id=chosen_lib,
+        value=value if value is not None else device,
+        footprint=chosen_fp,
+        origin=origin,
+    )
+    return conn, joins, legend
+
+
+def _build_legend(
+    ref: str, device: str, assigned: list[tuple[str, str, str]]
+) -> ConnectorLegend:
+    """``ConnectorLegend.positions[i]`` is the silk label for pad number ``i+1``
+    (the contiguous ``1..N`` case the synthesized terminals always produce). Pads
+    that aren't plain integers (an arbitrary-pinout connector) are skipped — the
+    legend documents the field-wired terminals, where pads are always 1..N.
+
+    Open Decision 6 dedup: two positions on the SAME net sharing a label is fine
+    (two ``GND`` taps → both ``GND``). Two DIFFERENT nets that shorten to the same
+    label would be ambiguous on the silk, so the later one gets a ``_2`` suffix."""
+    int_pads = [(int(pad), label, net) for pad, label, net in assigned if pad.isdigit()]
+    positions: list[str] = []
+    if int_pads:
+        size = max(p for p, _, _ in int_pads)
+        positions = [""] * size
+        label_net: dict[str, str] = {}   # label -> first net that claimed it
+        used: dict[str, int] = {}
+        for pad, label, net in int_pads:
+            owner = label_net.get(label)
+            if owner is None or owner == net:
+                label_net.setdefault(label, net)
+                final = label
+            else:                         # different net, same label -> suffix
+                used[label] = used.get(label, 1) + 1
+                final = f"{label}_{used[label]}"
+            positions[pad - 1] = final
+    return ConnectorLegend(ref=ref, positions=positions, device=device)

--- a/src/kicad_mcp/utils/firmware/connectors.py
+++ b/src/kicad_mcp/utils/firmware/connectors.py
@@ -54,6 +54,8 @@ _CONNECTOR_TYPES: dict[str, tuple[str, str, bool]] = {
     "pluggable":      (_HEADER_SYM, "J", False),
 }
 
+VALID_CONNECTOR_TYPES = frozenset(_CONNECTOR_TYPES)
+
 # Type tag stored on the synthesized Peripheral (informational; not a symbol).
 _TYPE_TAG = {
     "screw_terminal": "TERM",

--- a/src/kicad_mcp/utils/firmware/generate.py
+++ b/src/kicad_mcp/utils/firmware/generate.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
-from kicad_mcp.utils.firmware.intent import DesignIntent
+from kicad_mcp.utils.firmware.intent import DesignIntent, is_remote
 from kicad_mcp.utils.firmware.knowledge import role_to_pin_name
 from kicad_mcp.utils.firmware.mcu_pinmap import (
     gpio_to_pin_number,
@@ -46,8 +46,13 @@ def generate_schematic(intent: DesignIntent, schematic_path: str) -> dict[str, A
     to_place: list[tuple[str, Optional[str], str, Optional[str]]] = [
         (intent.mcu.ref, intent.mcu.lib_id, intent.mcu.part, intent.mcu.footprint)
     ]
+    # Remote peripherals are field-wired (a terminal carries their nets), so they
+    # are documented in the BOM but never placed as a symbol — their original pin
+    # endpoints then drop out of the wiring loop (ref not in ``placed``), leaving
+    # only the synthesized terminal wired. (See remote_peripherals template.)
     to_place += [
-        (p.ref, p.lib_id, p.value or p.type, p.footprint) for p in intent.peripherals
+        (p.ref, p.lib_id, p.value or p.type, p.footprint)
+        for p in intent.peripherals if not is_remote(intent, p.ref)
     ]
 
     placed: dict[str, Any] = {}

--- a/src/kicad_mcp/utils/firmware/intent.py
+++ b/src/kicad_mcp/utils/firmware/intent.py
@@ -88,6 +88,22 @@ class ConnectorLegend:
 
 
 @dataclass
+class Placement:
+    """A board.yaml placement directive — where a device physically lives relative
+    to the board. The SINGLE source for the locus decision (CLAUDE.md Rule 3),
+    keyed in ``DesignIntent.placements`` by the handle that exists in the intent:
+    a **bus stem** (``CMCA_MIC``) for a bus-template device, or a **peripheral
+    ref** (``U2``) for a carded device. ``device`` is the human-supplied identity
+    — firmware names these only in comments, so it cannot be recovered, only
+    declared (honest-by-construction)."""
+    locus: str = "on_board"          # on_board | remote | on_board_with_remote_io
+    device: Optional[str] = None     # field-wired device identity (legend + BOM)
+    connector: str = "screw_terminal"   # screw_terminal | pin_header | pluggable
+    footprint: Optional[str] = None  # series-default override for the terminal
+    external_io: list[str] = field(default_factory=list)  # roles crossing (remote_io)
+
+
+@dataclass
 class Mcu:
     ref: str
     part: str
@@ -125,7 +141,25 @@ class DesignIntent:
     nets: list[Net] = field(default_factory=list)
     gaps: list[Gap] = field(default_factory=list)
     connector_legends: list[ConnectorLegend] = field(default_factory=list)
+    # board.yaml placement directives, keyed by bus stem or peripheral ref.
+    placements: dict[str, "Placement"] = field(default_factory=dict)
     provenance: dict[str, Any] = field(default_factory=dict)
+
+
+# --- locus helpers (single source for the remote check) ----------------------
+
+VALID_LOCI = ("on_board", "remote", "on_board_with_remote_io")
+
+
+def placement_for(intent: "DesignIntent", key: str) -> Optional[Placement]:
+    """The placement directive for a bus stem or peripheral ref, or None."""
+    return intent.placements.get(key)
+
+
+def is_remote(intent: "DesignIntent", key: str) -> bool:
+    """True if ``key`` (bus stem or peripheral ref) is declared fully remote."""
+    pl = intent.placements.get(key)
+    return pl is not None and pl.locus == "remote"
 
 
 # --- platformio board detection ----------------------------------------------
@@ -412,6 +446,10 @@ def from_dict(d: dict[str, Any]) -> DesignIntent:
             ConnectorLegend(**_only_fields(ConnectorLegend, c))
             for c in d.get("connector_legends", [])
         ],
+        placements={
+            k: Placement(**_only_fields(Placement, v))
+            for k, v in (d.get("placements", {}) or {}).items()
+        },
         provenance=d.get("provenance", {}),
     )
 

--- a/src/kicad_mcp/utils/firmware/intent.py
+++ b/src/kicad_mcp/utils/firmware/intent.py
@@ -26,7 +26,7 @@ from kicad_mcp.utils.firmware.parse import (
     address_base,
 )
 
-SCHEMA_VERSION = 3  # v3: typed buses (I2S/I2C/UART) for bus-driven templates
+SCHEMA_VERSION = 4  # v4: placement locus + connector legends (placement-locus phase)
 
 # Gap categories firmware is structurally blind to — always emitted so the doc
 # is honest about what a human/LLM must still supply.
@@ -68,6 +68,23 @@ class Peripheral:
     bus: Optional[str] = None
     address: Optional[int] = None
     origin: str = "imported"     # "imported"|"template"|"user"
+    # Placement locus — where the device physically lives relative to the board.
+    # A board-level decision (firmware cannot know if a mic is reflowed or hung on
+    # 18" of wire), so it is set from board.yaml, never firmware-derived.
+    #   on_board                 -> place the symbol/footprint (default)
+    #   remote                   -> not placed; its nets cross to a terminal
+    #   on_board_with_remote_io  -> placed, but external-load nets cross to a terminal
+    locus: str = "on_board"
+
+
+@dataclass
+class ConnectorLegend:
+    """Per-connector silk-legend metadata, populated by ``synthesize_connector``,
+    consumed by ``pcb_pipeline`` (``_step_silkscreen_legends``). The silk legend
+    IS the field-wiring documentation for a terminal — not cosmetic."""
+    ref: str                 # e.g. "J3" — identifies the footprint in the placed PCB
+    positions: list[str]     # positions[i] = short label for pad number (i+1)
+    device: str              # e.g. "INMP441" — set as the footprint value/description
 
 
 @dataclass
@@ -107,6 +124,7 @@ class DesignIntent:
     buses: list[Bus] = field(default_factory=list)
     nets: list[Net] = field(default_factory=list)
     gaps: list[Gap] = field(default_factory=list)
+    connector_legends: list[ConnectorLegend] = field(default_factory=list)
     provenance: dict[str, Any] = field(default_factory=dict)
 
 
@@ -390,6 +408,10 @@ def from_dict(d: dict[str, Any]) -> DesignIntent:
             for n in d.get("nets", [])
         ],
         gaps=[Gap(**_only_fields(Gap, g)) for g in d.get("gaps", [])],
+        connector_legends=[
+            ConnectorLegend(**_only_fields(ConnectorLegend, c))
+            for c in d.get("connector_legends", [])
+        ],
         provenance=d.get("provenance", {}),
     )
 

--- a/src/kicad_mcp/utils/firmware/knowledge.py
+++ b/src/kicad_mcp/utils/firmware/knowledge.py
@@ -105,8 +105,7 @@ SPH0645 = {
     "vdd": "VDD", "gnd": "GND",
 }
 # Generic module headers (lib_id, footprint). Pin numbers are "1".."N".
-HDR_1X2 = ("Connector_Generic:Conn_01x02",
-           "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical")
+# (1x02 speaker headers are now synthesized via connectors.synthesize_connector.)
 HDR_1X4 = ("Connector_Generic:Conn_01x04",
            "Connector_PinHeader_2.54mm:PinHeader_1x04_P2.54mm_Vertical")
 HDR_1X5 = ("Connector_Generic:Conn_01x05",

--- a/src/kicad_mcp/utils/firmware/sidecar.py
+++ b/src/kicad_mcp/utils/firmware/sidecar.py
@@ -17,6 +17,14 @@ extra_connectors:
     lib_id: Connector:Barrel_Jack
     footprint: "Connector_BarrelJack:BarrelJack_Horizontal"
     nets: {"1": "+5V", "2": "GND"}
+placement:                     # WHERE each device lives (board-level, firmware-blind)
+  CMCA_MIC:                    # keyed by bus stem (or a peripheral ref like U2)
+    locus: remote              # not placed; its signals cross to a screw terminal
+    device: INMP441            # human-supplied identity (firmware names it only in a comment)
+  CMCA_I2S:
+    locus: on_board_with_remote_io   # amp stays on board; speaker leads cross out
+    device: MAX98357A
+    external_io: [outp, outn]
 ```
 """
 from __future__ import annotations
@@ -29,10 +37,20 @@ from typing import Any, Optional
 import yaml
 
 from kicad_mcp.utils.firmware.cards import valid_lib_id
-from kicad_mcp.utils.firmware.intent import DesignIntent, Endpoint, Net, Peripheral
+from kicad_mcp.utils.firmware.connectors import VALID_CONNECTOR_TYPES
+from kicad_mcp.utils.firmware.intent import (
+    DesignIntent,
+    Endpoint,
+    Gap,
+    Net,
+    Placement,
+    Peripheral,
+    VALID_LOCI,
+)
 from kicad_mcp.utils.firmware.power_names import RAILS as _RAILS
 
 _POWER_SOURCES = frozenset({"usb_c", "usb", "barrel", "header", "battery", "screw_terminal"})
+_CONNECTOR_KINDS = VALID_CONNECTOR_TYPES
 _SIDECAR_NAME = "board.yaml"
 
 # A valid KiCad reference is a letter prefix + number (e.g. J1) — no underscores.
@@ -62,6 +80,41 @@ class BoardSidecar:
     power_source: Optional[str] = None
     board_size_mm: Optional[list[float]] = None
     extra_connectors: list[dict[str, Any]] = field(default_factory=list)
+    # placement directives, keyed by bus stem (CMCA_MIC) or peripheral ref (U2).
+    placement: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+
+def _validate_placement(d: dict[str, Any], errs: list[str]) -> None:
+    """Structural validation of the ``placement`` section (no intent yet — the
+    key-exists-in-intent check happens in ``apply_sidecar``)."""
+    placement = d.get("placement")
+    if placement is None:
+        return
+    if not isinstance(placement, dict):
+        errs.append("placement must be a mapping of device-key -> directive")
+        return
+    for key, spec in placement.items():
+        where = f"placement[{key!r}]"
+        if not isinstance(spec, dict):
+            errs.append(f"{where}: must be a mapping")
+            continue
+        locus = spec.get("locus")
+        if locus not in VALID_LOCI:
+            errs.append(f"{where}: locus {locus!r} not in {list(VALID_LOCI)}")
+        conn = spec.get("connector")
+        if conn is not None and conn not in _CONNECTOR_KINDS:
+            errs.append(f"{where}: connector {conn!r} not in {sorted(_CONNECTOR_KINDS)}")
+        if "device" in spec and not isinstance(spec["device"], str):
+            errs.append(f"{where}: device must be a string")
+        if "footprint" in spec and not isinstance(spec["footprint"], str):
+            errs.append(f"{where}: footprint must be a string")
+        eio = spec.get("external_io")
+        if eio is not None and not (isinstance(eio, list)
+                                    and all(isinstance(r, str) for r in eio)):
+            errs.append(f"{where}: external_io must be a list of role strings")
+        if locus == "on_board_with_remote_io" and not eio:
+            errs.append(f"{where}: on_board_with_remote_io requires a non-empty "
+                        "external_io list (the roles that cross to a terminal)")
 
 
 def _validate(d: dict[str, Any]) -> list[str]:
@@ -92,6 +145,7 @@ def _validate(d: dict[str, Any]) -> list[str]:
             for pin, net in nets.items():
                 if not isinstance(pin, str) or not isinstance(net, str):
                     errs.append(f"{where}: nets entries must be pin_str -> net_str")
+    _validate_placement(d, errs)
     return errs
 
 
@@ -112,6 +166,7 @@ def load_sidecar(path: str) -> BoardSidecar:
         power_source=data.get("power_source"),
         board_size_mm=data.get("board_size_mm"),
         extra_connectors=list(data.get("extra_connectors", []) or []),
+        placement=dict(data.get("placement", {}) or {}),
     )
 
 
@@ -175,4 +230,35 @@ def apply_sidecar(
 
     if added_refs:
         _resolve_gap(intent, "connectors", source_name, added_refs)
+
+    _apply_placement(intent, sidecar.placement)
     return intent
+
+
+def _apply_placement(intent: DesignIntent, placement: dict[str, dict[str, Any]]) -> None:
+    """Record placement directives into ``intent.placements`` (the single source
+    consulted by the locus-aware templates + generator) and project the realized
+    locus onto each addressed peripheral. A key that binds to neither a bus stem
+    nor a peripheral ref is surfaced as a gap — never silently ignored."""
+    if not placement:
+        return
+    bus_names = {b.name for b in intent.buses}
+    periph_by_ref = {p.ref: p for p in intent.peripherals}
+    for key, spec in placement.items():
+        pl = Placement(
+            locus=spec.get("locus", "on_board"),
+            device=spec.get("device"),
+            connector=spec.get("connector", "screw_terminal"),
+            footprint=spec.get("footprint"),
+            external_io=list(spec.get("external_io", []) or []),
+        )
+        intent.placements[key] = pl
+        if key in periph_by_ref:
+            periph_by_ref[key].locus = pl.locus
+        elif key not in bus_names:
+            intent.gaps.append(Gap(
+                "placement_unknown_target",
+                f"board.yaml placement key {key!r} matches no bus stem "
+                f"{sorted(bus_names)} or peripheral ref "
+                f"{sorted(periph_by_ref)}; directive ignored.",
+            ))

--- a/src/kicad_mcp/utils/firmware/sidecar.py
+++ b/src/kicad_mcp/utils/firmware/sidecar.py
@@ -37,14 +37,16 @@ from typing import Any, Optional
 import yaml
 
 from kicad_mcp.utils.firmware.cards import valid_lib_id
-from kicad_mcp.utils.firmware.connectors import VALID_CONNECTOR_TYPES
+from kicad_mcp.utils.firmware.connectors import (
+    ConnectorPosition,
+    VALID_CONNECTOR_TYPES,
+    synthesize_connector,
+)
 from kicad_mcp.utils.firmware.intent import (
     DesignIntent,
-    Endpoint,
     Gap,
     Net,
     Placement,
-    Peripheral,
     VALID_LOCI,
 )
 from kicad_mcp.utils.firmware.power_names import RAILS as _RAILS
@@ -209,15 +211,26 @@ def apply_sidecar(
         friendly = str(c["ref"])
         ref = _normalize_ref(friendly, existing_refs)   # KiCad-valid (J1, …)
         existing_refs.add(ref)
-        p = Peripheral(
-            ref=ref, type="CONN", lib_id=c["lib_id"],
-            value=c.get("value", friendly),              # keep the friendly name
-            footprint=c.get("footprint"), origin="user",
+        # Route through the unified §4 helper for ref/pin-count validation + a silk
+        # legend (the two mechanics this fragment lacked). The user supplies the
+        # symbol + explicit pin→net map, so lib_id/pins are passed verbatim and the
+        # pre-normalized ref is handed back by a fixed allocator.
+        positions = [ConnectorPosition(net_name=str(net), label=str(net), pin=str(pin))
+                     for pin, net in c["nets"].items()]
+
+        def _fixed_alloc(_prefix: str, _r: str = ref) -> str:
+            return _r   # ref was already normalized above; honor it verbatim
+
+        conn, joins, legend = synthesize_connector(
+            positions, alloc=_fixed_alloc, connector_type="pluggable",
+            device=str(c.get("value", friendly)), lib_id=c["lib_id"],
+            footprint=c.get("footprint"), value=c.get("value", friendly),
+            origin="user",
         )
-        intent.peripherals.append(p)
+        intent.peripherals.append(conn)
+        intent.connector_legends.append(legend)
         added_refs.append(ref)
-        for pin, net_name in c["nets"].items():
-            ep = Endpoint(ref=ref, pin=str(pin))
+        for net_name, ep in joins:
             tgt = nets_by_name.get(net_name)
             if tgt is not None:
                 tgt.endpoints.append(ep)
@@ -233,6 +246,32 @@ def apply_sidecar(
 
     _apply_placement(intent, sidecar.placement)
     return intent
+
+
+# Bus types that are USUALLY field-wired transducers/sensors. Open Decision 1:
+# locus defaults to on_board (never a silent remote), but the importer NUDGES the
+# user to declare a locus for these so a remote device isn't forgotten.
+_COMMONLY_REMOTE_BUS_TYPES = frozenset({"I2S_IN", "I2S_OUT", "UART"})
+
+
+def advise_unspecified_placement(intent: DesignIntent) -> None:
+    """Append one advisory gap listing commonly-field-wired buses that have no
+    ``placement:`` directive — a prompt to set their locus, NOT an assumption.
+    Idempotent: does nothing if such an advisory is already present (so a
+    re-import doesn't stack duplicates)."""
+    if any(g.kind == "placement_unspecified" for g in intent.gaps):
+        return
+    unset = sorted(b.name for b in intent.buses
+                   if b.type in _COMMONLY_REMOTE_BUS_TYPES
+                   and b.name not in intent.placements)
+    if unset:
+        intent.gaps.append(Gap(
+            "placement_unspecified",
+            f"Buses {unset} are commonly field-wired (mic / speaker / sensor) but "
+            "have no board.yaml `placement:` directive — defaulting to on_board. "
+            "Set locus: remote (or on_board_with_remote_io) for any wired in from "
+            "off-board.",
+        ))
 
 
 def _apply_placement(intent: DesignIntent, placement: dict[str, dict[str, Any]]) -> None:

--- a/src/kicad_mcp/utils/firmware/sidecar.py
+++ b/src/kicad_mcp/utils/firmware/sidecar.py
@@ -114,9 +114,11 @@ def _validate_placement(d: dict[str, Any], errs: list[str]) -> None:
         if eio is not None and not (isinstance(eio, list)
                                     and all(isinstance(r, str) for r in eio)):
             errs.append(f"{where}: external_io must be a list of role strings")
-        if locus == "on_board_with_remote_io" and not eio:
-            errs.append(f"{where}: on_board_with_remote_io requires a non-empty "
-                        "external_io list (the roles that cross to a terminal)")
+        # external_io is OPTIONAL, documentary metadata: the realized
+        # on_board_with_remote_io path (an I2S_OUT amp bus) crosses its speaker
+        # outputs intrinsically. It is NOT required — requiring a field no
+        # template consumes would be a footgun (see _REALIZED_LOCI for what is
+        # actually realized; an unrealized locus is flagged at apply time).
 
 
 def _validate(d: dict[str, Any]) -> list[str]:
@@ -274,14 +276,31 @@ def advise_unspecified_placement(intent: DesignIntent) -> None:
         ))
 
 
+# (target-kind, bus-type, locus) combinations a template ACTUALLY realizes. A
+# directive outside this set passes structural validation but no template
+# consumes it, so the device would be placed/crossed the WRONG way silently —
+# we flag it instead (honest-by-construction). bus-type is None for a ref target.
+#   bus  I2S_IN  remote                  -> i2s_mic terminal
+#   bus  UART    remote                  -> uart_device_header terminal
+#   bus  I2S_OUT on_board_with_remote_io -> i2s_output_amps speaker terminals
+#   ref  *       remote                  -> remote_peripherals terminal
+_REALIZED_LOCI: frozenset[tuple[str, Optional[str], str]] = frozenset({
+    ("bus", "I2S_IN", "remote"),
+    ("bus", "UART", "remote"),
+    ("bus", "I2S_OUT", "on_board_with_remote_io"),
+    ("ref", None, "remote"),
+})
+
+
 def _apply_placement(intent: DesignIntent, placement: dict[str, dict[str, Any]]) -> None:
     """Record placement directives into ``intent.placements`` (the single source
     consulted by the locus-aware templates + generator) and project the realized
-    locus onto each addressed peripheral. A key that binds to neither a bus stem
-    nor a peripheral ref is surfaced as a gap — never silently ignored."""
+    locus onto each addressed peripheral. A key that binds to no target — or a
+    target/locus combination no template realizes — is surfaced as a gap, never
+    silently ignored."""
     if not placement:
         return
-    bus_names = {b.name for b in intent.buses}
+    bus_by_name = {b.name: b for b in intent.buses}
     periph_by_ref = {p.ref: p for p in intent.peripherals}
     for key, spec in placement.items():
         pl = Placement(
@@ -294,10 +313,24 @@ def _apply_placement(intent: DesignIntent, placement: dict[str, dict[str, Any]])
         intent.placements[key] = pl
         if key in periph_by_ref:
             periph_by_ref[key].locus = pl.locus
-        elif key not in bus_names:
+            kind, bus_type = "ref", None
+        elif key in bus_by_name:
+            kind, bus_type = "bus", bus_by_name[key].type
+        else:
             intent.gaps.append(Gap(
                 "placement_unknown_target",
                 f"board.yaml placement key {key!r} matches no bus stem "
-                f"{sorted(bus_names)} or peripheral ref "
+                f"{sorted(bus_by_name)} or peripheral ref "
                 f"{sorted(periph_by_ref)}; directive ignored.",
+            ))
+            continue
+        # on_board is the default no-op; any other locus must have a realization.
+        if pl.locus != "on_board" and (kind, bus_type, pl.locus) not in _REALIZED_LOCI:
+            tgt = f"{bus_type} bus" if kind == "bus" else "peripheral"
+            intent.gaps.append(Gap(
+                "placement_unsupported",
+                f"board.yaml placement {key!r}: locus {pl.locus!r} on a {tgt} is "
+                "not realized by any template (the device would be placed "
+                "on-board unchanged); supported: I2S_IN/UART bus + remote, "
+                "I2S_OUT bus + on_board_with_remote_io, peripheral ref + remote.",
             ))

--- a/src/kicad_mcp/utils/firmware/templates.py
+++ b/src/kicad_mcp/utils/firmware/templates.py
@@ -422,12 +422,16 @@ def i2s_output_amps(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
                 Endpoint(ref=r.ref, pin="2"), Endpoint(ref=amp.ref, pin=M["din"])))
             # speaker connector (unified §4 helper -> carries a silk legend).
             p_net, n_net = f"SPK{idx}{side}_P", f"SPK{idx}{side}_N"
+            # Honor a board.yaml connector/footprint override only on the realized
+            # remote_io path (passing placement when locus is on_board would let
+            # its default connector="screw_terminal" override the pin-header default).
+            spk_pl = pl if pl is not None and pl.locus == "on_board_with_remote_io" else None
             _spk, te = _emit_connector(
                 ex, alloc,
                 [ConnectorPosition(p_net, f"{side}+"),
                  ConnectorPosition(n_net, f"{side}-")],
                 device=(pl.device if pl and pl.device else "Speaker"),
-                connector_type=spk_type, value=f"SPK{idx}{side}",
+                placement=spk_pl, connector_type=spk_type, value=f"SPK{idx}{side}",
             )
             ex.new_nets += [
                 _passive_net(p_net, Endpoint(ref=amp.ref, pin=M["outp"]), te[p_net]),

--- a/src/kicad_mcp/utils/firmware/templates.py
+++ b/src/kicad_mcp/utils/firmware/templates.py
@@ -34,6 +34,7 @@ from kicad_mcp.utils.firmware.intent import (
     Net,
     Peripheral,
     Placement,
+    is_remote,
 )
 from kicad_mcp.utils.firmware.power_names import RAILS as _RAILS
 
@@ -125,9 +126,15 @@ def _emit_connector(
 def _peripheral_is_remote(intent: DesignIntent, p: Peripheral) -> bool:
     """A carded peripheral declared fully ``remote`` in board.yaml is not placed,
     so it gets no on-board support glue (its bypass/straps live at the device).
-    Power is still delivered over the wire — via the terminal's +3V3/GND taps."""
-    pl = intent.placements.get(p.ref)
-    return (pl is not None and pl.locus == "remote") or p.locus == "remote"
+    Power is still delivered over the wire — via the terminal's +3V3/GND taps.
+
+    Delegates to ``intent.is_remote`` (placements = the SINGLE source) so this
+    glue-suppression check can never disagree with ``generate``'s placement-
+    exclusion check (which also reads placements). ``Peripheral.locus`` is only a
+    serialized display projection — never an independent behavioral source — so a
+    hand-edited doc cannot land in the split state where a remote device is placed
+    yet has its glue suppressed."""
+    return is_remote(intent, p.ref)
 
 
 def _ic_power_pins(intent: DesignIntent) -> list[tuple[str, list[str], list[str]]]:

--- a/src/kicad_mcp/utils/firmware/templates.py
+++ b/src/kicad_mcp/utils/firmware/templates.py
@@ -22,13 +22,20 @@ from dataclasses import dataclass, field
 from typing import Callable, Optional
 
 from kicad_mcp.utils.firmware import knowledge as K
+from kicad_mcp.utils.firmware.connectors import (
+    ConnectorPosition,
+    synthesize_connector,
+)
 from kicad_mcp.utils.firmware.intent import (
+    ConnectorLegend,
     DesignIntent,
     Endpoint,
     Gap,
     Net,
     Peripheral,
+    Placement,
 )
+from kicad_mcp.utils.firmware.power_names import RAILS as _RAILS
 
 
 def _first(signals: dict[str, int], *roles: str) -> Optional[int]:
@@ -49,6 +56,7 @@ class Expansion:
     new_nets: list[Net] = field(default_factory=list)
     resolved: list[str] = field(default_factory=list)
     gaps: list[Gap] = field(default_factory=list)   # new gaps a template surfaces
+    legends: list[ConnectorLegend] = field(default_factory=list)  # connector silk legends
 
 
 class RefAllocator:
@@ -79,14 +87,60 @@ def _res(alloc: RefAllocator, value: str, footprint: str) -> Peripheral:
                       footprint=footprint, origin="template")
 
 
+def _emit_connector(
+    ex: Expansion,
+    alloc: RefAllocator,
+    positions: list[ConnectorPosition],
+    *,
+    device: str,
+    placement: Optional[Placement] = None,
+    connector_type: str = "pin_header",
+    value: Optional[str] = None,
+) -> tuple[Peripheral, dict[str, Endpoint]]:
+    """Synthesize a connector for ``positions`` (via the ONE §4 helper) and fold
+    the common parts into ``ex``: the Peripheral into ``components``, every
+    power-rail position onto ``power`` (so the rail-merge dedups it), and the silk
+    legend into ``legends``. Returns ``(connector, {net_name: terminal_endpoint})``
+    for the SIGNAL positions, so the caller wires each into a fresh net together
+    with its near-side (MCU/amp) endpoint — avoiding the join-before-new_nets
+    ordering hazard in ``expand_intent``. ``placement`` overrides the connector
+    type/footprint from board.yaml."""
+    ctype = placement.connector if placement and placement.connector else connector_type
+    footprint = placement.footprint if placement else None
+    conn, joins, legend = synthesize_connector(
+        positions, alloc=alloc.next, device=device, connector_type=ctype,
+        footprint=footprint, value=value,
+    )
+    ex.components.append(conn)
+    ex.legends.append(legend)
+    signal_eps: dict[str, Endpoint] = {}
+    for net_name, ep in joins:
+        if net_name in _RAILS:
+            ex.power.append((net_name, ep))   # rail tap (power delivered over wire)
+        else:
+            signal_eps[net_name] = ep
+    return conn, signal_eps
+
+
+def _peripheral_is_remote(intent: DesignIntent, p: Peripheral) -> bool:
+    """A carded peripheral declared fully ``remote`` in board.yaml is not placed,
+    so it gets no on-board support glue (its bypass/straps live at the device).
+    Power is still delivered over the wire — via the terminal's +3V3/GND taps."""
+    pl = intent.placements.get(p.ref)
+    return (pl is not None and pl.locus == "remote") or p.locus == "remote"
+
+
 def _ic_power_pins(intent: DesignIntent) -> list[tuple[str, list[str], list[str]]]:
-    """(ref, supply_pin_names, ground_pin_names) for every placed IC."""
+    """(ref, supply_pin_names, ground_pin_names) for every placed IC. Remote
+    peripherals are excluded — they are not on the board (glue suppression)."""
     out: list[tuple[str, list[str], list[str]]] = []
     if intent.mcu is not None:
         mi = K.resolve_mcu_by_part(intent.mcu.part)
         if mi is not None:
             out.append((intent.mcu.ref, [mi["supply_pin"]], [mi["ground_pin"]]))
     for p in intent.peripherals:
+        if _peripheral_is_remote(intent, p):
+            continue
         info = K.resolve_peripheral(p.type)
         if info is not None:
             out.append((p.ref, list(info["supply_pins"]), list(info["ground_pins"])))
@@ -204,6 +258,8 @@ def device_config(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
     An out-of-range address is flagged as a gap, never silently strapped."""
     ex = Expansion()
     for p in intent.peripherals:
+        if _peripheral_is_remote(intent, p):
+            continue   # remote device configures itself off-board (glue suppression)
         info = K.resolve_peripheral(p.type)
         if info is None or "config" not in info:
             continue
@@ -312,8 +368,11 @@ def _header(alloc: RefAllocator, hdr: tuple[str, str], value: str) -> Peripheral
 def i2s_output_amps(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
     """Each I2S-output bus -> a stereo MAX98357A pair (L/R) with shared BCLK/LRC,
     per-channel DIN via 1kΩ isolators, SD_MODE channel straps (L→GND, R→+3V3),
-    decoupling, and a 2-pin speaker header per channel. GAIN is left at the 9 dB
-    Hi-Z default (the GAIN GPIO stays a flagged orphan)."""
+    decoupling, and a 2-pin speaker connector per channel (the unified §4 helper,
+    so it carries a silk legend). The amps stay on-board; the speaker leads always
+    cross out to a connector — a pin header by default, or a screw terminal when
+    the bus is declared ``on_board_with_remote_io`` in board.yaml. GAIN is left at
+    the 9 dB Hi-Z default (the GAIN GPIO stays a flagged orphan)."""
     ex = Expansion()
     if intent.mcu is None:
         return ex
@@ -328,6 +387,10 @@ def i2s_output_amps(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
         din_g = bus.signals.get("DIN")
         if bclk_g is None or lrc_g is None or din_g is None:
             continue
+        pl = intent.placements.get(bus.name)
+        spk_type = ("screw_terminal"
+                    if pl is not None and pl.locus == "on_board_with_remote_io"
+                    else "pin_header")
         b_net, l_net, d_net = f"I2S{idx}_BCLK", f"I2S{idx}_LRC", f"I2S{idx}_DIN"
         # MCU drives the shared clocks + data bus.
         ex.joins += [(b_net, Endpoint(ref=mcu, gpio=bclk_g)),
@@ -350,14 +413,18 @@ def i2s_output_amps(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
             ex.joins.append((d_net, Endpoint(ref=r.ref, pin="1")))
             ex.new_nets.append(_passive_net(f"I2S{idx}{side}_DIN",
                 Endpoint(ref=r.ref, pin="2"), Endpoint(ref=amp.ref, pin=M["din"])))
-            # speaker header
-            spk = _header(alloc, K.HDR_1X2, f"SPK{idx}{side}")
-            ex.components.append(spk)
+            # speaker connector (unified §4 helper -> carries a silk legend).
+            p_net, n_net = f"SPK{idx}{side}_P", f"SPK{idx}{side}_N"
+            _spk, te = _emit_connector(
+                ex, alloc,
+                [ConnectorPosition(p_net, f"{side}+"),
+                 ConnectorPosition(n_net, f"{side}-")],
+                device=(pl.device if pl and pl.device else "Speaker"),
+                connector_type=spk_type, value=f"SPK{idx}{side}",
+            )
             ex.new_nets += [
-                _passive_net(f"SPK{idx}{side}_P", Endpoint(ref=amp.ref, pin=M["outp"]),
-                             Endpoint(ref=spk.ref, pin="1")),
-                _passive_net(f"SPK{idx}{side}_N", Endpoint(ref=amp.ref, pin=M["outn"]),
-                             Endpoint(ref=spk.ref, pin="2")),
+                _passive_net(p_net, Endpoint(ref=amp.ref, pin=M["outp"]), te[p_net]),
+                _passive_net(n_net, Endpoint(ref=amp.ref, pin=M["outn"]), te[n_net]),
             ]
         # decoupling for the amp-pair supply
         cb, cbu = _cap(alloc, "100nF", K.FP_C_BYPASS), _cap(alloc, "10uF", K.FP_C_BULK)
@@ -370,7 +437,10 @@ def i2s_output_amps(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
 
 
 def i2s_mic(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
-    """Each I2S-input bus -> an SPH0645 MEMS mic (SEL→GND, VDD bypass)."""
+    """Each I2S-input bus -> an SPH0645 MEMS mic (SEL→GND, VDD bypass), UNLESS the
+    bus is declared ``remote`` in board.yaml — then the mic is field-wired and the
+    bus crosses to a screw terminal instead of an on-board chip (no chip, no
+    bypass: the device's support glue lives at the device)."""
     ex = Expansion()
     if intent.mcu is None:
         return ex
@@ -383,6 +453,10 @@ def i2s_mic(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
         ws_g = _first(bus.signals, "WS", "LRC")
         sd_g = _first(bus.signals, "SD", "DOUT")
         if bclk_g is None or ws_g is None or sd_g is None:
+            continue
+        pl = intent.placements.get(bus.name)
+        if pl is not None and pl.locus == "remote":
+            _emit_remote_mic(ex, alloc, mcu, bclk_g, ws_g, sd_g, pl)
             continue
         mic = Peripheral(ref=alloc.next("MK"), type="SPH0645", lib_id=S["lib_id"],
                          value="SPH0645LM4H", footprint=S["footprint"], origin="template")
@@ -399,6 +473,35 @@ def i2s_mic(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
             _passive_net("MIC_SD", Endpoint(ref=mcu, gpio=sd_g), Endpoint(ref=mic.ref, pin=S["data"])),
         ]
     return ex
+
+
+def _emit_remote_mic(
+    ex: Expansion, alloc: RefAllocator, mcu: str,
+    bclk_g: int, ws_g: int, sd_g: int, pl: Placement,
+) -> None:
+    """Field-wired I2S mic: a screw terminal carries the three I2S signals plus a
+    +3V3/GND tap (power delivered over the wire)."""
+    device = pl.device or "I2S mic"
+    positions = [
+        ConnectorPosition("MIC_BCLK", "BCLK"),
+        ConnectorPosition("MIC_WS", "WS"),
+        ConnectorPosition("MIC_SD", "SD"),
+        ConnectorPosition("+3V3", "+3V3"),
+        ConnectorPosition("GND", "GND"),
+    ]
+    conn, te = _emit_connector(ex, alloc, positions, device=device, placement=pl,
+                               connector_type="screw_terminal")
+    ex.new_nets += [
+        _passive_net("MIC_BCLK", Endpoint(ref=mcu, gpio=bclk_g), te["MIC_BCLK"]),
+        _passive_net("MIC_WS", Endpoint(ref=mcu, gpio=ws_g), te["MIC_WS"]),
+        _passive_net("MIC_SD", Endpoint(ref=mcu, gpio=sd_g), te["MIC_SD"]),
+    ]
+    ex.gaps.append(Gap(
+        "remote_device",
+        f"{device} (I2S mic): remote — field-wired to {conn.ref} "
+        f"(5-pos screw terminal); sourced off-board.",
+        resolved=True, resolved_by="placement", resolved_components=[conn.ref],
+    ))
 
 
 def i2c_device_header(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
@@ -436,7 +539,9 @@ def i2c_device_header(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
 
 def uart_device_header(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
     """Each UART bus -> a 4-pin module header (GND/VCC/TX/RX) + bypass.
-    Header TX -> MCU RX, header RX <- MCU TX (crossover)."""
+    Header TX -> MCU RX, header RX <- MCU TX (crossover). A bus declared
+    ``remote`` in board.yaml crosses to a screw terminal instead (field-wired
+    sensor, e.g. an LD2410 on flying leads)."""
     ex = Expansion()
     if intent.mcu is None:
         return ex
@@ -448,6 +553,11 @@ def uart_device_header(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
         rx_g = _first(bus.signals, "RX", "RXD")
         tx_g = _first(bus.signals, "TX", "TXD")
         if rx_g is None or tx_g is None:
+            continue
+        pl = intent.placements.get(bus.name)
+        if pl is not None and pl.locus == "remote":
+            _emit_remote_uart(ex, alloc, mcu, n, rx_g, tx_g, pl)
+            n += 1
             continue
         j = _header(alloc, K.HDR_1X4, f"UART{n}")
         c = _cap(alloc, "100nF", K.FP_C_BYPASS)
@@ -464,6 +574,81 @@ def uart_device_header(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
     return ex
 
 
+def _emit_remote_uart(
+    ex: Expansion, alloc: RefAllocator, mcu: str, n: int,
+    rx_g: int, tx_g: int, pl: Placement,
+) -> None:
+    """Field-wired UART sensor: a screw terminal carries RX/TX + a +3V3/GND tap."""
+    device = pl.device or "UART device"
+    rx_net, tx_net = f"UART{n}_RX", f"UART{n}_TX"
+    positions = [
+        ConnectorPosition(rx_net, "RX"),
+        ConnectorPosition(tx_net, "TX"),
+        ConnectorPosition("+3V3", "+3V3"),
+        ConnectorPosition("GND", "GND"),
+    ]
+    conn, te = _emit_connector(ex, alloc, positions, device=device, placement=pl,
+                               connector_type="screw_terminal")
+    ex.new_nets += [
+        _passive_net(rx_net, Endpoint(ref=mcu, gpio=rx_g), te[rx_net]),
+        _passive_net(tx_net, Endpoint(ref=mcu, gpio=tx_g), te[tx_net]),
+    ]
+    ex.gaps.append(Gap(
+        "remote_device",
+        f"{device} (UART): remote — field-wired to {conn.ref} "
+        f"(4-pos screw terminal); sourced off-board.",
+        resolved=True, resolved_by="placement", resolved_components=[conn.ref],
+    ))
+
+
+def _short_label(net_name: str, role: Optional[str]) -> str:
+    """Silk label for a crossing signal: its firmware role if known, else the net
+    name with a leading bus prefix trimmed (``I2C0_SDA`` -> ``SDA``)."""
+    if role:
+        return role
+    if "_" in net_name:
+        return net_name.rsplit("_", 1)[-1]
+    return net_name
+
+
+def remote_peripherals(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
+    """A CARDED peripheral declared ``remote`` in board.yaml (keyed by its ref) is
+    field-wired: every signal net it touches crosses to a screw terminal, plus a
+    +3V3/GND tap. The peripheral stays in the intent (for the BOM) but is excluded
+    from placement by the generator, so its own pin endpoints drop out and only
+    the terminal is wired. Its support glue is already suppressed (``_ic_power_pins``
+    / ``device_config`` skip it)."""
+    ex = Expansion()
+    for p in intent.peripherals:
+        pl = intent.placements.get(p.ref)
+        if pl is None or pl.locus != "remote":
+            continue
+        # Signal nets this peripheral touches (rails excluded — power crosses as a
+        # tap, not a retarget). One position per net, first-seen label wins.
+        seen: dict[str, str] = {}
+        for net in intent.nets:
+            if net.name in _RAILS:
+                continue
+            role = next((ep.role for ep in net.endpoints if ep.ref == p.ref), None)
+            if any(ep.ref == p.ref for ep in net.endpoints) and net.name not in seen:
+                seen[net.name] = _short_label(net.name, role)
+        device = pl.device or p.value or p.type
+        positions = [ConnectorPosition(nn, lbl) for nn, lbl in seen.items()]
+        positions += [ConnectorPosition("+3V3", "+3V3"), ConnectorPosition("GND", "GND")]
+        conn, te = _emit_connector(ex, alloc, positions, device=device, placement=pl,
+                                   connector_type="screw_terminal")
+        # Signal nets already exist (from import) — join the terminal onto them.
+        for net_name, ep in te.items():
+            ex.joins.append((net_name, ep))
+        ex.gaps.append(Gap(
+            "remote_device",
+            f"{device} ({p.type}): remote — field-wired to {conn.ref} "
+            f"({len(positions)}-pos screw terminal); sourced off-board.",
+            resolved=True, resolved_by="placement", resolved_components=[conn.ref],
+        ))
+    return ex
+
+
 _REGISTRY: list[tuple[str, Callable[[DesignIntent, RefAllocator], Expansion]]] = [
     ("power_tree", power_tree),
     ("decoupling", decoupling),
@@ -475,6 +660,7 @@ _REGISTRY: list[tuple[str, Callable[[DesignIntent, RefAllocator], Expansion]]] =
     ("i2c_device_header", i2c_device_header),
     ("uart_device_header", uart_device_header),
     ("device_config", device_config),
+    ("remote_peripherals", remote_peripherals),
 ]
 
 
@@ -513,6 +699,8 @@ def expand_intent(intent: DesignIntent) -> DesignIntent:
 
         for g in ex.gaps:               # new gaps a template surfaces directly
             intent.gaps.append(g)
+
+        intent.connector_legends.extend(ex.legends)   # synthesized-terminal silk
 
         for kind in ex.resolved:
             gap = gaps_by_kind.get(kind)

--- a/tests/integration/test_firmware_pcb_pipeline.py
+++ b/tests/integration/test_firmware_pcb_pipeline.py
@@ -248,11 +248,18 @@ def test_audio_remote_to_routed_pcb(mcp_server, tmp_path):
     assert len(refs_on("MIC_BCLK")) >= 2     # MCU + terminal
     assert "U1" in refs_on("+3V3")
 
-    # No legend label overlaps a pad (the field-wiring silk must stay readable).
+    # NO legend label overlaps a pad (the field-wiring silk must stay readable).
+    # Scope the check to the legend labels (every position on every synthesized
+    # terminal), NOT all board silk — a dense board may have pre-existing refdes
+    # overlaps unrelated to this feature.
+    from kicad_mcp.utils.firmware.intent import load_intent
+    legend_labels = {pos for L in load_intent(str(intent)).connector_legends
+                     for pos in L.positions if pos}
+    assert legend_labels, "expected synthesized-terminal legends"
     ov = _op_check_silkscreen_overlaps(str(pro).replace(".kicad_pro", ".kicad_pcb"))
     pad_hits = {o.get("silk_text") for o in ov.get("overlaps", [])}
-    assert not (pad_hits & {"BCLK", "WS", "SD", "RX", "TX"}), (
-        f"legend label overlaps a pad: {pad_hits}")
+    assert not (pad_hits & legend_labels), (
+        f"legend label(s) overlap a pad: {sorted(pad_hits & legend_labels)}")
 
 
 def test_track_geometry_to_routed_pcb(mcp_server, tmp_path):

--- a/tests/integration/test_firmware_pcb_pipeline.py
+++ b/tests/integration/test_firmware_pcb_pipeline.py
@@ -172,6 +172,89 @@ def test_audio_s3_to_routed_pcb(mcp_server, tmp_path):
     assert len(refs_on("I2S0_BCLK")) == 3               # MCU + 2 amps share the clock
 
 
+def test_audio_remote_to_routed_pcb(mcp_server, tmp_path):
+    """Placement locus on the audio node: a board.yaml declares the mic + presence
+    sensor REMOTE (field-wired) and the amps on_board_with_remote_io. The board
+    builds with screw terminals instead of the SPH0645/LD2410, routes ~complete,
+    and the synthesized terminals carry a silk legend (the field-wiring doc).
+
+    The on-board audio path is still gated by test_audio_s3_to_routed_pcb above —
+    this adds the remote shape without losing that coverage."""
+    import shutil
+
+    from kicad_mcp.tools.pcb_silkscreen import _op_check_silkscreen_overlaps
+
+    design = _tool(mcp_server, "design")
+    build = _tool(mcp_server, "build_pcb_from_schematic")
+
+    # Stage the audio firmware + a board.yaml in tmp (board.yaml is auto-detected
+    # next to config.h; the canonical fixture stays pristine / on-board).
+    fw = tmp_path / "fw"
+    fw.mkdir()
+    shutil.copy(AUDIO_CONFIG_H, fw / "config.h")
+    shutil.copy(AUDIO_CONFIG_H.parent / "platformio.ini", fw / "platformio.ini")
+    (fw / "board.yaml").write_text(
+        "placement:\n"
+        "  CMCA_MIC: {locus: remote, device: INMP441}\n"
+        "  CMCA_PRESENCE: {locus: remote, device: LD2410}\n"
+        "  CMCA_I2S: {locus: on_board_with_remote_io, device: MAX98357A, external_io: [outp, outn]}\n"
+        "  CMCA_I2S2: {locus: on_board_with_remote_io, device: MAX98357A, external_io: [outp, outn]}\n"
+    )
+
+    intent = tmp_path / "intent.yaml"
+    sch = tmp_path / "ar.kicad_sch"
+    pro = tmp_path / "ar.kicad_pro"
+
+    r1 = design(operation="import_firmware", firmware_path=str(fw / "config.h"),
+                out_path=str(intent))
+    assert r1["status"] == "ok"
+    assert r1["sidecar"] is not None
+
+    r2 = design(operation="expand_templates", intent_path=str(intent))
+    assert r2["status"] == "ok"
+    # After expansion the manifest reports the field-wired devices off-board, with
+    # their terminals (the terminals are synthesized during template expansion).
+    assert r2["summary"].get("remote_devices")
+
+    r3 = design(operation="generate_schematic", intent_path=str(intent),
+                schematic_path=str(sch))
+    assert r3["status"] == "ok" and not r3["unresolved_endpoints"]
+
+    pro.write_text(json.dumps(_MINIMAL_PRO))
+    r4 = build(project_path=str(pro), board_width_mm=110, board_height_mm=90,
+               autoroute_passes=4, export_gerbers=False, intent_path=str(intent))
+    assert r4["status"] == "ok"
+    assert r4["pads_assigned"] > 0
+    _assert_mostly_routed(r4, max_unrouted=4)
+    assert r4["steps"]["zones"]["zones_added"] >= 1
+
+    # The silk-legend step ran and labelled the synthesized terminals.
+    silk = r4["steps"]["silkscreen_legends"]
+    assert silk.get("labels_added", 0) > 0
+    assert not silk.get("missing_refs")
+
+    from kicad_mcp.utils.netlist_parser import extract_netlist_via_cli
+    nl = extract_netlist_via_cli(str(sch))
+    vals = [c.get("value") for c in nl["components"].values()]
+    # NO on-board mic substitute / presence header — they are field-wired terminals.
+    assert "SPH0645LM4H" not in vals
+    assert vals.count("INMP441") == 1 and vals.count("LD2410") == 1
+    # Amps stay on board (two stereo pairs).
+    assert vals.count("MAX98357A") == 4
+
+    def refs_on(net):
+        return {x["component"] for x in nl["nets"].get(net, [])}
+    # The mic terminal sits on the I2S mic clock the MCU drives.
+    assert len(refs_on("MIC_BCLK")) >= 2     # MCU + terminal
+    assert "U1" in refs_on("+3V3")
+
+    # No legend label overlaps a pad (the field-wiring silk must stay readable).
+    ov = _op_check_silkscreen_overlaps(str(pro).replace(".kicad_pro", ".kicad_pcb"))
+    pad_hits = {o.get("silk_text") for o in ov.get("overlaps", [])}
+    assert not (pad_hits & {"BCLK", "WS", "SD", "RX", "TX"}), (
+        f"legend label overlaps a pad: {pad_hits}")
+
+
 def test_track_geometry_to_routed_pcb(mcp_server, tmp_path):
     """The THIRD board shape: an I2C sensor-hub (track-geometry car). Exercises
     the generalization that matters here — MULTIPLE address-declared devices,

--- a/tests/test_firmware_connectors.py
+++ b/tests/test_firmware_connectors.py
@@ -169,6 +169,17 @@ def test_different_nets_same_label_suffixed():
     assert legend.positions == ["GND", "GND_2"]  # different nets -> disambiguate
 
 
+def test_three_different_nets_same_label_get_distinct_suffixes():
+    # The suffix counter must advance — three colliding nets must NOT collapse to
+    # a duplicate "SIG_2"/"SIG_2" (which would be ambiguous on the silk).
+    _c, _j, legend = synthesize_connector(
+        _pos(("SIG_A", "SIG"), ("SIG_B", "SIG"), ("SIG_C", "SIG")),
+        alloc=_Alloc(), device="X",
+    )
+    assert legend.positions == ["SIG", "SIG_2", "SIG_3"]
+    assert len(set(legend.positions)) == 3   # all distinct
+
+
 # --- error paths -------------------------------------------------------------
 
 def test_empty_positions_raises():

--- a/tests/test_firmware_connectors.py
+++ b/tests/test_firmware_connectors.py
@@ -27,7 +27,7 @@ class _Alloc:
 
 
 def _pos(*pairs):
-    return [ConnectorPosition(net_name=n, label=l) for n, l in pairs]
+    return [ConnectorPosition(net_name=n, label=lbl) for n, lbl in pairs]
 
 
 # --- symbol sizing -----------------------------------------------------------

--- a/tests/test_firmware_connectors.py
+++ b/tests/test_firmware_connectors.py
@@ -1,0 +1,191 @@
+"""Unit tests for the unified ``synthesize_connector`` helper (placement-locus L2).
+
+No KiCad needed — these pin the structural mechanics (symbol sizing, pin-count
+validation at/below/above N, ref allocation, position labeling, legend dedup).
+Pin-existence against real symbols is covered in the integration tier.
+"""
+import pytest
+
+from kicad_mcp.utils.firmware.connectors import (
+    ConnectorError,
+    ConnectorPosition,
+    default_footprint,
+    symbol_pin_count,
+    synthesize_connector,
+)
+
+
+class _Alloc:
+    """Minimal collision-free ref allocator (mirrors templates.RefAllocator)."""
+
+    def __init__(self) -> None:
+        self._n: dict[str, int] = {}
+
+    def __call__(self, prefix: str) -> str:
+        self._n[prefix] = self._n.get(prefix, 0) + 1
+        return f"{prefix}{self._n[prefix]}"
+
+
+def _pos(*pairs):
+    return [ConnectorPosition(net_name=n, label=l) for n, l in pairs]
+
+
+# --- symbol sizing -----------------------------------------------------------
+
+def test_screw_terminal_sized_to_n():
+    conn, joins, legend = synthesize_connector(
+        _pos(("MIC_BCLK", "BCLK"), ("MIC_WS", "WS"), ("MIC_SD", "SD"),
+             ("+3V3", "+3V3"), ("GND", "GND")),
+        alloc=_Alloc(), device="INMP441",
+    )
+    assert conn.lib_id == "Connector:Screw_Terminal_01x05"
+    assert conn.footprint == ("TerminalBlock_Phoenix:TerminalBlock_Phoenix_"
+                              "MKDS-1,5-5-5.08_1x05_P5.08mm_Horizontal")
+    assert conn.value == "INMP441"
+    assert conn.type == "TERM"
+    assert len(joins) == 5
+    # pads auto-assigned 1..5 in order
+    assert [ep.pin for _net, ep in joins] == ["1", "2", "3", "4", "5"]
+    assert [net for net, _ep in joins] == ["MIC_BCLK", "MIC_WS", "MIC_SD", "+3V3", "GND"]
+    assert legend.ref == conn.ref
+    assert legend.device == "INMP441"
+    assert legend.positions == ["BCLK", "WS", "SD", "+3V3", "GND"]
+
+
+def test_pin_header_uses_conn_symbol_and_header_footprint():
+    conn, _j, _l = synthesize_connector(
+        _pos(("SPK_P", "L+"), ("SPK_N", "L-")),
+        alloc=_Alloc(), device="SPK0L", connector_type="pin_header",
+    )
+    assert conn.lib_id == "Connector_Generic:Conn_01x02"
+    assert conn.footprint == "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical"
+    assert conn.type == "HDR"
+
+
+# --- pin-count validation: at / below / above N ------------------------------
+
+def test_symbol_pin_count_parses_01xNN():
+    assert symbol_pin_count("Connector:Screw_Terminal_01x05") == 5
+    assert symbol_pin_count("Connector_Generic:Conn_01x12") == 12
+    assert symbol_pin_count("Connector:Barrel_Jack") is None  # no count encoded
+
+
+def test_explicit_lib_id_at_capacity_ok():
+    # 5 positions into a 5-pin symbol — exactly at N, allowed.
+    conn, _j, _l = synthesize_connector(
+        _pos(("a", "A"), ("b", "B"), ("c", "C"), ("d", "D"), ("e", "E")),
+        alloc=_Alloc(), device="X", lib_id="Connector:Screw_Terminal_01x05",
+    )
+    assert conn.lib_id == "Connector:Screw_Terminal_01x05"
+
+
+def test_explicit_lib_id_below_capacity_ok():
+    # 4 positions into a 5-pin symbol — below N, allowed (spare position).
+    conn, joins, _l = synthesize_connector(
+        _pos(("a", "A"), ("b", "B"), ("c", "C"), ("d", "D")),
+        alloc=_Alloc(), device="X", lib_id="Connector:Screw_Terminal_01x05",
+    )
+    assert len(joins) == 4
+
+
+def test_explicit_lib_id_above_capacity_raises():
+    # 6 positions into a 5-pin symbol — above N, the latent bug the helper closes.
+    with pytest.raises(ConnectorError, match="exceed"):
+        synthesize_connector(
+            _pos(("a", "A"), ("b", "B"), ("c", "C"), ("d", "D"), ("e", "E"), ("f", "F")),
+            alloc=_Alloc(), device="X", lib_id="Connector:Screw_Terminal_01x05",
+        )
+
+
+def test_explicit_pad_above_capacity_raises():
+    with pytest.raises(ConnectorError, match="exceed"):
+        synthesize_connector(
+            [ConnectorPosition("a", "A", pin="9")],
+            alloc=_Alloc(), device="X", lib_id="Connector:Screw_Terminal_01x05",
+        )
+
+
+# --- footprint defaults ------------------------------------------------------
+
+def test_phoenix_in_range_vs_pinheader_fallback():
+    assert "MKDS-1,5-2-5.08_1x02" in default_footprint("screw_terminal", 2)
+    assert "MKDS-1,5-16-5.08_1x16" in default_footprint("screw_terminal", 16)
+    # N=1 (below Phoenix min) and N=17 (above max) fall back to a pin header.
+    assert default_footprint("screw_terminal", 1).startswith("Connector_PinHeader")
+    assert default_footprint("screw_terminal", 17).startswith("Connector_PinHeader")
+
+
+# --- ref allocation ----------------------------------------------------------
+
+def test_alloc_is_called_per_prefix_collision_free():
+    alloc = _Alloc()
+    c1, _, _ = synthesize_connector(_pos(("a", "A"), ("b", "B")), alloc=alloc, device="X")
+    c2, _, _ = synthesize_connector(_pos(("c", "C"), ("d", "D")), alloc=alloc, device="Y")
+    assert c1.ref == "J1" and c2.ref == "J2"   # distinct, collision-free
+
+
+# --- explicit pins (fragment c: arbitrary pinout) ----------------------------
+
+def test_explicit_pins_honored():
+    conn, joins, legend = synthesize_connector(
+        [ConnectorPosition("+5V", "+5V", pin="1"),
+         ConnectorPosition("GND", "GND", pin="2")],
+        alloc=_Alloc(), device="PWR_IN",
+        lib_id="Connector:Barrel_Jack",
+        footprint="Connector_BarrelJack:BarrelJack_Horizontal",
+    )
+    assert [ep.pin for _n, ep in joins] == ["1", "2"]
+    assert conn.lib_id == "Connector:Barrel_Jack"
+    assert conn.footprint == "Connector_BarrelJack:BarrelJack_Horizontal"
+    assert legend.positions == ["+5V", "GND"]
+
+
+def test_mixed_explicit_and_auto_pads_avoid_collision():
+    # one explicit pad 2; the auto ones must skip it.
+    conn, joins, _l = synthesize_connector(
+        [ConnectorPosition("a", "A"),                 # auto -> 1
+         ConnectorPosition("b", "B", pin="2"),        # explicit 2
+         ConnectorPosition("c", "C")],                # auto -> 3 (skips taken 2)
+        alloc=_Alloc(), device="X", connector_type="pin_header",
+    )
+    assert [ep.pin for _n, ep in joins] == ["1", "2", "3"]
+
+
+# --- legend dedup (Open Decision 6) ------------------------------------------
+
+def test_two_gnd_positions_share_label():
+    _c, _j, legend = synthesize_connector(
+        _pos(("GND", "GND"), ("GND", "GND")),
+        alloc=_Alloc(), device="X",
+    )
+    assert legend.positions == ["GND", "GND"]   # same net -> share, not suffixed
+
+
+def test_different_nets_same_label_suffixed():
+    _c, _j, legend = synthesize_connector(
+        _pos(("GND_A", "GND"), ("GND_B", "GND")),
+        alloc=_Alloc(), device="X",
+    )
+    assert legend.positions == ["GND", "GND_2"]  # different nets -> disambiguate
+
+
+# --- error paths -------------------------------------------------------------
+
+def test_empty_positions_raises():
+    with pytest.raises(ConnectorError, match="at least one"):
+        synthesize_connector([], alloc=_Alloc(), device="X")
+
+
+def test_unknown_connector_type_raises():
+    with pytest.raises(ConnectorError, match="connector_type"):
+        synthesize_connector(_pos(("a", "A")), alloc=_Alloc(), device="X",
+                             connector_type="bananas")
+
+
+def test_duplicate_explicit_pads_raise():
+    with pytest.raises(ConnectorError, match="duplicate"):
+        synthesize_connector(
+            [ConnectorPosition("a", "A", pin="1"),
+             ConnectorPosition("b", "B", pin="1")],
+            alloc=_Alloc(), device="X",
+        )

--- a/tests/test_firmware_placement_locus.py
+++ b/tests/test_firmware_placement_locus.py
@@ -217,3 +217,131 @@ def test_advisory_idempotent_and_skips_placed():
     adv = [g for g in intent.gaps if g.kind == "placement_unspecified"]
     assert len(adv) == 1
     assert "CMCA_MIC" not in adv[0].detail   # placed bus excluded from the nudge
+
+
+def test_advisory_lists_every_field_wired_bus_type():
+    """I2S_OUT must be in the nudge too (not just I2S_IN/UART) — pins the full
+    _COMMONLY_REMOTE_BUS_TYPES set so dropping a type is caught."""
+    intent = _intent(AUDIO)
+    advise_unspecified_placement(intent)
+    detail = next(g.detail for g in intent.gaps if g.kind == "placement_unspecified")
+    for stem in ("CMCA_MIC", "CMCA_PRESENCE", "CMCA_I2S", "CMCA_I2S2"):
+        assert stem in detail
+
+
+# --- net wiring of synthesized terminals (Rule 2: survives the router) --------
+
+def test_remote_peripheral_terminal_joins_its_signal_net():
+    """A carded remote device's terminal must actually join the device's signal
+    net (else the terminal is a routing island with no net)."""
+    intent = _intent(TRACK_GEOM)
+    ref = intent.peripherals[0].ref          # an MPU6050 on the shared I2C bus
+    apply_sidecar(intent, BoardSidecar(placement={ref: {"locus": "remote",
+                                                        "device": "MPU6050"}}))
+    intent = expand_intent(intent)
+    term = next(p for p in intent.peripherals if p.type == "TERM" and p.value == "MPU6050")
+    sda = next(n for n in intent.nets if n.name == "I2C_SDA")
+    assert term.ref in {ep.ref for ep in sda.endpoints}   # terminal is on the bus
+
+
+def test_remote_mic_terminal_signals_reach_mcu_and_terminal():
+    intent = _audio_with_placement({"CMCA_MIC": {"locus": "remote", "device": "INMP441"}})
+    term = next(p for p in intent.peripherals if p.value == "INMP441")
+    bclk = next(n for n in intent.nets if n.name == "MIC_BCLK")
+    refs = {ep.ref for ep in bclk.endpoints}
+    assert intent.mcu.ref in refs and term.ref in refs   # MCU drives -> terminal
+
+
+def test_on_board_with_remote_io_speaker_net_joins_amp_and_terminal():
+    intent = _audio_with_placement({
+        "CMCA_I2S": {"locus": "on_board_with_remote_io", "device": "MAX98357A",
+                     "external_io": ["outp", "outn"]},
+    })
+    spk_p = next(n for n in intent.nets if n.name == "SPK0L_P")
+    refs = {ep.ref for ep in spk_p.endpoints}
+    term = next(p for p in intent.peripherals
+                if p.type == "TERM" and p.value == "SPK0L")
+    amps = {p.ref for p in intent.peripherals if p.type == "MAX98357A"}
+    assert term.ref in refs                    # terminal on the speaker net
+    assert refs & amps                         # an amp output on the speaker net
+
+
+# --- external_io is currently DECLARATIVE (H1: pin the invariant) -------------
+
+def test_external_io_listing_does_not_drop_a_speaker_side():
+    """external_io is validated + required for on_board_with_remote_io but the amp
+    template intrinsically crosses BOTH outp and outn. Declaring only [outp] must
+    NOT drop the outn side — pin this invariant so the dead-param state is locked
+    and documented (a future ref-keyed path may consume external_io; until then
+    this asserts no silent surprise)."""
+    intent = _audio_with_placement({
+        "CMCA_I2S": {"locus": "on_board_with_remote_io", "device": "MAX98357A",
+                     "external_io": ["outp"]},     # only one role listed
+    })
+    term = next(p for p in intent.peripherals if p.type == "TERM" and p.value == "SPK0L")
+    leg = next(L for L in intent.connector_legends if L.ref == term.ref)
+    assert leg.positions == ["L+", "L-"]          # BOTH sides still cross
+
+
+# --- v4 schema serialization round-trip (M7) ---------------------------------
+
+def test_v4_fields_survive_save_load(tmp_path):
+    from kicad_mcp.utils.firmware.intent import load_intent, save_intent
+    intent = _audio_with_placement({"CMCA_MIC": {"locus": "remote", "device": "INMP441"}})
+    assert intent.connector_legends and intent.placements    # populated pre-save
+    p = tmp_path / "intent.yaml"
+    save_intent(intent, str(p))
+    back = load_intent(str(p))
+    assert back.placements["CMCA_MIC"].locus == "remote"
+    assert back.placements["CMCA_MIC"].device == "INMP441"
+    mic_leg = next(L for L in back.connector_legends if L.device == "INMP441")
+    assert mic_leg.positions == ["BCLK", "WS", "SD", "+3V3", "GND"]
+
+
+def test_round_trip_remote_peripheral_stays_consistent(tmp_path):
+    """H2 regression: after save/load, the glue-suppression check (templates) and
+    the placement-exclusion check (generate) must agree — both read placements,
+    never the Peripheral.locus projection independently."""
+    from kicad_mcp.utils.firmware.intent import is_remote, load_intent, save_intent
+    from kicad_mcp.utils.firmware.templates import _peripheral_is_remote
+    intent = _intent(TRACK_GEOM)
+    ref = intent.peripherals[0].ref
+    apply_sidecar(intent, BoardSidecar(placement={ref: {"locus": "remote",
+                                                        "device": "MPU6050"}}))
+    p = tmp_path / "i.yaml"
+    save_intent(intent, str(p))
+    back = load_intent(str(p))
+    per = next(x for x in back.peripherals if x.ref == ref)
+    assert is_remote(back, ref) == _peripheral_is_remote(back, per)   # never split
+
+
+def test_locus_only_projection_without_placement_is_not_behaviorally_remote():
+    """A hand-edited Peripheral.locus='remote' with NO placements entry must not
+    silently land in the split state (placed but glue-suppressed). placements is
+    the single behavioral source: both checks agree it is NOT remote."""
+    from kicad_mcp.utils.firmware.intent import Peripheral, is_remote
+    from kicad_mcp.utils.firmware.templates import _peripheral_is_remote
+    intent = _intent(TRACK_GEOM)
+    p = intent.peripherals[0]
+    p.locus = "remote"                           # projection set, placements empty
+    assert intent.placements == {}
+    assert is_remote(intent, p.ref) is False
+    assert _peripheral_is_remote(intent, p) is False
+
+
+# --- bus-stem apply path (L3) ------------------------------------------------
+
+def test_apply_bus_stem_key_records_placement_without_unknown_gap():
+    intent = _intent(AUDIO)                      # buses, no carded peripherals
+    apply_sidecar(intent, BoardSidecar(placement={
+        "CMCA_MIC": {"locus": "remote", "device": "INMP441"}}))
+    assert intent.placements["CMCA_MIC"].locus == "remote"
+    assert not any(g.kind == "placement_unknown_target" for g in intent.gaps)
+
+
+# --- silk-legend pipeline step: no-legends fast path (M5, no KiCad) -----------
+
+def test_silkscreen_legends_step_noop_without_legends():
+    from kicad_mcp.tools.pcb_pipeline import _step_silkscreen_legends
+    res = _step_silkscreen_legends("/nonexistent.kicad_pcb", [])
+    assert res["status"] == "ok" and res["labels_added"] == 0

--- a/tests/test_firmware_placement_locus.py
+++ b/tests/test_firmware_placement_locus.py
@@ -8,7 +8,6 @@ routing are gated in tests/integration/test_firmware_pcb_pipeline.py.
 from pathlib import Path
 
 import pytest
-import yaml
 
 from kicad_mcp.utils.firmware.intent import build_intent, find_board_id
 from kicad_mcp.utils.firmware.parse import (

--- a/tests/test_firmware_placement_locus.py
+++ b/tests/test_firmware_placement_locus.py
@@ -73,9 +73,10 @@ def test_validate_rejects_unknown_connector():
     assert any("connector" in e for e in errs)
 
 
-def test_validate_remote_io_requires_external_io():
-    errs = _validate({"placement": {"X": {"locus": "on_board_with_remote_io"}}})
-    assert any("external_io" in e for e in errs)
+def test_validate_external_io_is_optional():
+    # external_io is documentary, not required (the realized I2S amp path crosses
+    # speaker outputs intrinsically) — omitting it is NOT a structural error.
+    assert _validate({"placement": {"X": {"locus": "on_board_with_remote_io"}}}) == []
 
 
 def test_validate_rejects_non_list_external_io():
@@ -106,6 +107,56 @@ def test_apply_flags_unknown_placement_key():
     intent = _intent(AUDIO)
     apply_sidecar(intent, BoardSidecar(placement={"NOPE": {"locus": "remote"}}))
     assert any(g.kind == "placement_unknown_target" for g in intent.gaps)
+
+
+# --- support matrix: a directive no template realizes must be flagged (H1) ----
+
+def test_apply_flags_unrealized_locus_on_i2c_bus():
+    """A `remote` directive on an I2C bus has no template handler — it must be
+    flagged, not silently placed on-board."""
+    intent = _intent(AUDIO)        # CMCA_OLED is an I2C bus
+    apply_sidecar(intent, BoardSidecar(placement={
+        "CMCA_OLED": {"locus": "remote", "device": "OLED"}}))
+    assert any(g.kind == "placement_unsupported" for g in intent.gaps)
+
+
+def test_apply_flags_remote_io_on_non_i2s_bus():
+    intent = _intent(AUDIO)        # CMCA_PRESENCE is a UART bus
+    apply_sidecar(intent, BoardSidecar(placement={
+        "CMCA_PRESENCE": {"locus": "on_board_with_remote_io",
+                          "external_io": ["rx"]}}))
+    assert any(g.kind == "placement_unsupported" for g in intent.gaps)
+
+
+def test_apply_flags_remote_io_on_peripheral_ref():
+    """on_board_with_remote_io is not realized for a ref target (only `remote` is)."""
+    intent = _intent(TRACK_GEOM)
+    ref = intent.peripherals[0].ref
+    apply_sidecar(intent, BoardSidecar(placement={
+        ref: {"locus": "on_board_with_remote_io", "external_io": ["sda"]}}))
+    assert any(g.kind == "placement_unsupported" for g in intent.gaps)
+
+
+def test_apply_does_not_flag_realized_bus_combinations():
+    """The three realized BUS combos must NOT be flagged unsupported."""
+    intent = _intent(AUDIO)
+    apply_sidecar(intent, BoardSidecar(placement={
+        "CMCA_MIC": {"locus": "remote", "device": "INMP441"},          # I2S_IN
+        "CMCA_PRESENCE": {"locus": "remote", "device": "LD2410"},       # UART
+        "CMCA_I2S": {"locus": "on_board_with_remote_io",                # I2S_OUT
+                     "device": "MAX98357A", "external_io": ["outp", "outn"]},
+    }))
+    assert not any(g.kind == "placement_unsupported" for g in intent.gaps)
+
+
+def test_apply_does_not_flag_realized_ref_remote():
+    """The 4th realized combo (ref + remote) must NOT be flagged unsupported —
+    pins ('ref', None, 'remote') in _REALIZED_LOCI so dropping it is caught."""
+    intent = _intent(TRACK_GEOM)
+    ref = intent.peripherals[0].ref
+    apply_sidecar(intent, BoardSidecar(placement={
+        ref: {"locus": "remote", "device": "MPU6050"}}))
+    assert not any(g.kind == "placement_unsupported" for g in intent.gaps)
 
 
 # --- locus-aware bus templates (L4) ------------------------------------------

--- a/tests/test_firmware_placement_locus.py
+++ b/tests/test_firmware_placement_locus.py
@@ -1,0 +1,220 @@
+"""Placement-locus unit tests (no KiCad) — board.yaml placement channel, the
+locus-aware bus templates, glue suppression, legends, and the manifest.
+
+Intent/expand are pure Python, so the whole arc up to (but not including) the
+real-KiCad PCB build is exercised here. The PCB silk-legend step + 0-unconnected
+routing are gated in tests/integration/test_firmware_pcb_pipeline.py.
+"""
+from pathlib import Path
+
+import pytest
+import yaml
+
+from kicad_mcp.utils.firmware.intent import build_intent, find_board_id
+from kicad_mcp.utils.firmware.parse import (
+    idf_target_defines,
+    parse_defines,
+    partition,
+    select_active_branches,
+)
+from kicad_mcp.utils.firmware.sidecar import (
+    BoardSidecar,
+    SidecarError,
+    advise_unspecified_placement,
+    apply_sidecar,
+    load_sidecar,
+    _validate,
+)
+from kicad_mcp.utils.firmware.templates import expand_intent
+
+FIXTURES = Path(__file__).parent / "fixtures" / "firmware"
+AUDIO = FIXTURES / "audio_s3" / "config.h"
+TRACK_GEOM = FIXTURES / "track_geometry" / "config.h"
+
+
+def _intent(config_h: Path):
+    board = find_board_id(str(config_h))
+    text = select_active_branches(config_h.read_text(), idf_target_defines(board))
+    parsed = partition(parse_defines(text))
+    return build_intent(parsed, firmware_path=str(config_h), board_id=board)
+
+
+def _audio_with_placement(placement: dict):
+    intent = _intent(AUDIO)
+    apply_sidecar(intent, BoardSidecar(placement=placement))
+    return expand_intent(intent)
+
+
+def _types(intent):
+    return [p.type for p in intent.peripherals]
+
+
+def _legend(intent, ref):
+    return next(L for L in intent.connector_legends if L.ref == ref)
+
+
+# --- board.yaml placement validation (L5) ------------------------------------
+
+def test_validate_accepts_well_formed_placement():
+    d = {"placement": {
+        "CMCA_MIC": {"locus": "remote", "device": "INMP441"},
+        "CMCA_I2S": {"locus": "on_board_with_remote_io", "device": "MAX98357A",
+                     "external_io": ["outp", "outn"]},
+    }}
+    assert _validate(d) == []
+
+
+def test_validate_rejects_unknown_locus():
+    errs = _validate({"placement": {"X": {"locus": "floating"}}})
+    assert any("locus" in e for e in errs)
+
+
+def test_validate_rejects_unknown_connector():
+    errs = _validate({"placement": {"X": {"locus": "remote", "connector": "magnets"}}})
+    assert any("connector" in e for e in errs)
+
+
+def test_validate_remote_io_requires_external_io():
+    errs = _validate({"placement": {"X": {"locus": "on_board_with_remote_io"}}})
+    assert any("external_io" in e for e in errs)
+
+
+def test_validate_rejects_non_list_external_io():
+    errs = _validate({"placement": {"X": {"locus": "on_board_with_remote_io",
+                                          "external_io": "outp"}}})
+    assert any("external_io" in e for e in errs)
+
+
+def test_load_sidecar_raises_on_bad_placement(tmp_path):
+    p = tmp_path / "board.yaml"
+    p.write_text("placement: {CMCA_MIC: {locus: bogus}}")
+    with pytest.raises(SidecarError):
+        load_sidecar(str(p))
+
+
+# --- apply: records placements + flags unknown keys --------------------------
+
+def test_apply_records_placement_and_projects_peripheral_locus():
+    intent = _intent(TRACK_GEOM)            # has carded peripherals (U2/U3/U4)
+    ref = intent.peripherals[0].ref
+    apply_sidecar(intent, BoardSidecar(placement={ref: {"locus": "remote",
+                                                        "device": "Remote sensor"}}))
+    assert intent.placements[ref].locus == "remote"
+    assert next(p for p in intent.peripherals if p.ref == ref).locus == "remote"
+
+
+def test_apply_flags_unknown_placement_key():
+    intent = _intent(AUDIO)
+    apply_sidecar(intent, BoardSidecar(placement={"NOPE": {"locus": "remote"}}))
+    assert any(g.kind == "placement_unknown_target" for g in intent.gaps)
+
+
+# --- locus-aware bus templates (L4) ------------------------------------------
+
+def test_remote_i2s_mic_becomes_terminal_no_chip():
+    intent = _audio_with_placement({"CMCA_MIC": {"locus": "remote", "device": "INMP441"}})
+    assert "SPH0645" not in _types(intent)            # no on-board mic chip
+    terms = [p for p in intent.peripherals if p.value == "INMP441"]
+    assert len(terms) == 1
+    t = terms[0]
+    assert t.type == "TERM"
+    assert t.lib_id == "Connector:Screw_Terminal_01x05"  # BCLK/WS/SD/+3V3/GND
+    leg = _legend(intent, t.ref)
+    assert leg.positions == ["BCLK", "WS", "SD", "+3V3", "GND"]
+    assert any(g.kind == "remote_device" and "INMP441" in g.detail for g in intent.gaps)
+
+
+def test_remote_uart_becomes_terminal_no_header():
+    intent = _audio_with_placement({"CMCA_PRESENCE": {"locus": "remote", "device": "LD2410"}})
+    terms = [p for p in intent.peripherals if p.value == "LD2410"]
+    assert len(terms) == 1
+    assert terms[0].lib_id == "Connector:Screw_Terminal_01x04"  # RX/TX/+3V3/GND
+    assert _legend(intent, terms[0].ref).positions == ["RX", "TX", "+3V3", "GND"]
+
+
+def test_on_board_with_remote_io_amps_get_screw_terminal_speakers():
+    intent = _audio_with_placement({
+        "CMCA_I2S": {"locus": "on_board_with_remote_io", "device": "MAX98357A",
+                     "external_io": ["outp", "outn"]},
+    })
+    # amps stay on board
+    assert _types(intent).count("MAX98357A") >= 2
+    # CMCA_I2S speakers are screw terminals; the OTHER (unplaced) I2S bus stays pin header
+    spk_terms = [p for p in intent.peripherals
+                 if p.type == "TERM" and str(p.value).startswith("SPK0")]
+    assert spk_terms and all(
+        p.lib_id == "Connector:Screw_Terminal_01x02" for p in spk_terms)
+
+
+def test_default_speaker_is_pin_header_not_terminal():
+    intent = _audio_with_placement({})       # no placement -> default behavior
+    spk = [p for p in intent.peripherals if str(p.value).startswith("SPK")]
+    assert spk and all(p.type == "HDR" for p in spk)   # pin headers (back-compat)
+    assert all(p.lib_id == "Connector_Generic:Conn_01x02" for p in spk)
+
+
+# --- glue suppression --------------------------------------------------------
+
+def test_remote_mic_emits_no_bypass_cap():
+    """The remote mic's bypass cap lives at the device, not on this board: the
+    remote build has fewer caps than the on-board build."""
+    on_board = _audio_with_placement({})
+    remote = _audio_with_placement({"CMCA_MIC": {"locus": "remote", "device": "INMP441"}})
+    assert _types(remote).count("C") < _types(on_board).count("C")
+
+
+def test_remote_peripheral_excluded_from_power_ties():
+    """A carded peripheral made remote is not tied to +3V3 on the board; power is
+    delivered over the terminal's tap instead."""
+    intent = _intent(TRACK_GEOM)
+    ref = intent.peripherals[0].ref          # an MPU6050 instance
+    apply_sidecar(intent, BoardSidecar(placement={ref: {"locus": "remote",
+                                                        "device": "MPU6050"}}))
+    intent = expand_intent(intent)
+    rail = next(n for n in intent.nets if n.name == "+3V3")
+    assert ref not in {ep.ref for ep in rail.endpoints}   # not tied on-board
+    # but a remote terminal exists carrying it
+    assert any(g.kind == "remote_device" for g in intent.gaps)
+
+
+# --- edge cases --------------------------------------------------------------
+
+def test_remote_without_device_name_still_emits_terminal_and_legend():
+    intent = _audio_with_placement({"CMCA_MIC": {"locus": "remote"}})  # no device
+    terms = [p for p in intent.peripherals
+             if p.type == "TERM" and p.lib_id == "Connector:Screw_Terminal_01x05"]
+    assert len(terms) == 1
+    leg = _legend(intent, terms[0].ref)
+    assert leg.device == "I2S mic"                    # fallback identity
+    assert leg.positions == ["BCLK", "WS", "SD", "+3V3", "GND"]
+
+
+def test_two_remote_buses_get_distinct_collision_free_refs():
+    intent = _audio_with_placement({
+        "CMCA_MIC": {"locus": "remote", "device": "INMP441"},
+        "CMCA_PRESENCE": {"locus": "remote", "device": "LD2410"},
+    })
+    refs = [p.ref for p in intent.peripherals if p.type == "TERM"]
+    assert len(refs) == len(set(refs))                # no collisions
+    assert {p.value for p in intent.peripherals if p.type == "TERM"} >= {"INMP441", "LD2410"}
+
+
+# --- advisory (Open Decision 1) ----------------------------------------------
+
+def test_advisory_lists_unset_field_wired_buses():
+    intent = _intent(AUDIO)                  # I2S_IN/I2S_OUT/UART buses, no placement
+    advise_unspecified_placement(intent)
+    adv = [g for g in intent.gaps if g.kind == "placement_unspecified"]
+    assert len(adv) == 1
+    assert "CMCA_MIC" in adv[0].detail and "CMCA_PRESENCE" in adv[0].detail
+
+
+def test_advisory_idempotent_and_skips_placed():
+    intent = _intent(AUDIO)
+    apply_sidecar(intent, BoardSidecar(placement={
+        "CMCA_MIC": {"locus": "remote", "device": "INMP441"}}))
+    advise_unspecified_placement(intent)
+    advise_unspecified_placement(intent)     # second call must not stack
+    adv = [g for g in intent.gaps if g.kind == "placement_unspecified"]
+    assert len(adv) == 1
+    assert "CMCA_MIC" not in adv[0].detail   # placed bus excluded from the nudge


### PR DESCRIPTION
## Placement locus — `on_board` / `remote` / `on_board_with_remote_io`

Adds a fourth axis to the firmware front-end design intent: **where a device physically lives**. A device can now be placed on-board (current behavior), declared **`remote`** (field-wired — not placed; a screw terminal is synthesized and its nets cross to it), or **`on_board_with_remote_io`** (placed, but external-load nets cross to a terminal). For the audio-node this turns "MCU + amp + power core ringed by screw terminals" into something the model can actually express.

### Code-reality binding (a deliberate divergence from the spec)
The spec keyed locus by device *type* (`INMP441`), but those identities exist only in firmware **comments** — the macros are `CMCA_MIC_*`, `CMCA_PRESENCE_*`. A cold review caught this; after confirming the direction, `board.yaml placement:` is keyed by the handle that actually exists in the intent — a **bus stem** (`CMCA_MIC`) or a **peripheral ref** (`U2`) — with the device identity human-supplied (`device: INMP441`). `intent.placements` is the single source for the decision. This expanded scope to locus-aware bus templates (the audio-node's remote devices are bus-template artifacts, not first-class peripherals).

### What's in it (L1–L8)
- **connectors.py** — one `synthesize_connector` helper all three connector fragments now share (sizes `Screw_Terminal_01xN`/`Conn_01xN`, validates N vs symbol pin count — a latent bug none of them checked, emits a silk legend).
- **Locus-aware templates** — remote I2S mic / UART sensor → screw terminal (no substitute chip, glue suppressed); `on_board_with_remote_io` I2S amps → screw-terminal speakers; a `remote_peripherals` template for ref-keyed carded devices; `generate.py` excludes remote peripherals from placement.
- **board.yaml `placement:`** channel with validation + a `_REALIZED_LOCI` support matrix that flags a directive no template realizes (honest-by-construction, never a silent no-op).
- **Silk legends** — `pcb_pipeline` labels each synthesized terminal's pads (the field-wiring documentation) above the pad edge, with overlap-safe placement; strictly non-fatal.
- **Manifest** annotations (remote devices off-board with their terminal) + an advisory nudge for unset field-wired buses.

### Verification
- **Real KiCad 10:** 5/5 firmware integration tests, including a new end-to-end `test_audio_remote_to_routed_pcb` — the audio board builds with screw terminals instead of SPH0645/LD2410, routes within bounds, and every legend label clears every pad.
- **Eyeballed** the routed board: terminals carry correct per-pad legends (`BCLK/WS/SD/+3V3/GND`, `RX/TX/+3V3/GND`, `L±`/`R±`).
- Two cold-review passes (tests + implementation) + a targeted diff review; every finding fixed (notably the support-matrix gap and the silk step's broken "non-fatal" guarantee) or pinned by a test.
- Suite **332 firmware / 1806 total**, mypy clean (71 files), tool count unchanged (17).

### Deferred (tracked for a follow-up, mostly upstream)
Auto-placement quality surfaced by the rendered board — edge-aware terminal placement/orientation, sensible connector ordering, board auto-sizing (all in the generic autoplacer, affect all boards) — plus per-pad silk on module headers (the OLED J6). The locus feature itself is correct and complete; these are separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
