### PR TITLE
feat(placement): autoplacer v1.1 — mounting holes (Phase 5) + approval gate (Phase 7)

### DIFF
--- a/docs/PLAN_Autoplacer_v1.1.md
+++ b/docs/PLAN_Autoplacer_v1.1.md
@@ -1,0 +1,46 @@
+# Autoplacer v1.1 — Implementation Plan (Phase 5 + Phase 7)
+
+Branch `feat/autoplacer-v1.1` off `main`. Continues the human-rational autoplacer
+(v1 merged). See `docs/PLAN_Autoplacer_Human_Rational_System.md` for the parent plan.
+
+## Default decisions taken (override if wrong)
+- **count=2 holes** → top-left + bottom-right (diagonal).
+- **Hole footprint** → `MountingHole_3.2mm_M3_Pad_TopOnly` (copper pad on F.Cu; allows optional GND tie). Present + name-stable on KiCad 9 AND 10.
+- **`approved` default** = `True` on `build_pcb_from_schematic` (gate is opt-in; the real user-facing gate is the `design` op `propose_placement`).
+- **Render fidelity** = Level A (real temp PCB + `kicad-cli pcb export svg`), fallback `render_path: null` if cli absent.
+
+---
+
+## Phase 5 — Mounting holes
+
+1. **`sidecar.py`** — add `mounting_holes` to `BoardSidecar` (`count`/`drill_mm`/`inset_mm`/`keepout_mm`, all optional). Add `_KNOWN_SIDECAR_KEYS` frozenset + reject unknown top-level keys in `_validate`. Add `_validate_mounting_holes` (count ∈ {0,2,4}; positive numerics). Populate in `load_sidecar`; thread through `intent.source["mounting_holes"]` in `apply_sidecar`.
+2. **`pcb_pipeline.py`** — pure `_resolve_mounting_holes(mh_source)` merging defaults (`_HOLE_DEFAULTS = {count:4, drill_mm:3.2, inset_mm:3.5, keepout_mm:1.5}`); `count=0` disables.
+3. **`pcb_pipeline.py`** — new `_step_add_mounting_holes(pcb_path, holes)` (embedded pcbnew script): compute 4 corner positions from `inset_mm`; `FootprintLoad` the MountingHole; refs `H1..H4`; add a circular rule-area keepout per hole (radius = drill/2 + keepout_mm; `SetDoNotAllowTracks/Vias/Pads`; layer set via `GetEnabledLayers() & LSET.AllCuMask()`; KiCad 9/10 zone-fill compat via the `hasattr` pattern in `keepout_helpers.py:74`). **Use layer-ID constants, never name strings** (KiCad 10 F.CrtYd→F.Courtyard).
+4. **`pcb_pipeline.py`** — drop `"H"` from `_EDGE_DESIGNATOR_CLASSES` (line ~269) and the tier-2 docstring; holes are fixtures now, placed before the tier system.
+5. **`pcb_pipeline.py`** — return hole positions from the step; caller builds `fixed` placement hints for `H1..H4` so the engine registers their keepout boxes and later tiers avoid them.
+6. **`pcb_pipeline.py`** — `_content_aware_size` gains `corner_inset_mm=0.0` (added to both dims); default 0 keeps existing sizing tests green. `_estimate_board_size` passes `holes["inset_mm"]`.
+7. **`build_pcb_from_schematic`** — resolve holes from `design_intent.source`; run the hole step after outline; merge hole hints first (user hints override); add `add_mounting_holes` param (or infer from `count>0`).
+
+Tests: `TestResolveMountingHoles`, `TestContentAwareSizeWithCornerInset` (boundary at inset=0), sidecar unknown-key + count/drill boundary tests, integration `_refs_at_corners` assertion on `test_audio_remote_to_routed_pcb`, and a `count:0` → no-H-refs case.
+
+---
+
+## Phase 7 — Approval gate (`propose_placement`)
+
+1. **`pcb_pipeline.py`** — extract the terminal-edge-assignment loop (currently embedded-script lines ~1019–1040, pure: math + fp summaries + placement_decisions) into a pure Python `_plan_terminal_edges(...)`. Single source: the embedded script consumes it via params (like `wire_entry_table`); the parent-side propose op calls it directly. **No logic duplication.**
+2. **`design.py`** — `_op_propose_placement(*, intent_path, schematic_path, out_dir)`: load intent → extract netlist from the (already-generated) schematic → `_estimate_board_size(holes=...)` → `_plan_terminal_edges(...)` → emit terminal table + render. Workflow: `… generate_schematic → propose_placement → [human approves] → build_pcb_from_schematic`.
+3. **Render (Level A)** — build a temp PCB: `_step_create_pcb_and_outline` + `_step_add_mounting_holes` + a trimmed footprint-place-only step (stack J-refs on assigned edges, no nets/no routing), then `kicad-cli pcb export svg --layers F.Cu,B.Cu,F.SilkS,Edge.Cuts` (same path as `export.py:257`).
+4. **Response** — `{board_size_mm, antenna_edge, mounting_holes[], terminal_table[], crowded_edges[], render_path, proposed_board_yaml}`. `proposed_board_yaml` round-trips through `load_sidecar`.
+5. **`design.py`** — register `propose_placement` in the router dispatch + docstring (`schematic_path` param already exists).
+6. **`build_pcb_from_schematic`** — `approved: bool = True`; when `False`, run steps 1–4 only, return `status:"pending_approval"` + `proposal`. Programmer escape hatch, not the primary gate.
+
+Tests: `TestPlanTerminalEdges` (empty / one-edge / overflow boundary / no-antenna / over-wide), `TestProposeBoardYaml` (valid keys, round-trip), integration `test_propose_placement_audio_remote` (antenna_edge=top, no terminal on antenna edge, render non-empty, proposed_board_yaml loads, 4 holes).
+
+## External-system assumptions to verify
+- `MountingHole_3.2mm_M3_Pad_TopOnly` present on KiCad 9 & 10 (confirmed via find).
+- `SetDoNotAllowZoneFills` vs `SetDoNotAllowCopperPour` (9/10) on a rule-area zone.
+- `kicad-cli pcb export svg` valid from outline+footprints, no routed nets.
+- `zone.SetLayerSet(... AllCuMask())` on both versions (CI-gate).
+
+## Sequencing
+Phase 5 sidecar+pure helpers → `_content_aware_size` inset → Phase 7 `_plan_terminal_edges` extraction → Phase 5 hole step + `_EDGE_DESIGNATOR_CLASSES` → orchestrator wiring → Phase 7 op+render → router+`approved`.

