### PR TITLE
ci: add merge_group triggers (prereq for merge queue)

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Run on the merge queue's temp refs so the required check-docs check gates
+  # queued PRs (the queue blocks forever on a required check that never runs).
+  merge_group:
 
 jobs:
   check-docs:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Run on the merge queue's temp refs so "integration / kicad-10.0" can gate
+  # queued PRs. cancel-in-progress below is gated to pull_request, so a queue
+  # run is never cancelled.
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Run on the merge queue's temp refs so this workflow's required checks
+  # (pytest, check-mypy) gate queued PRs — without this the queue would wait
+  # forever for a check that never runs.
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
Prerequisite for enabling a **GitHub merge queue** on `main`.

A merge queue tests each PR on a temporary `gh-readonly-queue/...` ref via the `merge_group` event. Any status check the queue requires **must** run on that event, or the queue blocks forever waiting for a check that never reports.

Adds `merge_group:` to the three workflows producing the checks the queue will require:
- `tests.yml` → `pytest` (+ `check-mypy`)
- `docs-check.yml` → `check-docs`
- `integration.yml` → `integration / kicad-10.0`

**Inert until the queue is switched on** in branch protection — adds nothing to PR or push runs. `integration.yml`'s `cancel-in-progress` is already gated to `pull_request`, so a queue run is never cancelled.

Once this lands I'll enable the queue (require `pytest` + `check-docs` + `integration / kicad-10.0`), drop the now-redundant 'require up-to-date' flag, and report back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)