### PR TITLE
ci(dependabot): use --rebase in auto-merge (repo forbids merge commits)

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -10,6 +10,11 @@ name: Dependabot auto-merge
 #   3. Stale-cleanup workflow nudges Dependabot to rebase PRs that
 #      go untouched for >24h.
 #
+# NOTE: this repo allows ONLY rebase merges (allow_merge_commit and
+# allow_squash_merge are both false), so every `gh pr merge` here MUST use
+# --rebase. `--merge` fails with "Merge method merge commits are not allowed
+# on this repository", which silently left every Dependabot PR un-merged.
+#
 # Filter logic:
 #   * Security PR (any severity)            → auto-merge enabled
 #   * version-update:semver-patch           → auto-merge enabled
@@ -53,14 +58,14 @@ jobs:
         # alert-state is set only on security PRs (regardless of severity).
         # Security fixes auto-merge whenever CI passes — we want them in fast.
         if: steps.meta.outputs.alert-state != ''
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Auto-merge patch version updates
         if: steps.meta.outputs.update-type == 'version-update:semver-patch'
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -97,7 +102,7 @@ jobs:
             new_mm=$(echo "$new" | cut -d. -f1,2)
             if [ "$prev_mm" = "$new_mm" ] && [ "$prev" != "$new" ]; then
               echo "Patch-only constraint bump: $prev → $new — enabling auto-merge"
-              gh pr merge --auto --merge "$PR_URL"
+              gh pr merge --auto --rebase "$PR_URL"
               exit 0
             fi
           fi


### PR DESCRIPTION
## Problem
The Dependabot auto-merge workflow (`.github/workflows/dependabot-automerge.yml`) calls `gh pr merge --auto --merge` at all three sites (security / patch / constraint-patch). This repo allows **only rebase merges** (`allow_merge_commit` and `allow_squash_merge` both false), so each attempt fails:

```
GraphQL: Merge method merge commits are not allowed on this repository (enablePullRequestAutoMerge)
```

The `automerge` check goes red and every Dependabot PR sits un-merged despite green required CI (observed on #60 and #61).

## Fix
- Switch all three `gh pr merge` calls from `--merge` to `--rebase`.
- Document the rebase-only constraint in the workflow header so it isn't reintroduced.

No behavior change beyond the merge method; the severity/bump-type filter logic is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)