### PR TITLE
feat(firmware): part-resolution foundation — registry (C2) + part-name extractor (C1)

### DIFF
--- a/docs/PLAN_Firmware_Part_Resolution.md
+++ b/docs/PLAN_Firmware_Part_Resolution.md
@@ -1,0 +1,44 @@
+# Firmware Part-Resolution — Implementation Plan
+
+Branch `feat/firmware-part-resolution` off `main`. See `docs/SPEC_Firmware_Part_Resolution.md`
+(carried over from the unmerged `jovial-kilby` branch, commit `ba6c2da`).
+
+**Goal:** stop the firmware front end from INVENTING parts (it substitutes `SPH0645` for
+the user's actual `INMP441`). Resolve to the part the user declared; emit a disclosed gap
+when a resolved part has no shipped symbol/footprint, rather than silently substituting.
+
+## I1 BLOCKER — fix first
+> **I1: canonicalize-vs-raw-regex mismatch breaks hyphenated parts like ICS-43434 — match on raw strings, canonical only as lookup key**
+
+`canonical_type()` strips non-alphanumerics (`ICS-43434` → `ICS43434`), so a regex built from
+canonical names never matches the raw source text. **Fix:** the extractor matches on RAW names
+(`\bICS-43434\b`); `canonical_type` is used only as the card-lookup key. `cards.recognized_part_names()`
+returns `dict[str, str]` mapping `raw_name → canonical_key` (covers `type` + each `alias`).
+
+## Default decisions taken
+- **Branch base = `main`** (spec recommendation; cherry-pick only autoroute fixes from `agitated-curie` if needed). The prior `agitated-curie` INMP441 fanout work is NOT pulled in unless Brian says so.
+- **Resolution machinery proceeds without the INMP441 symbol** — until workstream A ships it, an INMP441 resolves and emits a `part_unavailable` gap (the honest behavior the spec wants). This is the bulk of the value and is unblocked.
+
+## BLOCKED on Brian (needed only for full completion, not the core)
+- Workstream A: author the INMP441 KiCad symbol + footprint. Needs datasheet pin-name decisions (SCK/SD/WS/L-R/GND×3/VDD/CHIPEN — CHIPEN must not float), and the bare-LGA-vs-module-header footprint default.
+- ICS-43434 as a sanctioned substitute → needs I2S firmware-compat check.
+
+## Phases (software core — all unblocked)
+- **C8 (test-first):** `tests/test_part_identity_guardrail.py` — assert every placed template peripheral with a non-generic type either has imported provenance or an `assumed_part`/`part_unavailable` gap names it. Mark `xfail` until C6 lands so the suite stays green; flip to strict after.
+- **C2 registry:** `cards.py` — validate optional `aliases` (list[str]) + `serves` (member of new `_SERVES_BUS_TYPES = {I2C,SPI,I2S_IN,I2S_OUT,UART}` — FINER than `_BUSES`, the I2 fix). Add `recognized_part_names() -> dict[str,str]` (I1 fix). New cards: `inmp441.yaml` (serves I2S_IN), `max98357a.yaml` (serves I2S_OUT, formalizes the `knowledge.py` constant), `sph0645.yaml` (serves I2S_IN, alias SPH0645LM4H). Keep `K.SPH0645`/`K.MAX98357A` Python dicts as disclosed fallbacks until the card path is proven.
+- **C1 extractor:** `part_extractor.py` (new, pure) — `collect_corpus(config_path)` reads PREPROCESSED config text (post-`select_active_branches`) + bounded `.cpp/.h` + `README/WIRING/CLAUDE.md`; `extract_part_names(corpus, recognized_names)` matches RAW names with `\b…\b` (case-insensitive), returns `PartEvidence` ordered source > config_comment > doc. The `// INMP441 …` standalone comment in the real config.h is visible only in raw text (parse_defines strips comments).
+- **C4 resolver:** extend `Bus` (intent.py) with `resolved_part`/`part_provenance`/`part_is_assumption`; bump `SCHEMA_VERSION`. `bus_part_resolver.py` (new, pure): for each bus, match cards whose `serves` == `bus.type`; if exactly one such part appears in corpus → high confidence; >1 → low (no silent pick, gap-worthy); 0 → none. NO proximity heuristics. Wire into `design.py:_op_import` after `build_intent`.
+- **C5 gap:** `generate.py` — when a resolved part's symbol lookup fails, emit `part_unavailable` gap into the intent (spec §5.4 exact text). Confirm the generate-mutates-intent pattern with Brian (I3/G2).
+- **C6 template split:** `templates.py` `i2s_mic`/`i2s_output_amps` — if `bus.resolved_part` & not assumption & card found → place card with `origin="imported"`; else disclosed fallback + `assumed_part` gap. INMP441 support glue (CHIPEN→VDD, L/R→GND, SD pulldown, decoupling) via card `config`/`static_ties` → handled by the generic `device_config` template, no new template code.
+- **C7 board.yaml override:** `sidecar.py` — `bus_part_overrides` (validated against `recognized_part_names()`; footprint-only swap leaves `lib_id`/identity). Stamps `bus.resolved_part`, `part_is_assumption=False`, provenance `user`.
+- **C9 golden:** new fixture `tests/fixtures/firmware/audio_inmp441/` (adds the `// INMP441` comment) → integration test asserts `resolved_part=="INMP441"`, not SPH0645. Existing `audio_s3` (no comment) keeps the fallback path → assert `assumed_part` gap now present.
+
+## External-system assumptions to verify
+- INMP441 footprint land pattern (datasheet) — before authoring.
+- KiCad symbol pin names for MAX98357A / SPH0645 cards (`~{SD_MODE}` negation is version-sensitive) — re-verify on 9 & 10.
+- `select_active_branches` runs BEFORE `collect_corpus` (dead `#else` parts ignored).
+- `kicad_sch_api` stable on absent lib_id (append to component_errors, no crash).
+- Project-library path discoverable by `get_symbol_cache()` for the INMP441 lib_id.
+
+## Build order
+C8 (xfail) → C2 registry (+I1 fix) → C1 extractor → C4 resolver → C5 gap → C6 templates → C7 sidecar → C9 golden. All but A are no-symbol-needed.

--- a/docs/SPEC_Firmware_Device_Cards.md
+++ b/docs/SPEC_Firmware_Device_Cards.md
@@ -51,6 +51,11 @@ lib_id: Connector_Generic:Conn_01x05
 value: GY-521 (MPU-6050)
 footprint: Connector_PinHeader_2.54mm:PinHeader_1x05_P2.54mm_Vertical
 bus: I2C                      # null for non-bus devices
+aliases: ["MPU-6050", "GY521"]  # optional; alternate RAW names firmware may spell
+                              # (part-resolution matches these too, hyphen intact)
+serves: I2C                   # optional; DIRECTIONAL bus a part resolves onto for
+                              # part-resolution — I2C|SPI|I2S_IN|I2S_OUT|UART
+                              # (finer than `bus`: a mic serves I2S_IN, an amp I2S_OUT)
 module: true                 # breakout-module-header representation (carrier-board)
 roles:                        # firmware signal-role (UPPER) -> symbol pin NAME or NUMBER
   SDA: "4"

--- a/docs/SPEC_Firmware_Part_Resolution.md
+++ b/docs/SPEC_Firmware_Part_Resolution.md
@@ -1,0 +1,209 @@
+# SPEC: Firmware-Driven Part Resolution
+
+**Status:** DRAFT — written 2026-05-31. **BLOCKED behind the placement-locus phase** (see `SPEC_Firmware_Placement_Locus.md`): locus is a foundational intent-model axis that changes what "place a resolved part" means (a remote device is realized as a terminal, not a placed symbol — e.g. the INMP441 on the audio-node), so it must land first. **Also has pending cold-review must-fixes** to fold in before implementation: I1 (canonicalize-vs-raw-regex mismatch breaks hyphenated parts like ICS-43434 — match on raw strings, canonical only as lookup key), I3/G2 (resolved-but-unplaceable + guardrail need a generate-time change; "generate_schematic no changes" is wrong), G1 (type-only binding does nothing for multi same-type buses — needs the bind-all-with-disclosure + bus-section-association tiers), I2 (`serves` validates against the finer `Bus.type` vocab), E5 (dead-branch guarantee covers config.h only; source/doc evidence is best-effort). **Requires fresh-session cold review before implementation** (per the project's Spec Review Rule: do not implement in the session that wrote the spec).
+
+**Scope:** Workstreams **A** (INMP441 library content) and **C** (read-from-firmware part-resolution layer). Workstream **B** (standalone disclosure/override patch) is **dropped** — it is a strict subset of C and would build the same scaffolding twice.
+
+---
+
+## 1. Problem
+
+The firmware front end translates ESP32 firmware into a schematic/PCB. Today it parses **only `#define` GPIO numbers**, then `expand_intent` runs templates that **hardcode specific application parts**:
+
+- `i2s_mic` unconditionally places a Knowles **SPH0645** for any `I2S_IN` bus.
+- `i2s_output_amps` unconditionally places a **MAX98357A** for any `I2S_OUT` bus.
+
+The user's real firmware (`mr-esp32/audio-node`) **names these parts explicitly**: `INMP441` in `config.h` comments (lines 43, 190) and a dedicated `amp_gain.cpp`/`.h` written around the MAX98357A's GAIN_SLOT pin. The pipeline discards all of it and guesses — and guessed **wrong** for the mic (SPH0645 ≠ INMP441; **not firmware-compatible** — different silicon, footprint, and the SPH0645's known data-alignment quirk).
+
+This violates the front end's core contract — *"honest-by-construction, never invent parts."* The defect is not that a default was chosen; it is that a **specific user-choice part was invented from a generic bus and presented silently as fact.**
+
+### Blast radius (audit result)
+
+| Template | Invented part | Trigger | Disclosed? | Verdict |
+|---|---|---|---|---|
+| `i2s_mic` | SPH0645 | `I2S_IN` bus | No | **Bug — wrong part** |
+| `i2s_output_amps` | MAX98357A | `I2S_OUT` bus | No | Silent, but *correct* default |
+| `usb_programming` | CP2102N | non-native-USB MCU | No | Silent; commodity glue |
+| `power_tree` | AMS1117-3.3 | 3V3 MCU | Partially (docstring only) | Silent; commodity glue |
+
+The MAX98357A case proves the principle: the **mechanism** (silent invention) is wrong even when the **part** happens to be right. There is no part-recovery path anywhere in the pipeline and no guardrail preventing silent invention.
+
+---
+
+## 2. Verified facts (external-system checks, 2026-05-31)
+
+These were confirmed against the installed KiCad libraries and the local filesystem this session. **Re-verify on the target machine / KiCad version before shipping.**
+
+| Part | KiCad symbol | KiCad footprint | Note |
+|---|---|---|---|
+| **INMP441** | **NONE** | **NONE** | Not in std libs, not in any 3rd-party/user lib on the machine. **This is the central constraint for workstream A.** |
+| MAX98357A | `Audio:MAX98357A` ✓ | `Package_DFN_QFN:HVQFN-16-1EP_3x3mm_P0.5mm_EP1.5x1.5mm` (in use today) | Resolution + placement both work. |
+| SPH0645 | `Sensor_Audio:SPH0645LM4H` ✓ | `Sensor_Audio:Knowles_SPH0645LM4H-6_3.5x2.65mm` ✓ | Usable as a **disclosed** fallback stand-in. |
+| ICS-43434 | `Sensor_Audio:ICS-43434` ✓ | (check) | Candidate **disclosed substitute** for INMP441 (24-bit I2S MEMS mic that ships with KiCad). Firmware-compatibility not yet verified. |
+
+**Implication:** resolving "INMP441" from firmware is necessary but **not sufficient** — there is nothing to instantiate. This forces the new **identity vs footprint vs availability** distinction below, and the **resolved-but-unplaceable** path (§5.4).
+
+`parse.py` captures *trailing inline* comments on `#define` lines (`Macro.comment`) but **drops standalone comment lines** — the `// --- INMP441 ... ---` callout at config.h:190 is a standalone line, so it is currently invisible. The extractor must read raw/preprocessed source text, **not** `ParsedFirmware`.
+
+---
+
+## 3. Architecture
+
+Three **separate axes**, previously conflated:
+
+1. **Identity** — *which part* (INMP441). Determinable from firmware (code > adjacent comments > docs > platformio).
+2. **Footprint / form-factor** — *bare chip vs module-on-header*. A board-level decision the firmware does **not** make; defaulted by the card, overridable per board. Never inferred from how the reference was prototyped.
+3. **Availability** — *does a KiCad symbol/footprint exist*. Independent of identity; can fail (INMP441) even when identity is certain.
+
+**Resolution order:** read the part from firmware **first** (authoritative, with provenance). Templates become a **disclosed fallback** consulted only when resolution fails. Glue/passives (LDO, decoupling, pull-ups, straps, gain/isolator resistors) **stay template-owned** — firmware does not name them and they are not user-choice parts.
+
+**Honest-by-construction restored:** every placed specific part carries *either* firmware provenance *or* a disclosed-assumption gap. Enforced by a guardrail test (§5.6).
+
+---
+
+## 4. Workstream A — INMP441 library content
+
+Author the INMP441 as a real, placeable part with **two footprints** (the form-factor axis):
+
+- **A1 — bare LGA**: author a KiCad symbol + footprint for the INMP441 bottom-port LGA. Pinout **verified against InvenSense datasheet DS-INMP441-00 Rev 1.0, Table 6** (9-pad LGA, not 6 — the breakout module hides pads 5/6/8/9):
+
+  | Pad | Name | Card role / tie |
+  |----|------|-----------------|
+  | 1 | SCK | role `BCLK` |
+  | 2 | SD | role `DATA`; **100 kΩ pulldown** (bus tri-state discharge) |
+  | 3 | WS | role `WS` |
+  | 4 | L/R | static_tie → GND (left channel default) |
+  | 5 | GND | ground (center pad) |
+  | 6 | GND | ground |
+  | 7 | VDD | supply; **0.1 µF decouple to pad 6** |
+  | 8 | CHIPEN | **static_tie → VDD — floating = mic disabled** (landmine; assert in tests) |
+  | 9 | GND | ground |
+
+  Support glue the template must add (firmware-blind): CHIPEN→VDD tie, L/R→GND tie, SD 100 kΩ pulldown, VDD 0.1 µF decoupling. The three GND pads (5/6/9) wire by number. **Note:** this is a fine-pitch bottom-port part — choosing it on a PCB reopens the fine-pitch fanout question. Real but bounded work.
+- **A2 — module header**: `Connector_Generic:Conn_01x06` (or the actual breakout pinout) — trivial, no custom symbol; matches the breakout modules in use on the bench.
+
+Default footprint = author's choice (recommend bare LGA to match the "PCB ≠ breadboard" intent); the alternative is selectable via `board.yaml` (§5.5). Ship both as committed project library content (air-gap: no synthesis at user time).
+
+**Open:** decide the canonical symbol pin names; verify against any reputable third-party INMP441 symbol before drawing from scratch.
+
+---
+
+## 5. Workstream C — resolution layer
+
+New stage inserted between `partition()` and `build_intent()`:
+
+```
+config.h text
+  → parse_defines + partition                       (unchanged)
+  → collect_corpus(config_path)                      (NEW; I/O shell)
+  → extract_part_names(corpus, recognized_names)     (NEW; pure)
+  → resolve_bus_parts(parsed, evidences, registry)   (NEW; pure)
+  → build_intent(parsed, bus_part_resolutions=...)   (Bus gains resolved_part + provenance)
+  → expand_intent                                    (templates read resolved_part; fallback discloses)
+  → apply_sidecar (board.yaml part/footprint override)
+  → generate_schematic                               (unchanged)
+```
+
+`Peripheral` dataclass and `generate_schematic` need **no** changes — a resolved part manifests as `lib_id`/`value`/`footprint` from a card.
+
+### 5.1 Part-name extractor (`part_extractor.py`, new)
+
+- `collect_corpus(config_path) -> FirmwareCorpus` — I/O shell. Reads: preprocessed config.h text (post-`select_active_branches`, for comments); `*.cpp`/`*.h` within a bounded depth of config.h; docs (`WIRING*.md`, `README*.md`, `CLAUDE.md`). Returns plain data tagged by kind (`config_comment` | `source` | `doc`).
+- `extract_part_names(corpus, recognized_names: frozenset[str]) -> list[PartEvidence]` — **pure**. Whole-word regex (`\bINMP441\b`, case-insensitive) so `INMP441_VDD` does not match. Must NOT import the card layer; `recognized_names` is injected.
+- `PartEvidence{part_name, file, line, kind, raw_text}` + a `category` (mic/amp/...) looked up from the registry downstream.
+
+**Tests** (`tests/test_part_extractor.py`, no KiCad): regex boundary at/below/above (`INMP441` matches, `INMP4411` does not, lowercase matches), part in block comment, line comment, C string literal; `collect_corpus` over a `tmp_path` tree.
+
+### 5.2 Recognition registry = cards (single source of truth)
+
+Cards gain an optional **`aliases`** list and a **`serves`** field (the bus type the part attaches to — `I2S_IN`, `I2S_OUT`, `I2C`, `UART`). `cards.recognized_part_names()` returns the union of all card `type` values + aliases, each run through the existing `canonical_type()` normalizer (no second source; no drift). Validator extends to check `aliases` (list of str) and `serves` (known bus type).
+
+**Tests** extend `test_device_cards.py`: alias validates; `recognized_part_names()` includes canonicalized type + aliases; parity check guards drift.
+
+### 5.3 Bus-part resolution (`bus_part_resolver.py`, new) — **binding by semantics, not proximity**
+
+`resolve_bus_parts(parsed, corpus, recognized_names) -> dict[bus_stem, ResolvedBusPart]`.
+
+**Binding rule (decided):** bind by **card-declared category ↔ bus type**, NOT by text proximity. A recognized part declares `serves: I2S_IN`; a bus has `type: I2S_IN`. For each bus, find recognized parts whose `serves` matches the bus type **and** which appear in the corpus:
+
+- exactly one → bind, `confidence="high"`, record provenance (file:line, kind);
+- zero → no resolution (→ fallback, §5.4);
+- more than one (e.g., two `I2S_IN` buses, one mic name) → `confidence="low"`, **do not guess** — surface a gap inviting `board.yaml` resolution.
+
+This explicitly **rejects** proximity/section-header heuristics (Open Decision 1 in the architect plan) as a syntactic-semantic seam: text position is not bus membership. Priority among evidence *kinds* for the same binding: source code > config comment > doc.
+
+`Bus` gains: `resolved_part: Optional[str]`, `part_provenance: Optional[dict]`, `part_is_assumption: bool`. `SCHEMA_VERSION` → 4 (back-compat via existing `_only_fields`). `build_intent` gains `bus_part_resolutions=...`; `design.py::_op_import` wires corpus collection + resolution in.
+
+**Tests** (`tests/test_bus_part_resolver.py`, no KiCad): source beats comment beats doc; single-match high; multi-match low (no silent pick); unknown name ignored; missing stem absent (no KeyError).
+
+### 5.4 Resolved-but-unplaceable path (**NEW — the INMP441 lesson**)
+
+When a part is resolved (identity known) but **no KiCad symbol/footprint is available** for its card's `lib_id`/`footprint`, the system must **not** silently fall back to a different chip. It emits a gap:
+
+> `Gap(kind="part_unavailable", detail="firmware specifies INMP441; no KiCad symbol/footprint shipped — options: (1) add project library content, (2) use module-header footprint, (3) board.yaml disclosed substitute", resolved=False)`
+
+and either places the user's chosen alternative (if `board.yaml` supplies one) or leaves a clearly-flagged placeholder. For INMP441 specifically, workstream A removes this gap by shipping the library content; the path exists for *future* resolved-but-absent parts.
+
+### 5.5 Footprint / form-factor override (`board.yaml`)
+
+`BoardSidecar` gains `bus_part_overrides: {bus_stem: {part?: str, footprint?: str}}`, applied in `apply_sidecar` after `build_intent` (existing pattern). `part` and `footprint` are independent: overriding `footprint` swaps only `Peripheral.footprint` (identity/`lib_id` unchanged) — this is how the user selects bare-LGA vs module-header for the INMP441, or forces a disclosed substitute. `part` validated against `recognized_part_names()`; unknown keys rejected (existing error discipline). User override → `part_provenance.kind="user"`, `part_is_assumption=False`, highest priority.
+
+**Tests** extend `test_firmware_sidecar.py`.
+
+### 5.6 Guardrail (`tests/test_part_identity_guardrail.py`, new)
+
+Fails if any placed **non-generic** part (not C/R/SW/HDR/CONN/USB_C/CP2102/AMS1117) lacks **either** `origin="imported"`/firmware provenance **or** a disclosed `assumed_part`/`part_unavailable` gap naming it. The test *is* the contract — silent invention becomes structurally impossible. Test-first (write before changing templates).
+
+### 5.7 Template split (`templates.py`)
+
+`i2s_mic` / `i2s_output_amps`: if `bus.resolved_part` set → load its card, place with `origin="imported"`; else → place the disclosed fallback default (SPH0645 / MAX98357A) **and** emit `assumed_part` gap, `origin="template"`. **Support glue stays template-owned** (decoupling, DIN isolator, SEL strap, speaker headers). MAX98357A/SPH0645 Python dicts in `knowledge.py` remain as fallback constants; deprecate once cards exist and the split is proven.
+
+### 5.8 Golden harness (`tests/integration/`)
+
+- Existing `test_audio_s3_to_routed_pcb` unchanged (fixture names no part → fallback SPH0645/MAX98357A + gaps; existing count assertions hold).
+- **New fixture** `tests/fixtures/firmware/audio_inmp441/` — config.h with the `// INMP441` callout (+ optional `amp_gain.cpp` stub naming MAX98357A). New test asserts: bus `resolved_part=="INMP441"`, provenance kind, placed mic `lib_id` = INMP441 card (not SPH0645), no `assumed_part` gap for the mic, and (once A ships) no `part_unavailable` gap.
+
+---
+
+## 6. Open decisions (for the cold reviewer)
+
+1. **INMP441 default footprint** — bare LGA (matches "PCB ≠ breadboard") vs module-header (matches bench reality, avoids fine-pitch). Spec recommends bare LGA as default with header overridable; confirm.
+2. **Disclosed substitute identity** — if a user wants a stand-in rather than authoring library content, is ICS-43434 the sanctioned choice? Requires a firmware-compatibility check against the INMP441 the firmware expects.
+3. **Tier-2 glue (CP2102N, AMS1117) disclosure** — fold into this work, or defer? They are silent-but-correct; lower priority than the mic.
+4. **Branch base** — build on `agitated-curie` (keeps the now-mooted fanout commits, which touch `i2s_mic`) or branch from `main` and shelve fanout. Recommend: **branch from main**, cherry-pick only the autoroute fixes, shelve fanout (it is subsumed/mooted; the bare-LGA INMP441 path can revive it later if chosen).
+
+---
+
+## 7. External-system assumptions to verify before implementation
+
+- INMP441 symbol pin names — **VERIFIED 2026-05-31** against datasheet DS-INMP441-00 Rev 1.0 Table 6 (see §4, A1). Still TODO at A-impl: the **land pattern / outline dimensions** for the footprint (same datasheet, pages 17–19).
+- `Audio:MAX98357A` and `Sensor_Audio:SPH0645LM4H` / `ICS-43434` pin names vs the card `roles` map, on KiCad 9 **and** 10 (integration `test_device_cards.py` is the catch; the `~{SD_MODE}` negation markup is version-sensitive).
+- `select_active_branches` strips inactive `#else`/`#if` blocks **before** the extractor reads comments (so a part named only in an excluded legacy block is correctly ignored) — confirm `collect_corpus` receives preprocessed config text.
+- `kicad_sch_api` behavior when a `lib_id` is absent (today: `component_errors`, not a crash) — the resolved-but-unplaceable path depends on detecting absence cleanly.
+
+---
+
+## 8. Out of scope / parked
+
+- **Amp GAIN pin** — firmware drives GAIN via GPIO (`CMCA_AMP_GAIN_BUS0/1`, GPIO 11/12, `amp_gain.cpp`); the template currently leaves GAIN floating (9 dB Hi-Z). So even "support glue" is partly firmware-determined. The resolution layer should eventually read this; **not** in the A+C MVP. Flag explicitly so it is not mistaken for covered.
+- **Pluggable firmware readers** for non-config.h ecosystems (STM32 .ioc, Zephyr DT).
+- **Fanout / fine-pitch plane-pad** work (the `agitated-curie` Stage-1/2 commits) — mooted for the module-header form; revived only if bare-LGA INMP441 is chosen.
+
+---
+
+## 9. Effort (focused pairing sessions)
+
+| | |
+|---|---|
+| A — INMP441 library content (2 footprints) | ~1 session (+ symbol/footprint authoring care) |
+| C1 extractor + corpus | 1–2 |
+| C2 registry (aliases/serves) | 0.5–1 |
+| C3 INMP441/MAX98357A cards + integration pin tests | 1 |
+| C4 resolver + Bus fields + `_op_import` wiring | 1–2 |
+| C5 resolved-but-unplaceable path | 0.5 |
+| C6 template split | 1 |
+| C7 board.yaml override | 1 |
+| C8 guardrail (test-first) | 0.5 |
+| C9 golden harness + INMP441 fixture | 0.5–1 |
+
+**MVP to a correct, honest board for the audio-node:** A + C3 + C6 (+ a one-line default-swap stopgap) ≈ 3 sessions. **Full layer:** ~8–10. Dependency order: C2 → C3 → C1 → C4 → (C5, C6) → C7 → C8 → C9; A in parallel.

--- a/docs/SPEC_Firmware_Part_Resolution.md
+++ b/docs/SPEC_Firmware_Part_Resolution.md
@@ -116,9 +116,9 @@ config.h text
 
 ### 5.2 Recognition registry = cards (single source of truth)
 
-Cards gain an optional **`aliases`** list and a **`serves`** field (the bus type the part attaches to — `I2S_IN`, `I2S_OUT`, `I2C`, `UART`). `cards.recognized_part_names()` returns the union of all card `type` values + aliases, each run through the existing `canonical_type()` normalizer (no second source; no drift). Validator extends to check `aliases` (list of str) and `serves` (known bus type).
+Cards gain an optional **`aliases`** list and a **`serves`** field (the directional bus type the part attaches to — `_SERVES_BUS_TYPES`: `I2S_IN`, `I2S_OUT`, `I2C`, `SPI`, `UART`). `cards.recognized_part_names()` returns `{raw_name: canonical_key}` — the RAW name (each card `type` + every alias, hyphen intact) is the dict KEY used to build the corpus regex; the `canonical_type()` form is only the VALUE used for card lookup. This IS the I1 contract: building the regex from canonical names would strip `ICS-43434`'s hyphen and never match the firmware text. Validator extends to check `aliases` (list of non-empty str) and `serves` (member of `_SERVES_BUS_TYPES`).
 
-**Tests** extend `test_device_cards.py`: alias validates; `recognized_part_names()` includes canonicalized type + aliases; parity check guards drift.
+**Tests** extend `test_device_cards.py`: alias/serves validate (accept/reject edges); `recognized_part_names()` maps raw type + aliases → canonical key (incl. the hyphenated `ICS-43434` I1 regression); a conflicting-alias claim across two cards raises.
 
 ### 5.3 Bus-part resolution (`bus_part_resolver.py`, new) — **binding by semantics, not proximity**
 

--- a/src/kicad_mcp/utils/firmware/cards.py
+++ b/src/kicad_mcp/utils/firmware/cards.py
@@ -38,6 +38,13 @@ _PROJECT_DIR = Path("firmware-devices")
 
 _BUSES = frozenset({"I2C", "SPI", "I2S", "UART", None})
 
+# What a card may declare it ``serves`` — the bus a part can be RESOLVED onto.
+# Deliberately FINER than ``_BUSES``: a bus is directional at resolution time
+# (``Bus.type`` is ``I2S_IN`` / ``I2S_OUT``), so a mic card serves ``I2S_IN`` and
+# an amp serves ``I2S_OUT``. Validating ``serves`` against ``_BUSES`` (which only
+# has the coarse ``"I2S"``) would let a card claim a bus it can never match.
+_SERVES_BUS_TYPES = frozenset({"I2C", "SPI", "I2S_IN", "I2S_OUT", "UART"})
+
 
 class CardError(ValueError):
     """A malformed card. Raised loudly at load — never silently skipped."""
@@ -138,8 +145,34 @@ def validate_peripheral_card(card: dict[str, Any]) -> list[str]:
         errs.append(f"{where}: roles must be a mapping role->pin")
     if not isinstance(card["module"], bool):
         errs.append(f"{where}: module must be a bool")
+    _validate_aliases(card.get("aliases"), where, errs)
+    _validate_serves(card.get("serves"), where, errs)
     _validate_config(card.get("config"), where, errs)
     return errs
+
+
+def _validate_aliases(aliases: Any, where: str, errs: list[str]) -> None:
+    """``aliases`` is optional; when present it must be a list of non-empty
+    strings (alternate part names the firmware might spell, e.g. SPH0645LM4H for
+    SPH0645). Each becomes a raw-name regex target in part resolution."""
+    if aliases is None:
+        return
+    if not isinstance(aliases, list) or not all(
+        isinstance(a, str) and a.strip() for a in aliases
+    ):
+        errs.append(f"{where}: aliases must be a list of non-empty strings")
+
+
+def _validate_serves(serves: Any, where: str, errs: list[str]) -> None:
+    """``serves`` is optional; when present it names the DIRECTIONAL bus this
+    part can be resolved onto (``_SERVES_BUS_TYPES``), matched against
+    ``Bus.type`` during part resolution."""
+    if serves is None:
+        return
+    if serves not in _SERVES_BUS_TYPES:
+        errs.append(
+            f"{where}: serves {serves!r} not in {sorted(_SERVES_BUS_TYPES)}"
+        )
 
 
 def validate_mcu_card(card: dict[str, Any]) -> list[str]:
@@ -173,6 +206,30 @@ def _card_dirs(extra_dirs: Optional[list[str]] = None) -> list[Path]:
         dirs.append(_PROJECT_DIR)
     dirs += [Path(p) for p in (extra_dirs or [])]
     return dirs
+
+
+def recognized_part_names(
+    peripherals: dict[str, dict[str, Any]]
+) -> dict[str, str]:
+    """Map every RAW part name a card answers to → its canonical lookup key.
+
+    The part-name extractor must match firmware text against the *raw* names
+    (``"INMP441"``, ``"ICS-43434"``, ``"SPH0645LM4H"``) — building the search
+    regex from canonical names would strip the hyphen in ``ICS-43434`` and never
+    match the source (blocker **I1**). So this returns ``raw -> canonical``: the
+    extractor compiles ``\\bRAW\\b`` patterns from the keys; the resolver then
+    looks the matched name's value up in the canonical-keyed ``peripherals`` dict.
+
+    Covers each card's ``type`` plus every ``aliases`` entry. Raw names collide
+    to the same canonical key by construction (``ICS-43434`` and ``ICS43434`` →
+    ``ICS43434``), so a firmware spelling either way resolves to one card.
+    """
+    out: dict[str, str] = {}
+    for card in peripherals.values():
+        canonical = canonical_type(str(card["type"]))
+        for raw in (str(card["type"]), *(card.get("aliases") or [])):
+            out[raw] = canonical
+    return out
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:

--- a/src/kicad_mcp/utils/firmware/cards.py
+++ b/src/kicad_mcp/utils/firmware/cards.py
@@ -11,6 +11,11 @@ This module is **pure data plumbing**: it imports nothing from ``knowledge.py``
 (avoids an import cycle) and returns plain dicts. ``knowledge.py`` casts those to
 its ``PeripheralInfo`` / ``McuInfo`` TypedDicts and exposes ``resolve_*``.
 
+For part-resolution it also exposes ``recognized_part_names()`` (raw part name →
+canonical lookup key) feeding the corpus scanner, and accepts two optional
+peripheral-card fields: ``aliases`` (alternate raw names) and ``serves`` (the
+directional bus a part resolves onto, ``_SERVES_BUS_TYPES``).
+
 Two validation tiers (the honesty backstop):
   * **structural** — here, no KiCad needed: required fields, types, strap math.
     Runs in the no-KiCad unit matrix.
@@ -228,6 +233,14 @@ def recognized_part_names(
     for card in peripherals.values():
         canonical = canonical_type(str(card["type"]))
         for raw in (str(card["type"]), *(card.get("aliases") or [])):
+            prior = out.get(raw)
+            if prior is not None and prior != canonical:
+                raise CardError(
+                    f"part name {raw!r} is claimed by two cards ({prior!r} and "
+                    f"{canonical!r}); a type/alias must map to exactly one card "
+                    "(load order is filesystem-dependent — silent last-write-wins "
+                    "would pick a card non-deterministically)"
+                )
             out[raw] = canonical
     return out
 

--- a/src/kicad_mcp/utils/firmware/part_extractor.py
+++ b/src/kicad_mcp/utils/firmware/part_extractor.py
@@ -119,8 +119,13 @@ def extract_part_names(
     hyphen in ``ICS-43434`` is preserved (blocker I1). Returns evidence sorted by
     kind strength (source > config_comment > doc), then file, then line.
     """
+    # Guard BOTH sides against a word char OR a hyphen, not just \b: a part name
+    # is a unit, so a hyphenated neighbour is a DIFFERENT part — "ICS-43434-PDM"
+    # and "PRE-INMP441" must NOT resolve to the bare "ICS-43434" / "INMP441" card.
+    # (Plain \b treats the inner hyphen as a boundary and would false-match those.)
     patterns = [
-        (raw, canon, re.compile(r"\b" + re.escape(raw) + r"\b", re.IGNORECASE))
+        (raw, canon,
+         re.compile(r"(?<![\w-])" + re.escape(raw) + r"(?![\w-])", re.IGNORECASE))
         for raw, canon in recognized_names.items()
     ]
     out: list[PartEvidence] = []
@@ -130,6 +135,8 @@ def extract_part_names(
                 if pat.search(line):
                     out.append(PartEvidence(
                         part_name=raw, canonical=canon, file=entry.file,
+                        # raw_text is DISPLAY-ONLY context; the match (part_name/
+                        # canonical/line) is complete, so this cap loses no data.
                         line=lineno, kind=entry.kind, raw_text=line.strip()[:200],
                     ))
     out.sort(key=lambda e: (_KIND_PRIORITY.get(e.kind, 9), e.file, e.line))

--- a/src/kicad_mcp/utils/firmware/part_extractor.py
+++ b/src/kicad_mcp/utils/firmware/part_extractor.py
@@ -1,0 +1,136 @@
+"""Part-name extraction from firmware — find which SPECIFIC part the user
+declared (``INMP441``, not a generic "I2S mic"), so the front end can resolve to
+it instead of inventing a substitute (the SPH0645 problem). C1 of the
+part-resolution feature; see ``docs/SPEC_Firmware_Part_Resolution.md``.
+
+Two pieces:
+  * ``collect_corpus`` — the I/O shell. Gathers searchable text: the PREPROCESSED
+    config.h (so a part named only in a dead ``#else`` branch stays invisible),
+    bounded sibling source files, and a few docs.
+  * ``extract_part_names`` — pure. Scans the corpus for the RAW recognized names
+    (``\\bICS-43434\\b``), never the canonical form (blocker I1: canonicalizing
+    first would strip the hyphen and never match the source).
+
+Data-capture rule: the source sweep is bounded, but a cap is never silent — the
+corpus carries ``truncated`` / ``files_scanned`` / ``files_errored`` so a caller
+can tell coverage was limited. Reads catch specific exceptions and count them.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from kicad_mcp.utils.firmware.parse import canonical_type
+
+# Evidence strength, low = strongest: a part named in compiled source outranks a
+# config comment, which outranks prose docs. Used to rank when a name appears in
+# several places (the resolver wants the most authoritative sighting first).
+_KIND_PRIORITY = {"source": 0, "config_comment": 1, "doc": 2}
+
+# Bounded source sweep (data-capture rule: a cap MUST be observable, never silent).
+_MAX_SOURCE_FILES = 200
+_SKIP_DIRS = frozenset({"build", ".pio", ".pio_libdeps", ".git", "node_modules",
+                        ".cache", "managed_components"})
+_SOURCE_SUFFIXES = frozenset({".cpp", ".c", ".cc", ".h", ".hpp", ".ino"})
+_DOC_NAMES_RE = re.compile(r"^(README|WIRING|HARDWARE|BOM|CLAUDE).*\.md$", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class CorpusEntry:
+    """One searchable blob: the preprocessed config text, a source file, or a doc."""
+    text: str
+    file: str          # source path, or "<config>" path for the preprocessed text
+    kind: str          # "source" | "config_comment" | "doc"
+
+
+@dataclass
+class FirmwareCorpus:
+    """The gathered text plus honest coverage accounting (data-capture rule)."""
+    entries: list[CorpusEntry] = field(default_factory=list)
+    files_scanned: int = 0      # source/doc files actually read
+    files_errored: int = 0      # files that failed to read (counted, not dropped silently)
+    truncated: bool = False     # hit _MAX_SOURCE_FILES — coverage was capped
+
+
+@dataclass(frozen=True)
+class PartEvidence:
+    """A single sighting of a recognized part name in the corpus."""
+    part_name: str     # the RAW name as matched (hyphen intact: "ICS-43434")
+    canonical: str     # canonical lookup key (the resolver fetches the card by this)
+    file: str
+    line: int          # 1-indexed
+    kind: str
+    raw_text: str      # the line it appeared on, trimmed (≤200 chars)
+
+
+def collect_corpus(config_path: str, config_text: str) -> FirmwareCorpus:
+    """Gather searchable firmware text rooted at ``config_path``'s directory.
+
+    ``config_text`` MUST be the preprocessed config.h (post
+    ``select_active_branches``) — a part named only in an inactive ``#else`` is
+    then correctly absent. Sibling ``*.cpp/.c/.h/.hpp/.ino`` and a few docs
+    (README/WIRING/HARDWARE/BOM/CLAUDE ``.md``) under the config's directory are
+    read from disk, skipping build/output trees, capped at ``_MAX_SOURCE_FILES``
+    with ``truncated`` set when the cap bites.
+    """
+    cfg = Path(config_path)
+    corpus = FirmwareCorpus(
+        entries=[CorpusEntry(text=config_text, file=str(cfg), kind="config_comment")]
+    )
+    root = cfg.resolve().parent
+    # Deterministic order so the cap (if hit) drops a stable tail, and evidence
+    # ordering is reproducible across runs.
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        if any(part in _SKIP_DIRS for part in path.relative_to(root).parts):
+            continue
+        is_source = path.suffix.lower() in _SOURCE_SUFFIXES
+        is_doc = bool(_DOC_NAMES_RE.match(path.name))
+        if not (is_source or is_doc):
+            continue
+        if path == cfg.resolve():
+            continue  # the config is already in as preprocessed config_comment text
+        if corpus.files_scanned >= _MAX_SOURCE_FILES:
+            corpus.truncated = True
+            break
+        try:
+            text = path.read_text(errors="replace")
+        except OSError:
+            corpus.files_errored += 1   # counted, never silently swallowed
+            continue
+        corpus.entries.append(
+            CorpusEntry(text=text, file=str(path),
+                        kind="source" if is_source else "doc")
+        )
+        corpus.files_scanned += 1
+    return corpus
+
+
+def extract_part_names(
+    corpus: FirmwareCorpus, recognized_names: dict[str, str]
+) -> list[PartEvidence]:
+    """Find every sighting of a recognized RAW part name in the corpus.
+
+    ``recognized_names`` maps RAW name → canonical key (from
+    ``cards.recognized_part_names``). Each raw name is matched whole-word and
+    case-insensitively, so ``INMP441`` matches but ``INMP4411`` does not, and the
+    hyphen in ``ICS-43434`` is preserved (blocker I1). Returns evidence sorted by
+    kind strength (source > config_comment > doc), then file, then line.
+    """
+    patterns = [
+        (raw, canon, re.compile(r"\b" + re.escape(raw) + r"\b", re.IGNORECASE))
+        for raw, canon in recognized_names.items()
+    ]
+    out: list[PartEvidence] = []
+    for entry in corpus.entries:
+        for lineno, line in enumerate(entry.text.splitlines(), 1):
+            for raw, canon, pat in patterns:
+                if pat.search(line):
+                    out.append(PartEvidence(
+                        part_name=raw, canonical=canon, file=entry.file,
+                        line=lineno, kind=entry.kind, raw_text=line.strip()[:200],
+                    ))
+    out.sort(key=lambda e: (_KIND_PRIORITY.get(e.kind, 9), e.file, e.line))
+    return out

--- a/tests/test_device_cards.py
+++ b/tests/test_device_cards.py
@@ -150,6 +150,18 @@ def test_recognized_part_names_maps_raw_to_canonical():
     assert names["SPH0645LM4H"] == "SPH0645"
 
 
+def test_recognized_part_names_conflicting_alias_raises():
+    # Two cards claiming the same name for different canonical keys is ambiguous
+    # (load order is filesystem-dependent) → loud error, not silent last-write-wins.
+    peripherals = {
+        "FOO": dict(_GOOD_PERIPHERAL, type="FOO", aliases=["SHARED"]),
+        "BAR": dict(_GOOD_PERIPHERAL, type="BAR", aliases=["SHARED"]),
+    }
+    with pytest.raises(CardError) as e:
+        recognized_part_names(peripherals)
+    assert "SHARED" in str(e.value)
+
+
 def test_recognized_part_names_hyphenated_raw_preserved_I1():
     # I1: the regex must match the RAW hyphenated name in firmware text, while
     # the canonical key (hyphen stripped) is what the resolver looks up. Both the

--- a/tests/test_device_cards.py
+++ b/tests/test_device_cards.py
@@ -17,6 +17,7 @@ from kicad_mcp.utils.firmware.cards import (
     CardError,
     compute_address_straps,
     load_cards,
+    recognized_part_names,
     validate_mcu_card,
     validate_peripheral_card,
 )
@@ -104,6 +105,63 @@ def test_address_strap_validation(strap, ok):
     card = dict(_GOOD_PERIPHERAL, config={"address_strap": strap})
     errs = validate_peripheral_card(card)
     assert (errs == []) is ok
+
+
+# --- aliases / serves (part-resolution registry fields) ----------------------
+
+@pytest.mark.parametrize("aliases,ok", [
+    (None, True),                       # optional — absent is fine
+    ([], True),                         # empty list is fine
+    (["SPH0645LM4H"], True),            # one alias
+    (["A", "B"], True),                 # several
+    ("SPH0645LM4H", False),             # a bare string is not a list
+    ([""], False),                      # empty-string alias
+    ([1], False),                       # non-string alias
+])
+def test_aliases_validation(aliases, ok):
+    card = dict(_GOOD_PERIPHERAL, aliases=aliases)
+    assert (validate_peripheral_card(card) == []) is ok
+
+
+@pytest.mark.parametrize("serves,ok", [
+    (None, True),                       # optional
+    ("I2C", True),
+    ("I2S_IN", True),                   # directional — the finer vocabulary
+    ("I2S_OUT", True),
+    ("I2S", False),                     # coarse bus name is NOT a valid serves
+    ("SDIO", False),                    # unknown
+])
+def test_serves_validation(serves, ok):
+    card = dict(_GOOD_PERIPHERAL, serves=serves)
+    assert (validate_peripheral_card(card) == []) is ok
+
+
+def test_recognized_part_names_maps_raw_to_canonical():
+    peripherals = {
+        "INMP441": dict(_GOOD_PERIPHERAL, type="INMP441"),
+        "SPH0645": dict(_GOOD_PERIPHERAL, type="SPH0645",
+                        aliases=["SPH0645LM4H"]),
+    }
+    names = recognized_part_names(peripherals)
+    # raw type names are present as keys, mapping to their canonical lookup key
+    assert names["INMP441"] == "INMP441"
+    assert names["SPH0645"] == "SPH0645"
+    # aliases are recognized too, mapping to the card's canonical key
+    assert names["SPH0645LM4H"] == "SPH0645"
+
+
+def test_recognized_part_names_hyphenated_raw_preserved_I1():
+    # I1: the regex must match the RAW hyphenated name in firmware text, while
+    # the canonical key (hyphen stripped) is what the resolver looks up. Both the
+    # hyphenated raw and its de-hyphenated alias must collide to one card key.
+    peripherals = {
+        "ICS43434": dict(_GOOD_PERIPHERAL, type="ICS-43434",
+                         aliases=["ICS43434"]),
+    }
+    names = recognized_part_names(peripherals)
+    assert "ICS-43434" in names                 # raw, hyphen intact for matching
+    assert names["ICS-43434"] == "ICS43434"      # canonical lookup key
+    assert names["ICS43434"] == "ICS43434"       # alias → same canonical key
 
 
 # --- packaged library loads + the migrated 6 entries are present --------------

--- a/tests/test_part_extractor.py
+++ b/tests/test_part_extractor.py
@@ -1,0 +1,138 @@
+"""Tests for the firmware part-name extractor (C1). No KiCad.
+
+Boundary-focused per CLAUDE.md: the whole-word regex is pinned at/below/above,
+the hyphenated ICS-43434 case is an I1 regression, and collect_corpus's bounded
+scan + overflow/error counters are exercised (data-capture rule — a cap is never
+silent).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_mcp.utils.firmware import part_extractor as pe
+from kicad_mcp.utils.firmware.part_extractor import (
+    CorpusEntry,
+    FirmwareCorpus,
+    collect_corpus,
+    extract_part_names,
+)
+
+# raw name -> canonical key, as cards.recognized_part_names() would return.
+_NAMES = {"INMP441": "INMP441", "ICS-43434": "ICS43434", "SPH0645LM4H": "SPH0645"}
+
+
+def _corpus(text: str, kind: str = "source", file: str = "x.cpp") -> FirmwareCorpus:
+    return FirmwareCorpus(entries=[CorpusEntry(text=text, file=file, kind=kind)])
+
+
+# --- whole-word matching: at / below / above the boundary --------------------
+
+@pytest.mark.parametrize("line,hits", [
+    ("#define MIC INMP441", ["INMP441"]),        # exact (at)
+    ("part is INMP4411 maybe", []),              # trailing word char (above) — no match
+    ("INMP44 short", []),                        # shorter (below) — no match
+    ("the inmp441 mic", ["INMP441"]),            # case-insensitive
+    ("// using ICS-43434 here", ["ICS-43434"]),  # hyphen preserved (I1)
+    ("XICS-43434", []),                          # leading word char — no boundary
+])
+def test_word_boundary(line, hits):
+    ev = extract_part_names(_corpus(line), _NAMES)
+    assert [e.part_name for e in ev] == hits
+
+
+def test_hyphenated_raw_maps_to_canonical_I1():
+    # I1: match the RAW hyphenated name in text, resolve via the canonical key.
+    ev = extract_part_names(_corpus("sensor: ICS-43434"), _NAMES)
+    assert ev[0].part_name == "ICS-43434"
+    assert ev[0].canonical == "ICS43434"
+
+
+def test_alias_maps_to_card_canonical():
+    ev = extract_part_names(_corpus('part = "SPH0645LM4H";'), _NAMES)
+    assert ev[0].part_name == "SPH0645LM4H"
+    assert ev[0].canonical == "SPH0645"
+
+
+def test_matches_in_comment_string_and_code():
+    text = "\n".join([
+        "#define MIC_DATA 41   // INMP441 data",   # inline comment
+        "// --- INMP441 wiring ---",               # standalone comment
+        'const char* part = "INMP441";',           # string literal
+    ])
+    ev = extract_part_names(_corpus(text), _NAMES)
+    assert len(ev) == 3
+    assert all(e.part_name == "INMP441" for e in ev)
+    assert [e.line for e in ev] == [1, 2, 3]
+
+
+def test_dead_branch_absent_when_preprocessed():
+    # The caller passes PREPROCESSED config text; a part only in the dropped
+    # #else branch is already gone, so it is correctly not found.
+    preprocessed = "#define MIC INMP441\n"   # the inactive #else SPH0645 line is stripped
+    ev = extract_part_names(_corpus(preprocessed, kind="config_comment"), _NAMES)
+    assert [e.part_name for e in ev] == ["INMP441"]
+
+
+def test_priority_source_beats_config_beats_doc():
+    corpus = FirmwareCorpus(entries=[
+        CorpusEntry("INMP441", "a.md", "doc"),
+        CorpusEntry("INMP441", "<config>", "config_comment"),
+        CorpusEntry("INMP441", "a.cpp", "source"),
+    ])
+    ev = extract_part_names(corpus, _NAMES)
+    assert [e.kind for e in ev] == ["source", "config_comment", "doc"]
+
+
+# --- collect_corpus: the bounded I/O sweep -----------------------------------
+
+def _write(p: Path, content: str = "x") -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content)
+
+
+def test_collect_corpus_scans_sources_and_docs_skips_build(tmp_path):
+    cfg = tmp_path / "config.h"
+    _write(cfg, "#define MIC INMP441\n")
+    _write(tmp_path / "main.cpp", "INMP441")
+    _write(tmp_path / "README.md", "uses INMP441")
+    _write(tmp_path / "build" / "junk.cpp", "INMP441")   # build tree → skipped
+    _write(tmp_path / "notes.txt", "INMP441")            # not source/doc → ignored
+    corpus = collect_corpus(str(cfg), cfg.read_text())
+    files = {Path(e.file).name for e in corpus.entries}
+    assert {"config.h", "main.cpp", "README.md"} <= files
+    assert "junk.cpp" not in files and "notes.txt" not in files
+    assert corpus.files_scanned == 2 and not corpus.truncated
+    cfg_entry = next(e for e in corpus.entries if Path(e.file).name == "config.h")
+    assert cfg_entry.kind == "config_comment"
+
+
+def test_collect_corpus_truncation_is_flagged(tmp_path, monkeypatch):
+    cfg = tmp_path / "config.h"
+    _write(cfg)
+    for i in range(5):
+        _write(tmp_path / f"f{i}.cpp", "INMP441")
+    monkeypatch.setattr(pe, "_MAX_SOURCE_FILES", 2)
+    corpus = collect_corpus(str(cfg), cfg.read_text())
+    assert corpus.truncated is True
+    assert corpus.files_scanned == 2
+
+
+def test_collect_corpus_counts_read_errors(tmp_path, monkeypatch):
+    cfg = tmp_path / "config.h"
+    _write(cfg)
+    _write(tmp_path / "ok.cpp", "INMP441")
+    _write(tmp_path / "bad.cpp", "INMP441")
+    orig = Path.read_text
+
+    def flaky(self, *a, **k):
+        if self.name == "bad.cpp":
+            raise OSError("simulated unreadable file")
+        return orig(self, *a, **k)
+
+    monkeypatch.setattr(Path, "read_text", flaky)
+    corpus = collect_corpus(str(cfg), "preprocessed config text")
+    assert corpus.files_errored == 1
+    names = {Path(e.file).name for e in corpus.entries}
+    assert "ok.cpp" in names and "bad.cpp" not in names

--- a/tests/test_part_extractor.py
+++ b/tests/test_part_extractor.py
@@ -36,10 +36,29 @@ def _corpus(text: str, kind: str = "source", file: str = "x.cpp") -> FirmwareCor
     ("the inmp441 mic", ["INMP441"]),            # case-insensitive
     ("// using ICS-43434 here", ["ICS-43434"]),  # hyphen preserved (I1)
     ("XICS-43434", []),                          # leading word char — no boundary
+    ("ICS-43434-PDM variant", []),               # trailing hyphen → different part
+    ("PRE-INMP441", []),                         # leading hyphen → different part
 ])
 def test_word_boundary(line, hits):
     ev = extract_part_names(_corpus(line), _NAMES)
     assert [e.part_name for e in ev] == hits
+
+
+@pytest.mark.parametrize("corpus", [
+    FirmwareCorpus(entries=[]),                          # empty corpus
+    FirmwareCorpus(entries=[CorpusEntry("INMP441", "x", "source")]),
+])
+def test_extract_empty_recognized_names_is_empty(corpus):
+    # no recognized names → nothing to find, regardless of corpus content
+    assert extract_part_names(corpus, {}) == []
+
+
+def test_extract_prefix_name_not_overmatched():
+    # SPH0645 is a prefix of SPH0645LM4H; text has only the longer form. The
+    # shorter name must NOT match the longer token (lookahead rejects trailing \w).
+    names = {"SPH0645": "SPH0645", "SPH0645LM4H": "SPH0645LM4H"}
+    ev = extract_part_names(_corpus("part SPH0645LM4H here"), names)
+    assert [e.part_name for e in ev] == ["SPH0645LM4H"]
 
 
 def test_hyphenated_raw_maps_to_canonical_I1():


### PR DESCRIPTION
First two steps of firmware part-resolution: stop the front end inventing parts (substituting SPH0645 for the user's actual INMP441). **Dormant infrastructure** — additive, changes no existing behavior; the extractor isn't wired into the pipeline yet and the new card fields are optional. The wiring (C4 resolver), gap emission (C5), template split (C6), board.yaml override (C7), and the golden fixture (C9) are follow-ups; INMP441 symbol authoring (workstream A) is the one item awaiting a datasheet call. See `docs/SPEC_Firmware_Part_Resolution.md` + `docs/PLAN_Firmware_Part_Resolution.md`.

## C2 — registry (cards.py)
- Optional card fields `serves` (directional bus: I2C/SPI/I2S_IN/I2S_OUT/UART — finer than the coarse `bus`) and `aliases`, both validated.
- `recognized_part_names() -> {raw_name: canonical_key}` — the **I1 fix**: match firmware text against RAW names (`\bICS-43434\b`, hyphen intact), use the canonical form only as the card-lookup key. Raises on a conflicting alias claim (no nondeterministic last-write-wins).

## C1 — part-name extractor (part_extractor.py, new)
- `collect_corpus` (preprocessed config + bounded sibling source/docs; data-capture-safe: file-cap overflow flag + read-error counter, never silent).
- `extract_part_names` — whole-word, case-insensitive, hyphen-preserving raw-name match; evidence ranked source > config_comment > doc.

## Tests
Boundary-focused: word-boundary at/below/above, hyphenated I1 regression, alias→canonical, conflicting-alias-raises, dead-#else-absence, corpus truncation/error counters, priority ordering. Full no-KiCad suite green, mypy clean. (No integration tests yet — C1/C2 are no-KiCad and not wired into the pipeline; integration lands with C9.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)