### PR TITLE
ci(integration): multi-runner safe — KiCad config isolation + cancel-in-progress

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,6 +9,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # One in-flight integration run per PR; a new push to the same PR cancels the
+  # superseded run so it stops occupying a scarce self-hosted runner. Keyed by
+  # github.ref, so different PRs never cancel each other. cancel-in-progress is
+  # gated to pull_request events ONLY — push-to-main runs are never cancelled
+  # (every merge commit must be fully tested before the next one lands).
+  group: integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   integration:
     name: integration / kicad-${{ matrix.kicad }}
@@ -40,6 +49,13 @@ jobs:
         run: uv sync
 
       - name: Run integration tests
+        # Isolate KiCad's config/cache per runner so concurrent kicad-cli runs
+        # (multiple self-hosted runners on one machine) can't race on shared
+        # config init or lock files. runner.temp is unique per runner and wiped
+        # per job. Verified: KiCad 10 honors KICAD_CONFIG_HOME (writes
+        # kicad_common.json there, ignores $HOME).
+        env:
+          KICAD_CONFIG_HOME: ${{ runner.temp }}/kicad-config
         run: |
           KICAD_INTEGRATION=1 uv run pytest tests/integration/ -v \
             --tb=short \


### PR DESCRIPTION
Prep for running **3 self-hosted runners** on the Studio so the integration matrix (kicad 9.0 + 10.0) and concurrent PRs stop serializing on one runner.

Two changes, both scoped to `.github/workflows/integration.yml`:

### 1. Per-runner KiCad config isolation
Concurrent `kicad-cli` runs on one machine could race on shared config init / lock files. Point `KICAD_CONFIG_HOME` at `${{ runner.temp }}/kicad-config` — unique per runner, wiped per job.

Verified locally that KiCad 10 honors the var (writes `kicad_common.json` there and ignores `$HOME`); KiCad also namespaces config under a version subdir, so the two matrix legs wouldn't collide even on a shared dir.

### 2. `concurrency` cancel-in-progress
Keyed by `github.ref`, with `cancel-in-progress` gated to `pull_request` events:
- a new push to a PR cancels its superseded run → frees the runner
- different PRs never cancel each other (distinct refs)
- **push-to-main runs are never cancelled** (every merge commit must be fully tested)

No behavior change on a single runner — this only removes contention/waste once more runners exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)