--- a/docs/PLAN_Autoplacer_v1.1.md
+++ b/docs/PLAN_Autoplacer_v1.1.md
@@ -44,3 +44,17 @@ Tests: `TestPlanTerminalEdges` (empty / one-edge / overflow boundary / no-antenn
 
 ## Sequencing
 Phase 5 sidecar+pure helpers → `_content_aware_size` inset → Phase 7 `_plan_terminal_edges` extraction → Phase 5 hole step + `_EDGE_DESIGNATOR_CLASSES` → orchestrator wiring → Phase 7 op+render → router+`approved`.
+
+## DEFERRED (RFE — cosmetic sizing quality, correctness complete)
+Phase 5 + Phase 7 are DONE and verified (integration 6/6 on KiCad 9 & 10), incl.
+two eyeball-driven fixes (holes pinned at corners; terminals cleared of corner
+holes). Deferred sizing polish, in priority order:
+1. **Axis-aware corner reservation.** `_hole_corner_clear` is reserved on BOTH
+   board axes, but only the terminal-EDGE (along) axis needs the full clearance;
+   the depth axis needs only the hole-center inset. Result: the board is taller
+   than the content needs (dead band between the interior cluster and the terminal
+   row). Fix: reserve full clearance only along the terminal edge, hole-center
+   inset on the depth axis. Cosmetic — does not affect routing/correctness.
+2. **Multi-edge terminal distribution** (the original v1 board-AREA RFE): spread
+   terminals across antenna-opposite + side edges → squarer, smaller board vs. the
+   current single-edge letterbox. Bigger change (side-edge silk crowding).

--- a/docs/SPEC_Autoplacer_Human_Rational_System.md
+++ b/docs/SPEC_Autoplacer_Human_Rational_System.md
@@ -171,6 +171,8 @@ orientation, `estimate_board_size` = area×2.5 + keepout, keepout-merged-into-fi
 
 - **Scope note — mounting holes are not greenfield.** `H` is already in `EDGE_CLASSES` →
   tier-2 edge placement today; §3's corner-fixtures path is a *change* from that, not a new
-  capability. And new `board.yaml` keys (mounting_holes, per-terminal order) **silently no-op**
-  unless added to the dataclass + `_validate` + `load_sidecar` + `apply_sidecar` together —
-  the validator currently ignores unknown keys (worth fixing: reject/warn on unknown keys).
+  capability. A new `board.yaml` key must be added to the dataclass + `_validate` +
+  `load_sidecar` + `apply_sidecar` together. **As of v1.1 the sidecar validator REJECTS
+  unknown top-level keys (and unknown `mounting_holes` sub-keys) with a `SidecarError`** —
+  a typo like `board_size` for `board_size_mm` is loud, not a silent no-op. (Earlier drafts
+  of this spec said unknown keys silently no-op; that is no longer true.)

--- a/src/kicad_mcp/tools/pcb_pipeline.py
+++ b/src/kicad_mcp/tools/pcb_pipeline.py
@@ -190,9 +190,10 @@ def _step_create_pcb_and_outline(
         if not fp_specs:
             return {"error": "No footprints to estimate board size from"}
 
-        inset = (holes["inset_mm"]
-                 if holes and holes.get("count", 0) > 0 else 0.0)
-        size_result = _estimate_board_size(fp_specs, corner_inset_mm=inset)
+        # Reserve the FULL corner clearance (center inset + keepout), not just the
+        # hole-center inset, so terminals laid out past the corner holes still fit.
+        size_result = _estimate_board_size(
+            fp_specs, corner_inset_mm=_hole_corner_clear(holes))
         if "error" in size_result:
             return size_result
 
@@ -291,6 +292,18 @@ def _resolve_mounting_holes(mh_source: Optional[Dict[str, Any]]) -> Dict[str, An
     if mh_source:
         holes.update({k: mh_source[k] for k in _HOLE_DEFAULTS if k in mh_source})
     return holes
+
+
+def _hole_corner_clear(holes: Optional[Dict[str, Any]]) -> float:
+    """Along-edge distance from a board corner that a mounting hole occupies: the
+    hole CENTER is ``inset`` in, and its keepout extends ``drill/2 + keepout``
+    further, so the corner is occupied out to their sum. 0 when holes are off.
+    SINGLE SOURCE for both board sizing (reserve this much at each corner) and
+    terminal layout (start the run past it) — so the two never disagree and a
+    terminal can't land on a hole."""
+    if not holes or holes.get("count", 0) <= 0:
+        return 0.0
+    return float(holes["inset_mm"] + holes["drill_mm"] / 2.0 + holes["keepout_mm"])
 
 
 def _step_add_mounting_holes(pcb_path: str, holes: Dict[str, Any]) -> Dict[str, Any]:
@@ -730,6 +743,7 @@ def _step_smart_placement(
     nets: Dict[str, List],
     spacing_mm: float = 1.0,
     placement_hints: Optional[Dict[str, Dict[str, Any]]] = None,
+    corner_clear_mm: float = 0.0,
 ) -> Dict[str, Any]:
     """Step 5: Smart tiered placement based on connectivity and component type.
 
@@ -759,6 +773,7 @@ params = json.loads(open(sys.argv[1]).read())
 
 board = pcbnew.LoadBoard(params["pcb_path"])
 spacing = params["spacing_mm"]
+corner_clear = params.get("corner_clear_mm", 0.0)  # corner space the mounting holes occupy
 outline = get_board_outline(board)
 
 if not outline:
@@ -1222,7 +1237,16 @@ for edge in ("top", "bottom", "left", "right"):
         if hint:
             placement_decisions.append({"event": "placement_hint_applied",
                                         "ref": ref, "directive": hint})
-    laid = layout_along_edge(items, edge, board_box, margin, spacing)
+    # Shrink the usable span ALONG this edge by the corner-hole clearance so the
+    # terminal run starts/ends past the two corner mounting holes (the cross-axis
+    # / seating depth is untouched). Without this a field terminal lands on a hole.
+    if edge in ("top", "bottom"):
+        lay_box = (board_xmin + corner_clear, board_ymin,
+                   board_xmax - corner_clear, board_ymax)
+    else:
+        lay_box = (board_xmin, board_ymin + corner_clear,
+                   board_xmax, board_ymax - corner_clear)
+    laid = layout_along_edge(items, edge, lay_box, margin, spacing)
     for (ref, x, y, fits) in laid:
         ang, rext, rpad = rot_by_ref[ref]
         el, er, et, eb = rext
@@ -1371,6 +1395,7 @@ print(json.dumps({
     return run_pcbnew_script(script, params={
         "pcb_path": pcb_path,
         "spacing_mm": spacing_mm,
+        "corner_clear_mm": corner_clear_mm,
         "net_members": dict(net_members),
         "placement_hints": dict(placement_hints or {}),
         "edge_classes": list(_EDGE_DESIGNATOR_CLASSES),
@@ -1971,8 +1996,12 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
             clean_hints.update(norm_holes)
             hint_warnings.extend(hole_ws)
 
-        # Step 5: Smart placement (tiered, connectivity-aware)
-        step = _step_smart_placement(pcb_path, nets, placement_hints=clean_hints)
+        # Step 5: Smart placement (tiered, connectivity-aware). corner_clear keeps
+        # edge terminals clear of the corner mounting holes (single source with
+        # the board-size reservation above, so the cleared span actually fits).
+        step = _step_smart_placement(
+            pcb_path, nets, placement_hints=clean_hints,
+            corner_clear_mm=_hole_corner_clear(holes))
         _record("smart_placement", step)
         # Non-fatal — continue even if placement is imperfect
 

--- a/src/kicad_mcp/tools/pcb_pipeline.py
+++ b/src/kicad_mcp/tools/pcb_pipeline.py
@@ -1621,6 +1621,66 @@ print(json.dumps({"status": "ok", "labels_added": labels_added,
     return res
 
 
+def _render_board_svg(pcb_path: str) -> Optional[str]:
+    """Best-effort flat SVG of the board (copper + silk + edge) for the approval
+    proposal. Returns the path, or None if kicad-cli is unavailable or the export
+    fails — NEVER raises: the proposal's value is its data; the picture is a bonus."""
+    try:
+        cli = get_kicad_cli_path(required=True)
+    except KiCadCLIError:
+        return None
+    assert cli is not None
+    out = os.path.splitext(pcb_path)[0] + "_proposal.svg"
+    try:
+        r = subprocess.run(
+            [cli, "pcb", "export", "svg", pcb_path, "-o", out,
+             "--layers", "F.Cu,B.Cu,F.SilkS,Edge.Cuts", "--page-size-mode", "2"],
+            capture_output=True, text=True, timeout=60,
+        )
+        return out if (r.returncode == 0 and os.path.exists(out)) else None
+    except (subprocess.SubprocessError, OSError):
+        return None
+
+
+def _build_placement_proposal(
+    pcb_path: str,
+    width_mm: float,
+    height_mm: float,
+    antenna_edge: Optional[str],
+    terminal_edges: Dict[str, str],
+    hole_positions: List[Dict[str, Any]],
+    legends: List[Dict[str, Any]],
+    holes: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Assemble the approval-gate proposal for the PLACED (unrouted) board: board
+    size, antenna edge, the per-terminal edge+device+positions table, the corner
+    hole positions, a machine-readable ``proposed_board_yaml`` the user can tweak
+    in natural language (Claude translates), and a best-effort SVG render. All
+    derived from the REAL placement decisions — no re-derivation, no seam."""
+    legend_by_ref = {L["ref"]: L for L in legends}
+    terminal_table = [
+        {"ref": ref, "edge": edge,
+         "device": (legend_by_ref.get(ref) or {}).get("device"),
+         "positions": (legend_by_ref.get(ref) or {}).get("positions", [])}
+        for ref, edge in sorted(terminal_edges.items())
+    ]
+    proposed_board_yaml: Dict[str, Any] = {
+        "board_size_mm": [width_mm, height_mm],
+        "mounting_holes": {k: holes[k]
+                           for k in ("count", "drill_mm", "inset_mm", "keepout_mm")},
+        "placement_hints": {ref: {"edge": edge}
+                            for ref, edge in sorted(terminal_edges.items())},
+    }
+    return {
+        "board_size_mm": [width_mm, height_mm],
+        "antenna_edge": antenna_edge,
+        "terminal_table": terminal_table,
+        "mounting_holes": hole_positions,
+        "render_path": _render_board_svg(pcb_path),
+        "proposed_board_yaml": proposed_board_yaml,
+    }
+
+
 def _step_export_gerbers(pcb_path: str) -> Dict[str, Any]:
     """Step 8 (optional): Export Gerber + drill files and create ZIP."""
     try:
@@ -1714,6 +1774,7 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
         intent_path: str = "",
         placement_hints: Optional[Dict[str, Dict[str, Any]]] = None,
         add_mounting_holes: bool = True,
+        approved: bool = True,
     ) -> Dict[str, Any]:
         """Build a complete routed PCB from a KiCad schematic in one step.
 
@@ -1745,6 +1806,13 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
                 Its ``source.board_size_mm`` (if any) sizes the board when no
                 explicit dimensions are given, and its ``placement_hints`` feed
                 the per-ref placement overrides below.
+            approved: When False, the APPROVAL GATE (spec §7): run the pipeline
+                through placement (which produces the real terminal-edge layout)
+                but STOP before the expensive autoroute, returning
+                ``status="pending_approval"`` and a ``proposal`` (board size,
+                antenna edge, per-terminal edge/positions table, hole positions,
+                a tweakable ``proposed_board_yaml``, and a best-effort SVG render).
+                Re-run with ``approved=True`` once the layout looks right.
             add_mounting_holes: Add corner M3 mounting holes (default True). The
                 count/drill/inset/keepout come from the design intent's
                 ``source.mounting_holes`` (board.yaml) or default to 4 × M3; pass
@@ -1853,12 +1921,14 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
         # placer is told to pin them (fixed hints below) so they stay at the
         # corners and their keepout boxes are reserved against other parts.
         hole_hints: Dict[str, Dict[str, Any]] = {}
+        hole_positions: List[Dict[str, Any]] = []
         if holes.get("count", 0) > 0:
             step_holes = _step_add_mounting_holes(pcb_path, holes)
             _record("mounting_holes", step_holes)   # non-fatal
+            hole_positions = step_holes.get("positions") or []
             hole_hints = {
                 r["ref"]: {"fixed": [r["x_mm"], r["y_mm"]], "rotation": 0}
-                for r in (step_holes.get("positions") or [])
+                for r in hole_positions
             }
 
         # Step 3: Load footprints onto board (temporary positions)
@@ -1905,6 +1975,24 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
             if d.get("event") == "rotation_chosen" and d.get("edge")
         }
 
+        def _run_silk_legends() -> None:
+            """Silk-legend pass (single source — used by the approval gate AND the
+            post-route step). Strictly NON-FATAL: a bad intent or a pcbnew failure
+            (run_pcbnew_script RAISES) is recorded, never propagated."""
+            if design_intent is None:
+                return
+            try:
+                _legends = [
+                    {"ref": L.ref, "positions": L.positions, "device": L.device}
+                    for L in design_intent.connector_legends
+                ]
+                _record("silkscreen_legends",
+                        _step_silkscreen_legends(pcb_path, _legends,
+                                                 terminal_edges=terminal_edges))
+            except Exception as e:  # noqa: BLE001 — documentation step, never fatal
+                _record("silkscreen_legends",
+                        {"error": f"silk legend step failed (non-fatal): {e}"})
+
         # Surface placement decisions + hint diagnostics as an events envelope
         # (mcp-events). Info-level rotation/hint records included so the response
         # documents what the autoplacer chose; warnings for bad/unmatched hints.
@@ -1926,6 +2014,28 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
             _env = _ev.to_envelope("info")
         if _env:
             pipeline_result["events"] = _env
+
+        # Approval gate (§7): stop BEFORE the expensive autoroute and return a
+        # proposal of the placed (unrouted) board. Placement is done, so the
+        # terminal edges/holes are REAL; only routing (the 3–4 min FreeRouter
+        # pass) is skipped. Run silk first so the render documents the terminals.
+        if not approved:
+            _run_silk_legends()
+            antenna_edge = next(
+                (d.get("edge") for d in (step.get("placement_decisions") or [])
+                 if d.get("event") == "keepout_overhang"), None)
+            legends = [
+                {"ref": L.ref, "positions": L.positions, "device": L.device}
+                for L in (design_intent.connector_legends if design_intent else [])
+            ]
+            pipeline_result["status"] = "pending_approval"
+            pipeline_result["proposal"] = _build_placement_proposal(
+                pcb_path, actual_width, actual_height, antenna_edge,
+                terminal_edges, hole_positions, legends, holes,
+            )
+            pipeline_result["pcb_path"] = pcb_path
+            pipeline_result["elapsed_seconds"] = round(time.time() - t0, 1)
+            return pipeline_result
 
         # Step 6: Autoroute
         step = _step_autoroute(pcb_path, passes=autoroute_passes)
@@ -1953,22 +2063,8 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
 
         # Step 7.5: Silk legends for synthesized terminals (firmware front end).
         # Field-wired terminals carry their wiring documentation on the silk.
-        # Strictly NON-FATAL: silk is documentation, never blocks fabrication —
-        # so a bad intent OR a pcbnew failure inside the step (run_pcbnew_script
-        # RAISES on subprocess error/timeout) is recorded, never propagated, so it
-        # cannot abort an already-routed board.
-        if design_intent is not None:
-            try:
-                _legends = [
-                    {"ref": L.ref, "positions": L.positions, "device": L.device}
-                    for L in design_intent.connector_legends
-                ]
-                step = _step_silkscreen_legends(pcb_path, _legends,
-                                                terminal_edges=terminal_edges)
-                _record("silkscreen_legends", step)
-            except Exception as e:  # noqa: BLE001 — documentation step, never fatal
-                _record("silkscreen_legends",
-                        {"error": f"silk legend step failed (non-fatal): {e}"})
+        # (Single source: same _run_silk_legends used by the approval gate above.)
+        _run_silk_legends()
 
         # Step 8: Export gerbers (optional)
         if export_gerbers:

--- a/src/kicad_mcp/tools/pcb_pipeline.py
+++ b/src/kicad_mcp/tools/pcb_pipeline.py
@@ -900,7 +900,14 @@ tier1, tier2, tier3, tier4 = [], [], [], []
 
 for ref, info in fp_info.items():
     cls = _ref_class(ref)
-    if info["has_keepout"]:
+    if "fixed" in placement_hints.get(ref, {}):
+        # An explicit fixed-coordinate hint is an ABSOLUTE override — honor it
+        # regardless of class. tier2 owns the fixed-placement path; without this a
+        # non-edge-class ref with fixed coords (e.g. an "H" mounting hole, no
+        # longer an edge class) would fall to the interior tier and be
+        # spiral-placed, silently ignoring its hint.
+        tier2.append(ref)
+    elif info["has_keepout"]:
         tier1.append(ref)
     elif cls in EDGE_CLASSES:
         tier2.append(ref)
@@ -1633,8 +1640,12 @@ def _render_board_svg(pcb_path: str) -> Optional[str]:
     out = os.path.splitext(pcb_path)[0] + "_proposal.svg"
     try:
         r = subprocess.run(
+            # --exclude-drawing-sheet: no title-block/rev frame, so the Edge.Cuts
+            # rectangle IS the only boundary in the image (a frame around a larger
+            # page reads as a false board edge and hides where parts really sit).
             [cli, "pcb", "export", "svg", pcb_path, "-o", out,
-             "--layers", "F.Cu,B.Cu,F.SilkS,Edge.Cuts", "--page-size-mode", "2"],
+             "--layers", "F.Cu,B.Cu,F.SilkS,Edge.Cuts",
+             "--page-size-mode", "2", "--exclude-drawing-sheet"],
             capture_output=True, text=True, timeout=60,
         )
         return out if (r.returncode == 0 and os.path.exists(out)) else None

--- a/src/kicad_mcp/tools/pcb_pipeline.py
+++ b/src/kicad_mcp/tools/pcb_pipeline.py
@@ -170,10 +170,13 @@ def _step_create_pcb_and_outline(
     width_mm: float,
     height_mm: float,
     components: Dict[str, Dict],
+    holes: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Step 2: Create PCB file and add board outline.
 
-    If width/height are 0, auto-estimates from component footprints.
+    If width/height are 0, auto-estimates from component footprints. When
+    ``holes`` requests corner mounting holes, the estimate reserves a
+    per-side inset so the holes don't crowd the content (spec §3 / Phase 5).
     """
     # Build footprint list for size estimation if needed
     auto_sized = False
@@ -187,7 +190,9 @@ def _step_create_pcb_and_outline(
         if not fp_specs:
             return {"error": "No footprints to estimate board size from"}
 
-        size_result = _estimate_board_size(fp_specs)
+        inset = (holes["inset_mm"]
+                 if holes and holes.get("count", 0) > 0 else 0.0)
+        size_result = _estimate_board_size(fp_specs, corner_inset_mm=inset)
         if "error" in size_result:
             return size_result
 
@@ -266,7 +271,104 @@ print(json.dumps({"status": "ok"}))
 # Designator classes that get EDGE placement (so they reserve perimeter, not
 # interior area). SINGLE SOURCE — passed into both embedded scripts (the size
 # estimator and the smart-placement loop) as a param so the two can't drift.
-_EDGE_DESIGNATOR_CLASSES = ("J", "SW", "H", "USB")
+# NOTE: "H" (mounting holes) is intentionally NOT here as of v1.1 — holes are
+# corner FIXTURES placed by _step_add_mounting_holes and pinned with `fixed`
+# hints, not edge-placed connectors. (A stray H from a schematic symbol falls to
+# the interior tier; the firmware front end never emits one.)
+_EDGE_DESIGNATOR_CLASSES = ("J", "SW", "USB")
+
+
+# Corner mounting-hole defaults (board.yaml `mounting_holes:` overrides these;
+# see sidecar._validate_mounting_holes). count=0 disables holes entirely.
+_HOLE_DEFAULTS = {"count": 4, "drill_mm": 3.2, "inset_mm": 3.5, "keepout_mm": 1.5}
+
+
+def _resolve_mounting_holes(mh_source: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Merge a board.yaml ``mounting_holes`` block over the defaults → one
+    canonical dict. Pure (no pcbnew). ``None`` (no sidecar / no key) yields the
+    full default (4 × M3); ``{}`` likewise; ``count: 0`` disables holes."""
+    holes = dict(_HOLE_DEFAULTS)
+    if mh_source:
+        holes.update({k: mh_source[k] for k in _HOLE_DEFAULTS if k in mh_source})
+    return holes
+
+
+def _step_add_mounting_holes(pcb_path: str, holes: Dict[str, Any]) -> Dict[str, Any]:
+    """Add corner M3 mounting holes + a no-copper keepout per hole.
+
+    Runs after the outline, before placement, so the placer (fed the holes as
+    ``fixed`` hints by the caller) keeps clear of the corners. Holes are
+    ``MountingHole_3.2mm_M3`` footprints (no net); each gets a square rule-area
+    keepout (no tracks/vias/pads) of half-extent ``drill/2 + keepout_mm`` on both
+    copper layers. ``count`` 4 = all corners, 2 = TL+BR diagonal, 0 = skip.
+
+    All pcbnew calls here were verified on KiCad 9.0.9 AND 10.0.3: the plain M3
+    footprint name, ``LSET().AddLayer`` (the ``&`` operator and 2-arg ctor both
+    fail), and the ``Outline().NewOutline()/Append`` zone build.
+    """
+    count = holes.get("count", 0)
+    if count == 0:
+        return {"status": "ok", "holes_added": 0, "skipped": "count=0"}
+
+    script = """
+import pcbnew, json, os, sys
+
+params = json.loads(open(sys.argv[1]).read())
+""" + LIB_SEARCH_HELPER + """
+board = pcbnew.LoadBoard(params["pcb_path"])
+lib = find_lib("MountingHole")
+if not lib:
+    print(json.dumps({"error": "MountingHole footprint library not found"}))
+    sys.exit(0)
+
+bb = board.GetBoardEdgesBoundingBox()
+inset = pcbnew.FromMM(params["inset_mm"])
+x0, y0, x1, y1 = bb.GetX(), bb.GetY(), bb.GetRight(), bb.GetBottom()
+# TL, TR, BR, BL — clockwise from top-left.
+all_corners = [(x0 + inset, y0 + inset), (x1 - inset, y0 + inset),
+               (x1 - inset, y1 - inset), (x0 + inset, y1 - inset)]
+corners = all_corners if params["count"] == 4 else [all_corners[0], all_corners[2]]
+
+half = pcbnew.FromMM(params["drill_mm"] / 2.0 + params["keepout_mm"])
+positions = []
+for i, (cx, cy) in enumerate(corners):
+    fp = pcbnew.FootprintLoad(lib, "MountingHole_3.2mm_M3")
+    if fp is None:
+        print(json.dumps({"error": "MountingHole_3.2mm_M3 not found"}))
+        sys.exit(0)
+    board.Add(fp)
+    fp.SetReference("H%d" % (i + 1))
+    fp.SetPosition(pcbnew.VECTOR2I(int(cx), int(cy)))
+    # No-copper keepout (square) so routing leaves the screw-head annulus clear.
+    z = pcbnew.ZONE(board)
+    z.SetIsRuleArea(True)
+    z.SetDoNotAllowTracks(True)
+    z.SetDoNotAllowVias(True)
+    z.SetDoNotAllowPads(True)
+    ls = pcbnew.LSET()
+    ls.AddLayer(pcbnew.F_Cu)
+    ls.AddLayer(pcbnew.B_Cu)
+    z.SetLayerSet(ls)
+    outline = z.Outline()
+    outline.NewOutline()
+    for dx, dy in ((-half, -half), (half, -half), (half, half), (-half, half)):
+        outline.Append(int(cx + dx), int(cy + dy))
+    board.Add(z)
+    positions.append({"ref": "H%d" % (i + 1),
+                      "x_mm": round(pcbnew.ToMM(int(cx)), 3),
+                      "y_mm": round(pcbnew.ToMM(int(cy)), 3)})
+
+board.Save(params["pcb_path"])
+print(json.dumps({"status": "ok", "holes_added": len(positions),
+                  "positions": positions}))
+"""
+    return run_pcbnew_script(script, params={
+        "pcb_path": pcb_path,
+        "count": count,
+        "drill_mm": holes["drill_mm"],
+        "inset_mm": holes["inset_mm"],
+        "keepout_mm": holes["keepout_mm"],
+    }, timeout=60.0)
 
 
 def _content_aware_size(
@@ -275,6 +377,7 @@ def _content_aware_size(
     routing_factor: float = 2.5,
     padding: float = 2.0,
     spacing: float = 1.0,
+    corner_inset_mm: float = 0.0,
 ) -> Dict[str, Any]:
     """Content-aware board size (spec §4) — pure, unit-tested without KiCad.
 
@@ -297,8 +400,11 @@ def _content_aware_size(
     # Terminals: total span ALONG their shared edge, and their inward DEPTH.
     term_along = sum(max(c["w"], c["h"]) + spacing for c in terminals)
     term_depth = max((min(c["w"], c["h"]) for c in terminals), default=0.0)
-    along = max(cluster, term_along) + 2 * padding      # edge must seat all terminals
-    depth = cluster + term_depth + 2 * padding          # cluster + one terminal band
+    # Corner mounting holes reserve real estate on every side (a hole sits inset
+    # from each edge with its own keepout), so both dimensions grow by 2×inset.
+    pad2 = 2 * padding + 2 * corner_inset_mm
+    along = max(cluster, term_along) + pad2             # edge must seat all terminals
+    depth = cluster + term_depth + pad2                 # cluster + one terminal band
     if terminal_edge_horizontal:
         w, h = along, depth
     else:
@@ -306,7 +412,9 @@ def _content_aware_size(
     return {"width_mm": math.ceil(w), "height_mm": math.ceil(h)}
 
 
-def _estimate_board_size(fp_specs: List[Dict[str, str]]) -> Dict[str, Any]:
+def _estimate_board_size(
+    fp_specs: List[Dict[str, str]], corner_inset_mm: float = 0.0,
+) -> Dict[str, Any]:
     """Estimate board dimensions from footprint specs. The bridge script only
     MEASURES (body w/h + whether the ref is an edge terminal); the content-aware
     math lives in the pure :func:`_content_aware_size` so it is testable and
@@ -386,7 +494,8 @@ print(json.dumps({"components": components, "errors": errors}))
     terminal_edge_horizontal = antenna_side in ("top", "bottom") if antenna_side else True
     return {
         "status": "ok",
-        "size": _content_aware_size(comps, terminal_edge_horizontal),
+        "size": _content_aware_size(comps, terminal_edge_horizontal,
+                                    corner_inset_mm=corner_inset_mm),
         "antenna_side": antenna_side,
         "errors": result.get("errors", []),
         "error_count": len(result.get("errors", [])),
@@ -1604,6 +1713,7 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
         export_gerbers: bool = False,
         intent_path: str = "",
         placement_hints: Optional[Dict[str, Dict[str, Any]]] = None,
+        add_mounting_holes: bool = True,
     ) -> Dict[str, Any]:
         """Build a complete routed PCB from a KiCad schematic in one step.
 
@@ -1635,6 +1745,11 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
                 Its ``source.board_size_mm`` (if any) sizes the board when no
                 explicit dimensions are given, and its ``placement_hints`` feed
                 the per-ref placement overrides below.
+            add_mounting_holes: Add corner M3 mounting holes (default True). The
+                count/drill/inset/keepout come from the design intent's
+                ``source.mounting_holes`` (board.yaml) or default to 4 × M3; pass
+                False to suppress holes without a board.yaml (or set
+                ``mounting_holes.count: 0`` there).
             placement_hints: Per-ref PCB placement overrides, keyed by KiCad
                 reference. Each value is a subset of ``{edge, rotation, fixed}``
                 — ``edge`` ∈ {top,bottom,left,right,none}, ``rotation`` ∈
@@ -1697,6 +1812,16 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
                     f"Could not load intent {intent_path} (non-fatal): {e}"
                 )
 
+        # Corner mounting holes (firmware-blind; board.yaml `mounting_holes:` →
+        # intent.source). Resolved before sizing so the auto-estimate can reserve
+        # the corner inset, and before placement so the holes are fixtures.
+        holes = _resolve_mounting_holes(
+            design_intent.source.get("mounting_holes")
+            if design_intent is not None else None
+        )
+        if not add_mounting_holes:        # caller escape hatch (no board.yaml needed)
+            holes = {**holes, "count": 0}
+
         # Board size precedence: explicit args (>0) > intent source.board_size_mm
         # > auto-estimate (resolved per axis; see _resolve_board_size).
         eff_width_mm, eff_height_mm, _bsz_from_intent = _resolve_board_size(
@@ -1708,9 +1833,9 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
                 f"Board sized to {eff_width_mm}x{eff_height_mm}mm from design intent"
             )
 
-        # Step 2: Create PCB + board outline
+        # Step 2: Create PCB + board outline (sizing reserves the hole inset)
         step = _step_create_pcb_and_outline(
-            pcb_path, eff_width_mm, eff_height_mm, components,
+            pcb_path, eff_width_mm, eff_height_mm, components, holes=holes,
         )
         if not _record("create_pcb", step):
             return pipeline_result
@@ -1723,6 +1848,18 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
             pipeline_result.setdefault("warnings", []).append(
                 f"Board auto-sized to {actual_width}x{actual_height}mm"
             )
+
+        # Step 2b: Corner mounting holes (fixtures). Added to the board now; the
+        # placer is told to pin them (fixed hints below) so they stay at the
+        # corners and their keepout boxes are reserved against other parts.
+        hole_hints: Dict[str, Dict[str, Any]] = {}
+        if holes.get("count", 0) > 0:
+            step_holes = _step_add_mounting_holes(pcb_path, holes)
+            _record("mounting_holes", step_holes)   # non-fatal
+            hole_hints = {
+                r["ref"]: {"fixed": [r["x_mm"], r["y_mm"]], "rotation": 0}
+                for r in (step_holes.get("positions") or [])
+            }
 
         # Step 3: Load footprints onto board (temporary positions)
         step = _step_load_footprints(pcb_path, components)
@@ -1745,6 +1882,13 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
             design_intent.placement_hints if design_intent is not None else None,
             placement_hints,
         )
+        # Mounting holes are physical fixtures we already placed — pin them at the
+        # corners at HIGHEST priority (else the placer, which no longer edge-places
+        # "H", would shove them into the interior). Normalized via the same path.
+        if hole_hints:
+            norm_holes, hole_ws = _merge_placement_hints(None, hole_hints)
+            clean_hints.update(norm_holes)
+            hint_warnings.extend(hole_ws)
 
         # Step 5: Smart placement (tiered, connectivity-aware)
         step = _step_smart_placement(pcb_path, nets, placement_hints=clean_hints)

--- a/src/kicad_mcp/utils/firmware/sidecar.py
+++ b/src/kicad_mcp/utils/firmware/sidecar.py
@@ -107,10 +107,14 @@ class BoardSidecar:
 
 # Top-level board.yaml keys. An unknown key is a loud error (catches a typo like
 # `board_size` for `board_size_mm` instead of silently ignoring the directive).
+# MUST stay in sync with the BoardSidecar fields above AND the data.get() calls
+# in load_sidecar — test_known_keys_all_accepted guards that all three agree.
 _KNOWN_SIDECAR_KEYS = frozenset({
     "power_source", "board_size_mm", "extra_connectors",
     "placement", "placement_hints", "mounting_holes",
 })
+
+_KNOWN_MOUNTING_HOLES_KEYS = frozenset({"count", "drill_mm", "inset_mm", "keepout_mm"})
 
 
 def _validate_placement(d: dict[str, Any], errs: list[str]) -> None:
@@ -176,7 +180,17 @@ def _validate_mounting_holes(d: dict[str, Any], errs: list[str]) -> None:
     if not isinstance(mh, dict):
         errs.append("mounting_holes must be a mapping")
         return
-    if "count" in mh and mh["count"] not in (0, 2, 4):
+    # Reject unknown sub-keys too — consistency with the top-level rejection, so a
+    # typo like `counnt: 4` is loud, not silently dropped (and silently default).
+    unknown = set(mh) - _KNOWN_MOUNTING_HOLES_KEYS
+    if unknown:
+        errs.append(
+            f"mounting_holes: unknown key(s) {sorted(unknown)} — "
+            f"valid: {sorted(_KNOWN_MOUNTING_HOLES_KEYS)}"
+        )
+    # bool is an int subclass and False == 0, so `False in (0,2,4)` is True — guard
+    # explicitly or `count: false` would slip through as 0.
+    if "count" in mh and (isinstance(mh["count"], bool) or mh["count"] not in (0, 2, 4)):
         errs.append(f"mounting_holes.count {mh['count']!r} must be 0, 2, or 4")
     for key in ("drill_mm", "inset_mm", "keepout_mm"):
         if key in mh:

--- a/src/kicad_mcp/utils/firmware/sidecar.py
+++ b/src/kicad_mcp/utils/firmware/sidecar.py
@@ -30,7 +30,15 @@ placement_hints:               # per-ref PCB placement overrides (keyed by KiCad
     edge: none                 # top|bottom|left|right|none ("none" = keep interior)
     rotation: 90               # 0|90|180|270 (omit to use the auto heuristic)
     fixed: [40, 12]            # absolute [x, y] mm (wins over edge/rotation)
+mounting_holes:                # corner fixture holes (firmware-blind mechanical)
+  count: 4                     # 4 (default) | 2 (diagonal) | 0 (none)
+  drill_mm: 3.2                # M3 = 3.2, M2.5 = 2.7
+  inset_mm: 3.5                # hole-centre inset from each board edge
+  keepout_mm: 1.5              # no-copper margin beyond the drill
 ```
+
+Unknown top-level keys are REJECTED (a typo like ``board_size`` for
+``board_size_mm`` is a loud error, never a silently-ignored directive).
 """
 from __future__ import annotations
 
@@ -91,6 +99,18 @@ class BoardSidecar:
     placement: dict[str, dict[str, Any]] = field(default_factory=dict)
     # PCB placement-hint overrides {edge, rotation, fixed}, keyed by KiCad ref.
     placement_hints: dict[str, dict[str, Any]] = field(default_factory=dict)
+    # corner mounting holes {count, drill_mm, inset_mm, keepout_mm}; None = use
+    # the pipeline default (4 × M3). Defaults are resolved in pcb_pipeline, not
+    # here — this layer only validates + carries the user's overrides.
+    mounting_holes: Optional[dict[str, Any]] = None
+
+
+# Top-level board.yaml keys. An unknown key is a loud error (catches a typo like
+# `board_size` for `board_size_mm` instead of silently ignoring the directive).
+_KNOWN_SIDECAR_KEYS = frozenset({
+    "power_source", "board_size_mm", "extra_connectors",
+    "placement", "placement_hints", "mounting_holes",
+})
 
 
 def _validate_placement(d: dict[str, Any], errs: list[str]) -> None:
@@ -145,8 +165,35 @@ def _validate_hints(d: dict[str, Any], errs: list[str]) -> None:
             errs.append(f"placement_hints[{key!r}]: must be a mapping")
 
 
+def _validate_mounting_holes(d: dict[str, Any], errs: list[str]) -> None:
+    """``mounting_holes`` is optional; when present it's a mapping with an integer
+    ``count`` in {0, 2, 4} and positive numeric ``drill_mm`` / ``inset_mm`` /
+    ``keepout_mm``. Missing fields fall back to pipeline defaults (validated
+    there); only supplied fields are checked here."""
+    mh = d.get("mounting_holes")
+    if mh is None:
+        return
+    if not isinstance(mh, dict):
+        errs.append("mounting_holes must be a mapping")
+        return
+    if "count" in mh and mh["count"] not in (0, 2, 4):
+        errs.append(f"mounting_holes.count {mh['count']!r} must be 0, 2, or 4")
+    for key in ("drill_mm", "inset_mm", "keepout_mm"):
+        if key in mh:
+            v = mh[key]
+            # bool is an int subclass — reject True/False masquerading as a number
+            if isinstance(v, bool) or not isinstance(v, (int, float)) or v <= 0:
+                errs.append(f"mounting_holes.{key} must be a positive number")
+
+
 def _validate(d: dict[str, Any]) -> list[str]:
     errs: list[str] = []
+    unknown = set(d) - _KNOWN_SIDECAR_KEYS
+    if unknown:
+        errs.append(
+            f"unknown board.yaml key(s) {sorted(unknown)} — "
+            f"valid keys: {sorted(_KNOWN_SIDECAR_KEYS)}"
+        )
     ps = d.get("power_source")
     if ps is not None and ps not in _POWER_SOURCES:
         errs.append(f"power_source {ps!r} not in {sorted(_POWER_SOURCES)}")
@@ -175,6 +222,7 @@ def _validate(d: dict[str, Any]) -> list[str]:
                     errs.append(f"{where}: nets entries must be pin_str -> net_str")
     _validate_placement(d, errs)
     _validate_hints(d, errs)
+    _validate_mounting_holes(d, errs)
     return errs
 
 
@@ -197,6 +245,8 @@ def load_sidecar(path: str) -> BoardSidecar:
         extra_connectors=list(data.get("extra_connectors", []) or []),
         placement=dict(data.get("placement", {}) or {}),
         placement_hints=dict(data.get("placement_hints", {}) or {}),
+        mounting_holes=(dict(data["mounting_holes"])
+                        if data.get("mounting_holes") is not None else None),
     )
 
 
@@ -229,6 +279,8 @@ def apply_sidecar(
         intent.source["power_source"] = sidecar.power_source
     if sidecar.board_size_mm is not None:
         intent.source["board_size_mm"] = list(sidecar.board_size_mm)
+    if sidecar.mounting_holes is not None:
+        intent.source["mounting_holes"] = dict(sidecar.mounting_holes)
 
     nets_by_name = {n.name: n for n in intent.nets}
     existing_refs = {p.ref for p in intent.peripherals}

--- a/tests/integration/test_firmware_pcb_pipeline.py
+++ b/tests/integration/test_firmware_pcb_pipeline.py
@@ -70,6 +70,33 @@ def _final_hole_positions(pcb_path):
     return run_pcbnew_script(script, params={"pcb": pcb_path}, timeout=60.0)
 
 
+def _terminal_hole_overlaps(pcb_path):
+    """Pairs of (terminal J*, mounting hole H*) whose courtyards OVERLAP — i.e. a
+    terminal sitting on a hole. Empty = clear. Uses GetBoundingBox(False, False)
+    (body+courtyard, no text bloat) for an AABB test. Guards the bug where a
+    field terminal was forced onto a corner hole because the keepout was
+    routing-only and the layout didn't reserve the corner."""
+    from kicad_mcp.utils.pcbnew_bridge import run_pcbnew_script
+    script = (
+        "import pcbnew, json, sys\n"
+        "b = pcbnew.LoadBoard(json.loads(open(sys.argv[1]).read())['pcb'])\n"
+        "def box(fp):\n"
+        "    bb = fp.GetBoundingBox(False, False)\n"
+        "    return (bb.GetX(), bb.GetY(), bb.GetRight(), bb.GetBottom())\n"
+        "J = {f.GetReference(): box(f) for f in b.GetFootprints()\n"
+        "     if f.GetReference().startswith('J')}\n"
+        "H = {f.GetReference(): box(f) for f in b.GetFootprints()\n"
+        "     if f.GetReference()[:1] == 'H' and f.GetReference()[1:].isdigit()}\n"
+        "out = []\n"
+        "for jr, (jx0, jy0, jx1, jy1) in J.items():\n"
+        "    for hr, (hx0, hy0, hx1, hy1) in H.items():\n"
+        "        if jx0 <= hx1 and jx1 >= hx0 and jy0 <= hy1 and jy1 >= hy0:\n"
+        "            out.append([jr, hr])\n"
+        "print(json.dumps({'overlaps': out}))\n"   # object, not bare array (bridge needs {})
+    )
+    return run_pcbnew_script(script, params={"pcb": pcb_path}, timeout=60.0)["overlaps"]
+
+
 def _assert_mostly_routed(r4, max_unrouted):
     """Assert the board routed essentially completely, within ``max_unrouted``.
 
@@ -440,10 +467,13 @@ def test_audio_remote_to_routed_pcb(mcp_server, tmp_path):
     hp = _final_hole_positions(r4["pcb_path"])
     assert set(hp) == {"H1", "H2", "H3", "H4"}
     for ref, (x, y) in hp.items():
-        near_x = x < 6.0 or x > bw - 6.0
-        near_y = y < 6.0 or y > bh - 6.0
+        near_x = x < 7.0 or x > bw - 7.0
+        near_y = y < 7.0 or y > bh - 7.0
         assert near_x and near_y, \
             f"{ref} at ({x},{y}) is not near a corner of {bw}x{bh} (moved off-corner)"
+    # And no field terminal sits ON a corner hole (courtyards must not overlap).
+    overlaps = _terminal_hole_overlaps(r4["pcb_path"])
+    assert overlaps == [], f"terminal(s) overlap mounting hole(s): {overlaps}"
 
     # §1 RFI: ALL field-wiring terminals share the SINGLE edge opposite the antenna
     # (the MCU antenna overhangs the top, so terminals are on the bottom) — none

--- a/tests/integration/test_firmware_pcb_pipeline.py
+++ b/tests/integration/test_firmware_pcb_pipeline.py
@@ -250,8 +250,11 @@ def test_firmware_to_routed_pcb(mcp_server, tmp_path):
 
     # 4) build a routed PCB from it — the core gate
     pro.write_text(json.dumps(_MINIMAL_PRO))
+    # add_mounting_holes=False: this explicit size was calibrated pre-Phase-5 and
+    # is tight; the test gates nets + routing, not holes (holes-on is gated by the
+    # roomy audio_s3 and the auto-sized audio-remote boards).
     r4 = build(project_path=str(pro), board_width_mm=90, board_height_mm=75,
-               autoroute_passes=2, export_gerbers=False)
+               autoroute_passes=2, export_gerbers=False, add_mounting_holes=False)
     assert r4["status"] == "ok"
     assert r4["pads_assigned"] > 0
     _assert_mostly_routed(r4, max_unrouted=2)
@@ -409,6 +412,18 @@ def test_audio_remote_to_routed_pcb(mcp_server, tmp_path):
     assert not r4["steps"]["smart_placement"].get("failed_placements"), \
         "content-aware size left parts unplaced (under-estimate)"
 
+    # §3 mounting holes (Phase 5): 4 corner M3 fixtures, each inset ~3.5mm from a
+    # corner (within line-width tolerance), pinned (not floating mid-board). The
+    # board still routes within bound above, so the corner keepouts didn't break it.
+    mh = r4["steps"]["mounting_holes"]
+    assert mh["holes_added"] == 4
+    assert {p["ref"] for p in mh["positions"]} == {"H1", "H2", "H3", "H4"}
+    for p in mh["positions"]:
+        near_x = abs(p["x_mm"] - 3.5) < 1.0 or abs(p["x_mm"] - (bw - 3.5)) < 1.0
+        near_y = abs(p["y_mm"] - 3.5) < 1.0 or abs(p["y_mm"] - (bh - 3.5)) < 1.0
+        assert near_x and near_y, \
+            f"{p['ref']} at ({p['x_mm']},{p['y_mm']}) not near a corner of {bw}x{bh}"
+
     # §1 RFI: ALL field-wiring terminals share the SINGLE edge opposite the antenna
     # (the MCU antenna overhangs the top, so terminals are on the bottom) — none
     # buried interior, none on the antenna edge.
@@ -551,8 +566,10 @@ def test_track_geometry_to_routed_pcb(mcp_server, tmp_path):
     # Placement is unchanged (the silk step runs AFTER routing), so this is pure
     # router nondeterminism: more passes keeps the tight bound non-flaky rather
     # than loosening it (matches the dense audio_s3 board, also best-of-6).
+    # add_mounting_holes=False: explicit pre-Phase-5 size, tight; gates nets +
+    # routing (holes-on gated by audio_s3 + audio-remote).
     r4 = build(project_path=str(pro), board_width_mm=90, board_height_mm=75,
-               autoroute_passes=6, export_gerbers=False)
+               autoroute_passes=6, export_gerbers=False, add_mounting_holes=False)
     assert r4["status"] == "ok"
     assert r4["pads_assigned"] > 0
     _assert_mostly_routed(r4, max_unrouted=2)            # buzzer orphan must not break routing
@@ -599,8 +616,10 @@ def test_sidecar_to_routed_pcb(mcp_server, tmp_path):
     assert r3["status"] == "ok" and not r3["unresolved_endpoints"]
 
     pro.write_text(json.dumps(_MINIMAL_PRO))
+    # add_mounting_holes=False: explicit pre-Phase-5 size, tight; gates the sidecar
+    # connector route, not holes (holes-on gated by audio_s3 + audio-remote).
     r4 = build(project_path=str(pro), board_width_mm=70, board_height_mm=55,
-               autoroute_passes=2, export_gerbers=False)
+               autoroute_passes=2, export_gerbers=False, add_mounting_holes=False)
     assert r4["status"] == "ok"
     _assert_mostly_routed(r4, max_unrouted=2)            # connector routes
 

--- a/tests/integration/test_firmware_pcb_pipeline.py
+++ b/tests/integration/test_firmware_pcb_pipeline.py
@@ -529,6 +529,56 @@ def test_audio_remote_to_routed_pcb(mcp_server, tmp_path):
         f"beyond the block on the inboard side)")
 
 
+def test_approval_gate_audio_remote(mcp_server, tmp_path):
+    """Phase 7 approval gate: build with approved=False returns a proposal of the
+    PLACED (unrouted) board — real terminal edges, holes, a tweakable board.yaml,
+    and (best-effort) a render — WITHOUT the expensive autoroute. Cheap (no route),
+    so it gates the gate on real KiCad without the 3-4 min FreeRouter pass."""
+    import shutil
+
+    import yaml
+
+    from kicad_mcp.utils.firmware.sidecar import load_sidecar
+
+    design = _tool(mcp_server, "design")
+    build = _tool(mcp_server, "build_pcb_from_schematic")
+
+    fw = tmp_path / "fw"
+    fw.mkdir()
+    shutil.copy(AUDIO_CONFIG_H, fw / "config.h")
+    shutil.copy(AUDIO_CONFIG_H.parent / "platformio.ini", fw / "platformio.ini")
+    (fw / "board.yaml").write_text(
+        "placement:\n"
+        "  CMCA_MIC: {locus: remote, device: INMP441}\n"
+        "  CMCA_PRESENCE: {locus: remote, device: LD2410}\n"
+        "  CMCA_I2S: {locus: on_board_with_remote_io, device: MAX98357A, external_io: [outp, outn]}\n"
+        "  CMCA_I2S2: {locus: on_board_with_remote_io, device: MAX98357A, external_io: [outp, outn]}\n"
+    )
+    intent = tmp_path / "intent.yaml"
+    sch = tmp_path / "ar.kicad_sch"
+    pro = tmp_path / "ar.kicad_pro"
+    design(operation="import_firmware", firmware_path=str(fw / "config.h"), out_path=str(intent))
+    design(operation="expand_templates", intent_path=str(intent))
+    design(operation="generate_schematic", intent_path=str(intent), schematic_path=str(sch))
+    pro.write_text(json.dumps(_MINIMAL_PRO))
+
+    r = build(project_path=str(pro), board_width_mm=0, board_height_mm=0,
+              export_gerbers=False, intent_path=str(intent), approved=False)
+
+    assert r["status"] == "pending_approval"
+    assert "autoroute" not in r["steps"]          # the expensive pass was skipped
+    prop = r["proposal"]
+    assert prop["antenna_edge"] == "top"          # S3 antenna overhangs the top
+    assert prop["terminal_table"], "no terminals in the proposal"
+    assert {t["edge"] for t in prop["terminal_table"]} == {"bottom"}   # antenna-opposite
+    assert len(prop["mounting_holes"]) == 4       # default corner holes proposed
+    # the proposed board.yaml is valid and round-trips through the sidecar loader
+    yp = tmp_path / "proposed.yaml"
+    yp.write_text(yaml.dump(prop["proposed_board_yaml"]))
+    sc = load_sidecar(str(yp))
+    assert sc.board_size_mm is not None and sc.mounting_holes is not None
+
+
 def test_track_geometry_to_routed_pcb(mcp_server, tmp_path):
     """The THIRD board shape: an I2C sensor-hub (track-geometry car). Exercises
     the generalization that matters here — MULTIPLE address-declared devices,

--- a/tests/integration/test_firmware_pcb_pipeline.py
+++ b/tests/integration/test_firmware_pcb_pipeline.py
@@ -50,6 +50,26 @@ def _tool(mcp, name):
     return asyncio.run(mcp.get_tool(name)).fn
 
 
+def _final_hole_positions(pcb_path):
+    """The H* mounting-hole positions as they ACTUALLY ended up on the board (mm).
+    Reads the placed board, not a step's report — placement can move a footprint
+    after a step records its intended spot (the bug this guards: holes that the
+    create step put at the corners were silently spiral-placed into the interior)."""
+    from kicad_mcp.utils.pcbnew_bridge import run_pcbnew_script
+    script = (
+        "import pcbnew, json, sys\n"
+        "b = pcbnew.LoadBoard(json.loads(open(sys.argv[1]).read())['pcb'])\n"
+        "out = {}\n"
+        "for fp in b.GetFootprints():\n"
+        "    r = fp.GetReference()\n"
+        "    if r and r[0] == 'H' and r[1:].isdigit():\n"
+        "        p = fp.GetPosition()\n"
+        "        out[r] = [round(pcbnew.ToMM(p.x), 2), round(pcbnew.ToMM(p.y), 2)]\n"
+        "print(json.dumps(out))\n"
+    )
+    return run_pcbnew_script(script, params={"pcb": pcb_path}, timeout=60.0)
+
+
 def _assert_mostly_routed(r4, max_unrouted):
     """Assert the board routed essentially completely, within ``max_unrouted``.
 
@@ -412,17 +432,18 @@ def test_audio_remote_to_routed_pcb(mcp_server, tmp_path):
     assert not r4["steps"]["smart_placement"].get("failed_placements"), \
         "content-aware size left parts unplaced (under-estimate)"
 
-    # §3 mounting holes (Phase 5): 4 corner M3 fixtures, each inset ~3.5mm from a
-    # corner (within line-width tolerance), pinned (not floating mid-board). The
+    # §3 mounting holes (Phase 5): 4 corner M3 fixtures that ACTUALLY ended up at
+    # the corners on the placed+routed board (read the board, not the step report —
+    # the placer used to silently move fixed-hint holes into the interior). The
     # board still routes within bound above, so the corner keepouts didn't break it.
-    mh = r4["steps"]["mounting_holes"]
-    assert mh["holes_added"] == 4
-    assert {p["ref"] for p in mh["positions"]} == {"H1", "H2", "H3", "H4"}
-    for p in mh["positions"]:
-        near_x = abs(p["x_mm"] - 3.5) < 1.0 or abs(p["x_mm"] - (bw - 3.5)) < 1.0
-        near_y = abs(p["y_mm"] - 3.5) < 1.0 or abs(p["y_mm"] - (bh - 3.5)) < 1.0
+    assert r4["steps"]["mounting_holes"]["holes_added"] == 4
+    hp = _final_hole_positions(r4["pcb_path"])
+    assert set(hp) == {"H1", "H2", "H3", "H4"}
+    for ref, (x, y) in hp.items():
+        near_x = x < 6.0 or x > bw - 6.0
+        near_y = y < 6.0 or y > bh - 6.0
         assert near_x and near_y, \
-            f"{p['ref']} at ({p['x_mm']},{p['y_mm']}) not near a corner of {bw}x{bh}"
+            f"{ref} at ({x},{y}) is not near a corner of {bw}x{bh} (moved off-corner)"
 
     # §1 RFI: ALL field-wiring terminals share the SINGLE edge opposite the antenna
     # (the MCU antenna overhangs the top, so terminals are on the bottom) — none
@@ -572,6 +593,13 @@ def test_approval_gate_audio_remote(mcp_server, tmp_path):
     assert prop["terminal_table"], "no terminals in the proposal"
     assert {t["edge"] for t in prop["terminal_table"]} == {"bottom"}   # antenna-opposite
     assert len(prop["mounting_holes"]) == 4       # default corner holes proposed
+    # And they ACTUALLY sit at the corners on the placed board (not just reported):
+    bw, bh = prop["board_size_mm"]
+    hp = _final_hole_positions(r["pcb_path"])
+    assert set(hp) == {"H1", "H2", "H3", "H4"}
+    for ref, (x, y) in hp.items():
+        assert (x < 6.0 or x > bw - 6.0) and (y < 6.0 or y > bh - 6.0), \
+            f"{ref} at ({x},{y}) not at a corner of {bw}x{bh}"
     # the proposed board.yaml is valid and round-trips through the sidecar loader
     yp = tmp_path / "proposed.yaml"
     yp.write_text(yaml.dump(prop["proposed_board_yaml"]))

--- a/tests/test_board_sizing.py
+++ b/tests/test_board_sizing.py
@@ -81,3 +81,20 @@ def test_largest_interior_dim_is_a_floor():
 def test_returns_single_size_not_a_list():
     s = _content_aware_size([{"w": 10.0, "h": 10.0, "is_terminal": False}])
     assert set(s) == {"width_mm", "height_mm"}
+
+
+# --- corner mounting-hole inset (Phase 5) ------------------------------------
+
+def test_corner_inset_zero_is_noop():
+    # inset=0 must equal the no-inset baseline — this is what keeps every other
+    # sizing test valid (the param defaults to 0.0).
+    comp = [{"w": 10.0, "h": 10.0, "is_terminal": False}]
+    assert _content_aware_size(comp, padding=2.0) == \
+        _content_aware_size(comp, padding=2.0, corner_inset_mm=0.0)
+
+
+def test_corner_inset_grows_both_dims_by_2x():
+    comp = [{"w": 10.0, "h": 10.0, "is_terminal": False}]
+    w0, h0 = _wh(_content_aware_size(comp, padding=2.0))
+    w1, h1 = _wh(_content_aware_size(comp, padding=2.0, corner_inset_mm=3.5))
+    assert (w1, h1) == (w0 + 7, h0 + 7)   # 2 * 3.5 on each axis

--- a/tests/test_firmware_sidecar.py
+++ b/tests/test_firmware_sidecar.py
@@ -194,3 +194,70 @@ def test_find_sidecar_one_dir_up(tmp_path):
     (inc / "config.h").write_text("#define X 1\n")
     (tmp_path / "board.yaml").write_text("power_source: usb_c\n")
     assert find_sidecar(str(inc / "config.h")) == str(tmp_path / "board.yaml")
+
+
+# --- unknown-key rejection ----------------------------------------------------
+
+def test_unknown_top_level_key_rejected(tmp_path):
+    # A typo for a real key is a loud error, not a silently-ignored directive.
+    with pytest.raises(SidecarError) as e:
+        load_sidecar(_write(tmp_path, "board_size: [90, 75]\n"))   # missing _mm
+    assert "unknown board.yaml key" in str(e.value) and "board_size" in str(e.value)
+
+
+def test_known_keys_all_accepted(tmp_path):
+    # Every documented key loads clean together (guards the _KNOWN set drifting).
+    sc = load_sidecar(_write(tmp_path, """\
+        power_source: usb_c
+        board_size_mm: [90, 75]
+        extra_connectors: []
+        placement: {}
+        placement_hints: {}
+        mounting_holes: {count: 4}
+    """))
+    assert sc.power_source == "usb_c"
+
+
+# --- mounting_holes -----------------------------------------------------------
+
+def test_mounting_holes_absent_is_none(tmp_path):
+    assert load_sidecar(_write(tmp_path, "power_source: usb_c\n")).mounting_holes is None
+
+
+def test_mounting_holes_loads(tmp_path):
+    sc = load_sidecar(_write(tmp_path, """\
+        mounting_holes:
+          count: 2
+          drill_mm: 2.7
+          inset_mm: 4.0
+          keepout_mm: 1.0
+    """))
+    assert sc.mounting_holes == {"count": 2, "drill_mm": 2.7,
+                                 "inset_mm": 4.0, "keepout_mm": 1.0}
+
+
+@pytest.mark.parametrize("body,needle", [
+    ("mounting_holes: 4\n", "mounting_holes must be a mapping"),
+    ("mounting_holes: {count: 3}\n", "count"),          # not in {0,2,4}
+    ("mounting_holes: {count: 1}\n", "count"),          # boundary just below 2
+    ("mounting_holes: {drill_mm: 0}\n", "drill_mm"),    # not positive
+    ("mounting_holes: {drill_mm: -1}\n", "drill_mm"),   # negative
+    ("mounting_holes: {inset_mm: true}\n", "inset_mm"),  # bool is not a number
+])
+def test_mounting_holes_rejected(tmp_path, body, needle):
+    with pytest.raises(SidecarError) as e:
+        load_sidecar(_write(tmp_path, body))
+    assert needle in str(e.value)
+
+
+@pytest.mark.parametrize("count", [0, 2, 4])
+def test_mounting_holes_count_accepted(tmp_path, count):
+    sc = load_sidecar(_write(tmp_path, f"mounting_holes: {{count: {count}}}\n"))
+    assert sc.mounting_holes == {"count": count}
+
+
+def test_apply_threads_mounting_holes_into_source():
+    i = _intent()
+    sc = BoardSidecar(mounting_holes={"count": 4, "drill_mm": 3.2})
+    apply_sidecar(i, sc)
+    assert i.source["mounting_holes"] == {"count": 4, "drill_mm": 3.2}

--- a/tests/test_firmware_sidecar.py
+++ b/tests/test_firmware_sidecar.py
@@ -206,7 +206,8 @@ def test_unknown_top_level_key_rejected(tmp_path):
 
 
 def test_known_keys_all_accepted(tmp_path):
-    # Every documented key loads clean together (guards the _KNOWN set drifting).
+    # Every documented key loads clean together AND populates — guards all three
+    # sources (BoardSidecar fields / _KNOWN_SIDECAR_KEYS / load_sidecar) from drift.
     sc = load_sidecar(_write(tmp_path, """\
         power_source: usb_c
         board_size_mm: [90, 75]
@@ -216,12 +217,26 @@ def test_known_keys_all_accepted(tmp_path):
         mounting_holes: {count: 4}
     """))
     assert sc.power_source == "usb_c"
+    assert sc.board_size_mm == [90, 75]
+    assert sc.extra_connectors == []
+    assert sc.placement == {}
+    assert sc.placement_hints == {}
+    assert sc.mounting_holes == {"count": 4}
 
 
 # --- mounting_holes -----------------------------------------------------------
 
 def test_mounting_holes_absent_is_none(tmp_path):
     assert load_sidecar(_write(tmp_path, "power_source: usb_c\n")).mounting_holes is None
+
+
+def test_mounting_holes_explicit_null_is_none(tmp_path):
+    assert load_sidecar(_write(tmp_path, "mounting_holes: null\n")).mounting_holes is None
+
+
+def test_mounting_holes_empty_mapping_loads_empty(tmp_path):
+    # all keys optional → an empty mapping is valid and falls back to pipeline defaults
+    assert load_sidecar(_write(tmp_path, "mounting_holes: {}\n")).mounting_holes == {}
 
 
 def test_mounting_holes_loads(tmp_path):
@@ -240,9 +255,11 @@ def test_mounting_holes_loads(tmp_path):
     ("mounting_holes: 4\n", "mounting_holes must be a mapping"),
     ("mounting_holes: {count: 3}\n", "count"),          # not in {0,2,4}
     ("mounting_holes: {count: 1}\n", "count"),          # boundary just below 2
+    ("mounting_holes: {count: false}\n", "count"),      # bool slips past `in (0,2,4)`
     ("mounting_holes: {drill_mm: 0}\n", "drill_mm"),    # not positive
     ("mounting_holes: {drill_mm: -1}\n", "drill_mm"),   # negative
     ("mounting_holes: {inset_mm: true}\n", "inset_mm"),  # bool is not a number
+    ("mounting_holes: {counnt: 4}\n", "unknown key"),   # typo'd sub-key not dropped
 ])
 def test_mounting_holes_rejected(tmp_path, body, needle):
     with pytest.raises(SidecarError) as e:

--- a/tests/test_mounting_holes.py
+++ b/tests/test_mounting_holes.py
@@ -1,0 +1,31 @@
+"""Pure tests for mounting-hole resolution (Phase 5). The footprint/keepout step
+itself is integration-gated (real KiCad); this covers the defaults-merge logic.
+Boundary-focused per CLAUDE.md: None vs {} vs partial-override vs count=0.
+"""
+from kicad_mcp.tools.pcb_pipeline import _resolve_mounting_holes
+
+_DEFAULT = {"count": 4, "drill_mm": 3.2, "inset_mm": 3.5, "keepout_mm": 1.5}
+
+
+def test_none_is_full_default():
+    assert _resolve_mounting_holes(None) == _DEFAULT
+
+
+def test_empty_mapping_is_full_default():
+    assert _resolve_mounting_holes({}) == _DEFAULT
+
+
+def test_partial_override_merges_over_defaults():
+    assert _resolve_mounting_holes({"count": 2, "drill_mm": 2.7}) == \
+        {"count": 2, "drill_mm": 2.7, "inset_mm": 3.5, "keepout_mm": 1.5}
+
+
+def test_count_zero_preserved_not_defaulted():
+    # count=0 (disable) must survive the merge, not get overwritten by default 4.
+    assert _resolve_mounting_holes({"count": 0})["count"] == 0
+
+
+def test_unknown_keys_ignored_only_known_merged():
+    # _resolve only copies known keys (validation/rejection is the sidecar's job).
+    assert _resolve_mounting_holes({"count": 2, "bogus": 9}) == \
+        {"count": 2, "drill_mm": 3.2, "inset_mm": 3.5, "keepout_mm": 1.5}

--- a/tests/test_new_tools.py
+++ b/tests/test_new_tools.py
@@ -848,6 +848,52 @@ class TestBuildPcbFromSchematic:
         assert result["gerber_zip"] == "/tmp/test-gerbers.zip"
         mock_gerbers.assert_called_once()
 
+    @patch("kicad_mcp.tools.pcb_pipeline._render_board_svg", return_value=None)
+    @patch("kicad_mcp.tools.pcb_pipeline._step_add_mounting_holes")
+    @patch("kicad_mcp.tools.pcb_pipeline._step_export_gerbers")
+    @patch("kicad_mcp.tools.pcb_pipeline._step_add_zones_and_fill")
+    @patch("kicad_mcp.tools.pcb_pipeline._step_autoroute")
+    @patch("kicad_mcp.tools.pcb_pipeline._step_smart_placement")
+    @patch("kicad_mcp.tools.pcb_pipeline._step_inject_nets_and_assign_pads")
+    @patch("kicad_mcp.tools.pcb_pipeline._step_load_footprints")
+    @patch("kicad_mcp.tools.pcb_pipeline._step_create_pcb_and_outline")
+    @patch("kicad_mcp.tools.pcb_pipeline._step_extract_netlist")
+    def test_approval_gate_stops_before_autoroute(
+        self, mock_netlist, mock_create, mock_place, mock_nets,
+        mock_optimize, mock_route, mock_zones, mock_gerbers, mock_holes,
+        mock_render, mcp_server, tmp_path,
+    ):
+        """approved=False returns a proposal and never runs autoroute/zones."""
+        pro = tmp_path / "test.kicad_pro"
+        pro.write_text("{}")
+        (tmp_path / "test.kicad_sch").write_text("(kicad_sch)")
+
+        mock_netlist.return_value = {
+            "status": "ok",
+            "components": {"R1": {"reference": "R1", "value": "10k", "footprint": "Resistor_SMD:R_0603"}},
+            "components_without_footprint": [],
+            "nets": {"SIG": [{"component": "R1", "pin": "1"}]},
+            "component_count": 1, "net_count": 1, "skipped_count": 0,
+        }
+        mock_create.return_value = {"status": "ok", "width_mm": 30, "height_mm": 20, "auto_sized": True}
+        mock_place.return_value = {"status": "ok", "placed_count": 1, "errors": [],
+                                   "placement_decisions": []}
+        mock_nets.return_value = {"status": "ok", "pads_assigned": 1, "nets_created": 1, "total_nets": 1}
+        mock_holes.return_value = {"status": "ok", "holes_added": 0, "positions": []}
+
+        fn = _get_tool_fn(mcp_server, "build_pcb_from_schematic")
+        result = fn(str(pro), approved=False)
+
+        assert result["status"] == "pending_approval"
+        prop = result["proposal"]
+        assert set(prop) >= {"board_size_mm", "antenna_edge", "terminal_table",
+                             "mounting_holes", "render_path", "proposed_board_yaml"}
+        assert prop["board_size_mm"] == [30, 20]
+        # The expensive steps were NOT run — that's the whole point of the gate.
+        mock_route.assert_not_called()
+        mock_zones.assert_not_called()
+        mock_gerbers.assert_not_called()
+
 
 class TestFinalizePadAssignment:
     """h-pad-deadboard: a board with pads requested but ZERO assigned is

--- a/tests/test_new_tools.py
+++ b/tests/test_new_tools.py
@@ -642,6 +642,7 @@ class TestBuildPcbFromSchematic:
         assert "error" in result
         assert "Schematic not found" in result["error"]
 
+    @patch("kicad_mcp.tools.pcb_pipeline._step_add_mounting_holes")
     @patch("kicad_mcp.tools.pcb_pipeline._step_export_gerbers")
     @patch("kicad_mcp.tools.pcb_pipeline._step_add_zones_and_fill")
     @patch("kicad_mcp.tools.pcb_pipeline._step_autoroute")
@@ -652,7 +653,7 @@ class TestBuildPcbFromSchematic:
     @patch("kicad_mcp.tools.pcb_pipeline._step_extract_netlist")
     def test_full_pipeline_happy_path(
         self, mock_netlist, mock_create, mock_place, mock_nets,
-        mock_optimize, mock_route, mock_zones, mock_gerbers,
+        mock_optimize, mock_route, mock_zones, mock_gerbers, mock_holes,
         mcp_server, tmp_path,
     ):
         """Full pipeline with all steps succeeding."""
@@ -682,6 +683,7 @@ class TestBuildPcbFromSchematic:
         mock_optimize.return_value = {"status": "ok", "components_placed": 2}
         mock_route.return_value = {"status": "ok", "tracks_after": 20, "vias_after": 2, "unconnected_after_routing": 0}
         mock_zones.return_value = {"status": "ok", "zones_added": 2}
+        mock_holes.return_value = {"status": "ok", "holes_added": 0, "positions": []}
 
         fn = _get_tool_fn(mcp_server, "build_pcb_from_schematic")
         result = fn(str(pro))
@@ -693,6 +695,7 @@ class TestBuildPcbFromSchematic:
         assert result["incomplete_nets"] == 0
         assert "export_gerbers" not in result["steps"]
 
+    @patch("kicad_mcp.tools.pcb_pipeline._step_add_mounting_holes")
     @patch("kicad_mcp.tools.pcb_pipeline._step_export_gerbers")
     @patch("kicad_mcp.tools.pcb_pipeline._step_add_zones_and_fill")
     @patch("kicad_mcp.tools.pcb_pipeline._step_autoroute")
@@ -703,7 +706,7 @@ class TestBuildPcbFromSchematic:
     @patch("kicad_mcp.tools.pcb_pipeline._step_extract_netlist")
     def test_explicit_board_size(
         self, mock_netlist, mock_create, mock_place, mock_nets,
-        mock_optimize, mock_route, mock_zones, mock_gerbers,
+        mock_optimize, mock_route, mock_zones, mock_gerbers, mock_holes,
         mcp_server, tmp_path,
     ):
         """Explicit board dimensions are passed through to create step."""
@@ -725,17 +728,20 @@ class TestBuildPcbFromSchematic:
         mock_optimize.return_value = {"status": "ok", "components_placed": 1}
         mock_route.return_value = {"status": "ok", "tracks_after": 5, "vias_after": 0, "unconnected_after_routing": 0}
         mock_zones.return_value = {"status": "ok", "zones_added": 2}
+        mock_holes.return_value = {"status": "ok", "holes_added": 0, "positions": []}
 
         fn = _get_tool_fn(mcp_server, "build_pcb_from_schematic")
         result = fn(str(pro), board_width_mm=22, board_height_mm=69)
 
         assert result["status"] == "ok"
-        # Verify explicit dimensions were passed
+        # Verify explicit dimensions were passed (with the default mounting-holes spec).
         mock_create.assert_called_once_with(
             str(tmp_path / "test.kicad_pcb"), 22, 69,
             mock_netlist.return_value["components"],
+            holes={"count": 4, "drill_mm": 3.2, "inset_mm": 3.5, "keepout_mm": 1.5},
         )
 
+    @patch("kicad_mcp.tools.pcb_pipeline._step_add_mounting_holes")
     @patch("kicad_mcp.tools.pcb_pipeline._step_add_zones_and_fill")
     @patch("kicad_mcp.tools.pcb_pipeline._step_autoroute")
     @patch("kicad_mcp.tools.pcb_pipeline._step_smart_placement")
@@ -745,7 +751,7 @@ class TestBuildPcbFromSchematic:
     @patch("kicad_mcp.tools.pcb_pipeline._step_extract_netlist")
     def test_autoroute_failure_stops_pipeline(
         self, mock_netlist, mock_create, mock_place, mock_nets,
-        mock_optimize, mock_route, mock_zones,
+        mock_optimize, mock_route, mock_zones, mock_holes,
         mcp_server, tmp_path,
     ):
         """Autoroute error stops pipeline — no zones step."""
@@ -766,6 +772,7 @@ class TestBuildPcbFromSchematic:
         mock_nets.return_value = {"status": "ok", "pads_assigned": 1, "nets_created": 1, "total_nets": 1}
         mock_optimize.return_value = {"status": "ok", "components_placed": 1}
         mock_route.return_value = {"error": "FreeRouter JAR not found"}
+        mock_holes.return_value = {"status": "ok", "holes_added": 0, "positions": []}
 
         fn = _get_tool_fn(mcp_server, "build_pcb_from_schematic")
         result = fn(str(pro))
@@ -798,6 +805,7 @@ class TestBuildPcbFromSchematic:
         assert "No components with footprints" in result["error"]
         assert any("2 component(s) skipped" in w for w in result.get("warnings", []))
 
+    @patch("kicad_mcp.tools.pcb_pipeline._step_add_mounting_holes")
     @patch("kicad_mcp.tools.pcb_pipeline._step_export_gerbers")
     @patch("kicad_mcp.tools.pcb_pipeline._step_add_zones_and_fill")
     @patch("kicad_mcp.tools.pcb_pipeline._step_autoroute")
@@ -808,7 +816,7 @@ class TestBuildPcbFromSchematic:
     @patch("kicad_mcp.tools.pcb_pipeline._step_extract_netlist")
     def test_gerber_export_when_requested(
         self, mock_netlist, mock_create, mock_place, mock_nets,
-        mock_optimize, mock_route, mock_zones, mock_gerbers,
+        mock_optimize, mock_route, mock_zones, mock_gerbers, mock_holes,
         mcp_server, tmp_path,
     ):
         """Gerber export runs only when export_gerbers=True."""
@@ -831,6 +839,7 @@ class TestBuildPcbFromSchematic:
         mock_route.return_value = {"status": "ok", "tracks_after": 5, "vias_after": 0, "unconnected_after_routing": 0}
         mock_zones.return_value = {"status": "ok", "zones_added": 2}
         mock_gerbers.return_value = {"status": "ok", "zip_path": "/tmp/test-gerbers.zip", "total_files": 12}
+        mock_holes.return_value = {"status": "ok", "holes_added": 0, "positions": []}
 
         fn = _get_tool_fn(mcp_server, "build_pcb_from_schematic")
         result = fn(str(pro), export_gerbers=True)


### PR DESCRIPTION
Completes the deferred v1.1 phases of the human-rational autoplacer.

## Phase 5 — corner mounting holes
- 4 (or 2) corner M3 holes (`MountingHole_3.2mm_M3`) + a no-copper rule-area keepout per hole; default on, opt out via `add_mounting_holes=False` or board.yaml `mounting_holes.count: 0`.
- board.yaml `mounting_holes` schema (count/drill/inset/keepout) + **unknown-top-level-key rejection** (a `board_size` typo is now a loud error).
- Content-aware sizing reserves the corner clearance; holes pinned via `fixed` hints so the placer keeps clear.
- **All pcbnew APIs verified on KiCad 9.0.9 AND 10.0.3 first** — caught two wrong assumptions (footprint name; `LSET &` operator).

## Phase 7 — approval gate
- `build_pcb_from_schematic(approved=False)` runs through placement, **stops before the expensive autoroute**, and returns a `proposal` (board size, antenna edge, per-terminal table, hole positions, a tweakable `proposed_board_yaml`, best-effort SVG render). Uses the real placement decisions — no re-derivation.

## Eyeball-driven fixes (Brian reviewed the proposal render)
- Holes were scattering to the interior (fixed-hint refs fell out of the tier that honors them) → **fixed-hint refs now route to tier-2** regardless of class.
- Terminals were landing on corner holes (keepout is routing-only) → **terminal layout now reserves the corner clearance** (single source shared with sizing).
- Proposal render excludes the drawing sheet (the frame was masquerading as the board edge).

## Tests
Unit 1987, mypy clean (73 files), **integration 6/6 on KiCad 9 AND 10**. New regression guards read the *placed* board, not step reports: holes actually at corners, and no terminal courtyard overlaps a hole.

Two cosmetic sizing RFEs deferred (axis-aware corner reservation; multi-edge distribution) — documented in `docs/PLAN_Autoplacer_v1.1.md`. Correctness is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)