### PR TITLE
feat(firmware): part-resolution — resolve declared parts, refuse silent substitution

### DIFF
--- a/docs/PLAN_Firmware_Part_Resolution.md
+++ b/docs/PLAN_Firmware_Part_Resolution.md
@@ -42,3 +42,34 @@ returns `dict[str, str]` mapping `raw_name → canonical_key` (covers `type` + e
 
 ## Build order
 C8 (xfail) → C2 registry (+I1 fix) → C1 extractor → C4 resolver → C5 gap → C6 templates → C7 sidecar → C9 golden. All but A are no-symbol-needed.
+
+## STATUS (this session) — C1–C9 software arc DONE, gated on real KiCad
+Branch `feat/firmware-part-resolution-2`. Done + green (no-KiCad 2042, integration
+23/23 on KiCad 9 & 10):
+- **C1** part-name extractor, **C2** registry (serves/aliases/recognized_part_names),
+  **C2b** MAX98357A + SPH0645 cards — on `main` (PR #66) / this branch.
+- **C4** Bus schema + pure resolver + part_serves_map; **C4-wire** runs it in
+  import_firmware (reports `resolved_parts`).
+- **C6** templates consume resolved_part (imported / assumed+gap / refuse-with-
+  part_unavailable) — resolution is now LOAD-BEARING.
+- **C7** board.yaml `bus_part_overrides` (user declares a bus's part, provenance
+  "user", wins over corpus).
+- **C8** part-identity guardrail (no silent substitution).
+- **C9** golden gate on audio_s3 (MAX98357A imported via corpus; unnamed mic =
+  disclosed assumed_part); expand_templates surfaces open gaps.
+
+Demonstrated: the audio firmware NAMES MAX98357A → both amp buses bind it from the
+corpus (not invented); the unnamed mic is a disclosed SPH0645 assumption.
+
+### DEFERRED (blocked or future)
+- **INMP441 symbol + card (workstream A)** — BLOCKED on datasheet (pin names incl.
+  CHIPEN-must-not-float; bare-LGA vs module footprint). Until then an INMP441
+  mention resolves to a `part_unavailable` gap (refuse-to-substitute, unit-covered)
+  rather than a placed part. The `audio_inmp441` C9 fixture lands with it.
+- **C5 generate-level part_unavailable** (symbol-absent-at-generate gap) — not
+  needed by any current path: shipped cards all have symbols, and a declared part
+  with no realizing template is already refused by C6's _decide_part BEFORE
+  placement. It becomes a useful safety net when a card exists whose symbol is
+  absent in a given KiCad install (e.g. the INMP441 card pre-symbol). Add then.
+- **C7 footprint-only override** parsed/validated but not applied (the INMP441
+  bare-LGA-vs-module case, blocked on the symbol).

--- a/docs/PLAN_Firmware_Part_Resolution.md
+++ b/docs/PLAN_Firmware_Part_Resolution.md
@@ -73,3 +73,22 @@ corpus (not invented); the unnamed mic is a disclosed SPH0645 assumption.
   absent in a given KiCad install (e.g. the INMP441 card pre-symbol). Add then.
 - **C7 footprint-only override** parsed/validated but not applied (the INMP441
   bare-LGA-vs-module case, blocked on the symbol).
+
+## UPDATE — INMP441 handled as a feature test case (not a production part)
+INMP441 is EOL (TDK discontinued it; absent from the KiCad lib — that's why it
+wasn't there). Rather than author a bare-LGA symbol for a dead part, it's used as
+a TEST CASE that exercises the feature's handling of a declared-but-unbuildable
+part: `inmp441.yaml` recognition card (module-header form) → firmware naming
+INMP441 resolves it → `i2s_mic` REFUSES to substitute SPH0645 (`part_unavailable`)
+→ board.yaml `bus_part_overrides` substitutes a current replacement (provenance
+"user"). Covered by `test_part_resolution_inmp441.py`; card validates on KiCad 9 & 10.
+
+**Real-board replacement (for mr-esp32, a SEPARATE effort):** the sensible
+still-made I2S MEMS mics in the KiCad lib are **SPH0645LM4H** (Knowles/Syntiant —
+already the template default + carded, so it just works) or **ICS-43434** (TDK,
+closest INMP441 spec-twin, needs a trivial card). PDM mics (Infineon IM69, Knowles
+SPH0641) are NOT drop-ins (different interface).
+
+Still deferred (genuinely optional): generalizing `i2s_mic` to place ANY resolved
+card's part (so an on-board INMP441/ICS-43434 module is placed, not refused);
+C5 generate-level symbol-absent gap; C7 footprint-only override application.

--- a/src/kicad_mcp/tools/design.py
+++ b/src/kicad_mcp/tools/design.py
@@ -32,14 +32,25 @@ import yaml
 from fastmcp import FastMCP
 
 from kicad_mcp.utils.firmware.autodraft import draft_card, extract_whoami
+from kicad_mcp.utils.firmware.bus_part_resolver import resolve_bus_parts
+from kicad_mcp.utils.firmware.cards import (
+    load_cards,
+    part_serves_map,
+    recognized_part_names,
+)
 from kicad_mcp.utils.firmware.generate import generate_schematic as _generate
 from kicad_mcp.utils.firmware.intent import (
     DesignIntent,
+    Gap,
     build_intent,
     candidate_devices,
     find_board_id,
     load_intent,
     save_intent,
+)
+from kicad_mcp.utils.firmware.part_extractor import (
+    collect_corpus,
+    extract_part_names,
 )
 from kicad_mcp.utils.firmware.knowledge import resolve_peripheral
 from kicad_mcp.utils.firmware.sidecar import (
@@ -180,6 +191,22 @@ def _op_import(*, firmware_path: Optional[str], out_path: Optional[str]) -> dict
                     "message": f"Malformed {sidecar_path}: {e}"}
         sidecar_applied = sidecar_path
 
+    # Part resolution (C4): bind each bus to the SPECIFIC part the firmware NAMES
+    # (in the preprocessed config text + sibling source/docs), never invent. Runs
+    # after the sidecar so a board.yaml override (provenance "user") is honored.
+    # An ambiguous bus (>1 candidate) is disclosed as a gap, never auto-picked.
+    peripherals, _ = load_cards()
+    corpus = collect_corpus(str(cfg), text)
+    evidence = extract_part_names(corpus, recognized_part_names(peripherals))
+    for r in resolve_bus_parts(intent.buses, evidence, part_serves_map(peripherals)):
+        if r.reason == "ambiguous":
+            intent.gaps.append(Gap(
+                "part_ambiguous",
+                f"Bus {r.bus!r} ({r.type}) names multiple candidate parts "
+                f"{r.candidates} in the firmware — not auto-bound (no silent pick). "
+                f"Disambiguate with a board.yaml bus_part_overrides entry.",
+            ))
+
     # Nudge (don't assume): list commonly-field-wired buses with no locus set.
     advise_unspecified_placement(intent)
 
@@ -200,6 +227,12 @@ def _op_import(*, firmware_path: Optional[str], out_path: Optional[str]) -> dict
         "sidecar": sidecar_applied,
         "board_size_mm": intent.source.get("board_size_mm"),
         "power_source": intent.source.get("power_source"),
+        # Which bus bound to which SPECIFIC part, and from where — so the caller
+        # sees the resolver isn't inventing (the SPH0645-for-INMP441 fix).
+        "resolved_parts": {
+            b.name: {"part": b.resolved_part, "via": b.part_provenance}
+            for b in intent.buses if b.resolved_part
+        },
     }
 
 

--- a/src/kicad_mcp/tools/design.py
+++ b/src/kicad_mcp/tools/design.py
@@ -273,6 +273,9 @@ def _op_expand(*, intent_path: Optional[str], out_path: Optional[str]) -> dict:
         "status": "ok", "intent_path": str(dest),
         "components_added": len(intent.peripherals) - n_comp_before,
         "gaps_resolved": [g.kind for g in intent.gaps if g.resolved],
+        # Open gaps the expansion surfaced (e.g. assumed_part / part_unavailable
+        # from part resolution) — disclosure is worthless if the op hides it.
+        "gaps": _gaps_list(intent),
         "summary": _summary(intent),
     }
 

--- a/src/kicad_mcp/utils/firmware/bus_part_resolver.py
+++ b/src/kicad_mcp/utils/firmware/bus_part_resolver.py
@@ -1,0 +1,65 @@
+"""Bus → part resolution (C4): determine which SPECIFIC part the user declared for
+each bus, FROM the firmware corpus — never invent. Pure: no card loading, no I/O.
+
+The rule (no proximity heuristics, no guessing): a recognized part is a CANDIDATE
+for a bus iff it appears in the corpus AND the bus type matches what its card
+``serves``. Exactly one candidate → resolve it (provenance ``corpus``); more than
+one → ambiguous, leave unresolved and let the caller disclose it (NEVER silently
+pick); zero → unresolved. Whatever a bus resolves to is the user's declared part;
+a template that can't realize it falls back with a disclosed gap (C5/C6), it does
+not substitute silently (the SPH0645-for-INMP441 bug this feature exists to kill).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from kicad_mcp.utils.firmware.intent import Bus
+from kicad_mcp.utils.firmware.part_extractor import PartEvidence
+
+
+@dataclass(frozen=True)
+class BusResolution:
+    """One bus's resolution outcome (for the caller to log / emit gaps from)."""
+    bus: str
+    type: str
+    resolved_part: Optional[str]            # canonical key, or None
+    candidates: list[str] = field(default_factory=list)  # all corpus parts serving this type
+    reason: str = "none"                    # "resolved" | "ambiguous" | "none"
+
+
+def resolve_bus_parts(
+    buses: list[Bus],
+    part_evidence: list[PartEvidence],
+    serves_by_part: dict[str, str],
+) -> list[BusResolution]:
+    """Set ``resolved_part`` / ``part_provenance`` on each bus from the corpus, and
+    return a per-bus :class:`BusResolution` (so the caller can gap the ambiguous
+    ones). ``serves_by_part`` maps canonical part → the bus type it serves (from
+    ``cards.part_serves_map``); ``part_evidence`` is the extractor's output.
+
+    A user-supplied resolution (``part_provenance == "user"``, set by a board.yaml
+    override before this runs) is left UNTOUCHED — the human's choice wins.
+    """
+    corpus_parts = {ev.canonical for ev in part_evidence}
+    out: list[BusResolution] = []
+    for bus in buses:
+        if bus.part_provenance == "user":      # explicit override already set — honor it
+            out.append(BusResolution(bus.name, bus.type, bus.resolved_part,
+                                     [bus.resolved_part] if bus.resolved_part else [],
+                                     "user"))
+            continue
+        candidates = sorted(
+            p for p in corpus_parts if serves_by_part.get(p) == bus.type
+        )
+        if len(candidates) == 1:
+            bus.resolved_part = candidates[0]
+            bus.part_provenance = "corpus"
+            out.append(BusResolution(bus.name, bus.type, candidates[0],
+                                     candidates, "resolved"))
+        else:
+            # 0 → no evidence; >1 → ambiguous (NEVER pick one silently). Both leave
+            # the bus unresolved; >1 is gap-worthy so the caller can surface it.
+            out.append(BusResolution(bus.name, bus.type, None, candidates,
+                                     "ambiguous" if candidates else "none"))
+    return out

--- a/src/kicad_mcp/utils/firmware/cards.py
+++ b/src/kicad_mcp/utils/firmware/cards.py
@@ -245,6 +245,17 @@ def recognized_part_names(
     return out
 
 
+def part_serves_map(
+    peripherals: dict[str, dict[str, Any]]
+) -> dict[str, str]:
+    """Map canonical part key → the directional bus type its card declares it
+    ``serves`` (cards without ``serves`` are omitted). Feeds the bus→part
+    resolver (C4): a recognized part is a candidate for a bus iff its ``serves``
+    matches the bus's ``type``. ``peripherals`` is already canonical-keyed."""
+    return {key: card["serves"]
+            for key, card in peripherals.items() if card.get("serves")}
+
+
 def _load_yaml(path: Path) -> dict[str, Any]:
     try:
         data = yaml.safe_load(path.read_text())

--- a/src/kicad_mcp/utils/firmware/devices/peripherals/inmp441.yaml
+++ b/src/kicad_mcp/utils/firmware/devices/peripherals/inmp441.yaml
@@ -1,0 +1,26 @@
+# INMP441 I2S MEMS microphone — EOL (TDK discontinued; absent from the KiCad lib,
+# which is WHY it can't be placed). Carried as a 6-pin breakout-MODULE header
+# (like the MPU6050/OLED cards) PURELY so the part resolver RECOGNIZES it: a
+# firmware "INMP441" mention resolves to this card, the i2s_mic template (which
+# builds SPH0645) then REFUSES to substitute and emits a part_unavailable gap, and
+# the user picks a current replacement via a board.yaml bus_part_overrides entry
+# (e.g. {part: SPH0645} or {part: ICS-43434}). It exercises the part-resolution
+# feature on a real EOL part; it is not placed unless i2s_mic is later generalized
+# to card-driven mics.
+#
+# Header pin order is the common single-row GY-INMP441 layout (1=L/R 2=WS 3=SCK
+# 4=SD 5=VDD 6=GND) — variant-specific, confirm against the actual module before
+# ever placing it.
+type: INMP441
+aliases: ["INMP441ACEZ", "GY-INMP441"]
+lib_id: Connector_Generic:Conn_01x06
+value: INMP441 (module)
+bus: I2S
+serves: I2S_IN
+footprint: Connector_PinHeader_2.54mm:PinHeader_1x06_P2.54mm_Vertical
+module: true
+roles: {SCK: "3", SD: "4", WS: "2"}
+supply_pins: ["5"]
+ground_pins: ["6"]
+config:
+  static_ties: [{pin: "1", rail: GND}]   # L/R low = left channel

--- a/src/kicad_mcp/utils/firmware/devices/peripherals/max98357a.yaml
+++ b/src/kicad_mcp/utils/firmware/devices/peripherals/max98357a.yaml
@@ -1,0 +1,14 @@
+# MAX98357A I2S class-D mono amplifier (the audio-node output stage). Formalizes
+# the knowledge.py MAX98357A constant; pins verified vs the audio-node ground
+# truth. `serves: I2S_OUT` lets the part resolver bind it when the firmware names
+# it (the audio config names "MAX98357A" in a bus comment).
+type: MAX98357A
+lib_id: Audio:MAX98357A
+value: MAX98357A
+bus: I2S
+serves: I2S_OUT
+footprint: Package_DFN_QFN:HVQFN-16-1EP_3x3mm_P0.5mm_EP1.5x1.5mm
+roles: {DIN: DIN, BCLK: BCLK, LRCLK: LRCLK, SD_MODE: "~{SD_MODE}", OUTP: OUTP, OUTN: OUTN}
+supply_pins: ["7", "8"]
+ground_pins: ["3", "11", "15", "17"]   # GND pins + EP pad 17
+module: false

--- a/src/kicad_mcp/utils/firmware/devices/peripherals/sph0645.yaml
+++ b/src/kicad_mcp/utils/firmware/devices/peripherals/sph0645.yaml
@@ -1,0 +1,17 @@
+# SPH0645LM4H I2S MEMS microphone. Formalizes the knowledge.py SPH0645 constant.
+# `serves: I2S_IN` lets the resolver bind it when the firmware names it; the
+# `SPH0645LM4H` alias covers the full datasheet spelling. (The audio-node mic is
+# actually an INMP441 — once that symbol exists and is named, the resolver binds
+# INMP441 instead; until then an INMP441 mention resolves to a part_unavailable
+# gap rather than silently substituting this part.)
+type: SPH0645
+aliases: ["SPH0645LM4H"]
+lib_id: Sensor_Audio:SPH0645LM4H
+value: SPH0645LM4H
+bus: I2S
+serves: I2S_IN
+footprint: Sensor_Audio:Knowles_SPH0645LM4H-6_3.5x2.65mm
+roles: {WS: WS, BCLK: BCLK, DATA: DATA, SEL: SEL}
+supply_pins: ["VDD"]
+ground_pins: ["GND"]
+module: false

--- a/src/kicad_mcp/utils/firmware/intent.py
+++ b/src/kicad_mcp/utils/firmware/intent.py
@@ -26,7 +26,7 @@ from kicad_mcp.utils.firmware.parse import (
     address_base,
 )
 
-SCHEMA_VERSION = 5  # v5: per-ref PCB placement_hints (edge/rotation/fixed override channel)
+SCHEMA_VERSION = 6  # v6: Bus part resolution (resolved_part/part_provenance/part_is_assumption)
 
 # Gap categories firmware is structurally blind to — always emitted so the doc
 # is honest about what a human/LLM must still supply.
@@ -129,6 +129,15 @@ class Bus:
     signals: dict[str, int] = field(default_factory=dict)  # role -> gpio
     address: Optional[int] = None   # I2C devices
     origin: str = "imported"
+    # Part resolution (C4): the SPECIFIC part the user declared for this bus,
+    # determined from the firmware corpus — NEVER invented. ``resolved_part`` is a
+    # canonical key (e.g. "INMP441"); None = unresolved (no/ambiguous evidence).
+    # ``part_provenance``: "corpus" (found in firmware) | "user" (board.yaml).
+    # ``part_is_assumption``: set True only when a template falls back to a default
+    # part because the resolved one is absent (then a gap discloses it).
+    resolved_part: Optional[str] = None
+    part_provenance: Optional[str] = None
+    part_is_assumption: bool = False
 
 
 @dataclass

--- a/src/kicad_mcp/utils/firmware/sidecar.py
+++ b/src/kicad_mcp/utils/firmware/sidecar.py
@@ -103,6 +103,10 @@ class BoardSidecar:
     # the pipeline default (4 × M3). Defaults are resolved in pcb_pipeline, not
     # here — this layer only validates + carries the user's overrides.
     mounting_holes: Optional[dict[str, Any]] = None
+    # part-resolution overrides, keyed by bus stem (e.g. CMCA_MIC): the user
+    # DECLARES the bus's part {part: "INMP441"} when firmware doesn't name it (or
+    # to correct an assumption/ambiguity). Provenance "user" — wins over corpus.
+    bus_part_overrides: dict[str, dict[str, Any]] = field(default_factory=dict)
 
 
 # Top-level board.yaml keys. An unknown key is a loud error (catches a typo like
@@ -111,8 +115,10 @@ class BoardSidecar:
 # in load_sidecar — test_known_keys_all_accepted guards that all three agree.
 _KNOWN_SIDECAR_KEYS = frozenset({
     "power_source", "board_size_mm", "extra_connectors",
-    "placement", "placement_hints", "mounting_holes",
+    "placement", "placement_hints", "mounting_holes", "bus_part_overrides",
 })
+
+_KNOWN_BUS_OVERRIDE_KEYS = frozenset({"part", "footprint"})
 
 _KNOWN_MOUNTING_HOLES_KEYS = frozenset({"count", "drill_mm", "inset_mm", "keepout_mm"})
 
@@ -237,7 +243,36 @@ def _validate(d: dict[str, Any]) -> list[str]:
     _validate_placement(d, errs)
     _validate_hints(d, errs)
     _validate_mounting_holes(d, errs)
+    _validate_bus_part_overrides(d, errs)
     return errs
+
+
+def _validate_bus_part_overrides(d: dict[str, Any], errs: list[str]) -> None:
+    """``bus_part_overrides`` is optional: a mapping of bus stem → ``{part?,
+    footprint?}`` (both strings). Whether ``part`` names a recognized device is
+    NOT checked here (that needs the card registry); an unrealizable part surfaces
+    as a ``part_unavailable`` gap at realization — consistent with the honest-gap
+    model, not a silent drop."""
+    ov = d.get("bus_part_overrides")
+    if ov is None:
+        return
+    if not isinstance(ov, dict):
+        errs.append("bus_part_overrides must be a mapping of bus-stem -> {part?, footprint?}")
+        return
+    for stem, spec in ov.items():
+        where = f"bus_part_overrides[{stem!r}]"
+        if not isinstance(spec, dict):
+            errs.append(f"{where}: must be a mapping")
+            continue
+        unknown = set(spec) - _KNOWN_BUS_OVERRIDE_KEYS
+        if unknown:
+            errs.append(f"{where}: unknown key(s) {sorted(unknown)} — "
+                        f"valid: {sorted(_KNOWN_BUS_OVERRIDE_KEYS)}")
+        if not spec:
+            errs.append(f"{where}: empty — give a part and/or footprint")
+        for k in ("part", "footprint"):
+            if k in spec and not (isinstance(spec[k], str) and spec[k].strip()):
+                errs.append(f"{where}: {k} must be a non-empty string")
 
 
 def load_sidecar(path: str) -> BoardSidecar:
@@ -261,6 +296,7 @@ def load_sidecar(path: str) -> BoardSidecar:
         placement_hints=dict(data.get("placement_hints", {}) or {}),
         mounting_holes=(dict(data["mounting_holes"])
                         if data.get("mounting_holes") is not None else None),
+        bus_part_overrides=dict(data.get("bus_part_overrides", {}) or {}),
     )
 
 
@@ -344,6 +380,24 @@ def apply_sidecar(
     # Stored raw; normalized + warned-on at build time (build_pcb_from_schematic).
     for ref, hint in sidecar.placement_hints.items():
         intent.placement_hints[ref] = dict(hint)
+
+    # Part overrides (C7): the user DECLARES a bus's part. Stamps provenance
+    # "user" so the resolver (which runs after this) leaves it untouched. Applied
+    # before resolution, so the human's choice wins over corpus evidence. A stem
+    # matching no bus is surfaced as a gap, never silently ignored.
+    bus_by_name = {b.name: b for b in intent.buses}
+    for stem, spec in sidecar.bus_part_overrides.items():
+        bus = bus_by_name.get(stem)
+        if bus is None:
+            intent.gaps.append(Gap(
+                "bus_part_override_unknown",
+                f"board.yaml bus_part_overrides key {stem!r} matches no bus "
+                f"{sorted(bus_by_name)}; ignored."))
+            continue
+        if spec.get("part"):
+            bus.resolved_part = str(spec["part"])
+            bus.part_provenance = "user"
+            bus.part_is_assumption = False
 
     return intent
 

--- a/src/kicad_mcp/utils/firmware/templates.py
+++ b/src/kicad_mcp/utils/firmware/templates.py
@@ -27,6 +27,7 @@ from kicad_mcp.utils.firmware.connectors import (
     synthesize_connector,
 )
 from kicad_mcp.utils.firmware.intent import (
+    Bus,
     ConnectorLegend,
     DesignIntent,
     Endpoint,
@@ -381,6 +382,42 @@ def _header(alloc: RefAllocator, hdr: tuple[str, str], value: str) -> Peripheral
                       footprint=hdr[1], origin="template")
 
 
+def _decide_part(bus: Bus, template_part: str, ex: Expansion) -> tuple[bool, str]:
+    """Part-resolution decision (C6) for a bus whose on-board template builds
+    ``template_part``. Returns ``(place, origin)`` and stamps the bus + emits the
+    honest gap. The three cases — the whole point of part resolution:
+
+      * ``resolved_part is None`` — firmware named no part for this bus → ASSUME
+        ``template_part`` (place it, origin ``template``, ``part_is_assumption``),
+        disclosed by an ``assumed_part`` gap.
+      * ``resolved_part == template_part`` — firmware named exactly this part →
+        place it as ``imported`` (provenance already ``corpus``/``user``).
+      * ``resolved_part != template_part`` — firmware declares a DIFFERENT part
+        this template can't build → DO NOT substitute ``template_part``; leave the
+        bus unrealized and disclose a ``part_unavailable`` gap. (This is the
+        SPH0645-for-INMP441 bug, refused.)
+    """
+    rp = bus.resolved_part
+    if rp is None:
+        bus.resolved_part = template_part
+        bus.part_provenance = "assumed"
+        bus.part_is_assumption = True
+        ex.gaps.append(Gap(
+            "assumed_part",
+            f"Bus {bus.name!r} ({bus.type}): firmware names no specific part; "
+            f"assumed {template_part}. Set a board.yaml bus_part_overrides entry "
+            f"if the real part differs."))
+        return True, "template"
+    if rp == template_part:
+        return True, "imported"
+    ex.gaps.append(Gap(
+        "part_unavailable",
+        f"Bus {bus.name!r} ({bus.type}): firmware declares {rp}, but no template "
+        f"or symbol realizes it yet — NOT substituting {template_part}. The bus is "
+        f"left unrealized until {rp} ships (add its device card + symbol)."))
+    return False, ""
+
+
 def i2s_output_amps(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
     """Each I2S-output bus -> a stereo MAX98357A pair (L/R) with shared BCLK/LRC,
     per-channel DIN via 1kΩ isolators, SD_MODE channel straps (L→GND, R→+3V3),
@@ -403,6 +440,9 @@ def i2s_output_amps(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
         din_g = bus.signals.get("DIN")
         if bclk_g is None or lrc_g is None or din_g is None:
             continue
+        place, amp_origin = _decide_part(bus, "MAX98357A", ex)
+        if not place:
+            continue   # firmware declares a different amp we can't realize (gapped)
         pl = intent.placements.get(bus.name)
         spk_type = ("screw_terminal"
                     if pl is not None and pl.locus == "on_board_with_remote_io"
@@ -414,7 +454,7 @@ def i2s_output_amps(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
                      (d_net, Endpoint(ref=mcu, gpio=din_g))]
         for side, sd_rail in (("L", "GND"), ("R", "+3V3")):
             amp = Peripheral(ref=alloc.next("U"), type="MAX98357A", lib_id=M["lib_id"],
-                             value="MAX98357A", footprint=M["footprint"], origin="template")
+                             value="MAX98357A", footprint=M["footprint"], origin=amp_origin)
             ex.components.append(amp)
             for p in K.MAX98357A_VDD_PINS:
                 ex.power.append(("+3V3", Endpoint(ref=amp.ref, pin=p)))
@@ -478,8 +518,11 @@ def i2s_mic(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
         if pl is not None and pl.locus == "remote":
             _emit_remote_mic(ex, alloc, mcu, bclk_g, ws_g, sd_g, pl)
             continue
+        place, mic_origin = _decide_part(bus, "SPH0645", ex)
+        if not place:
+            continue   # firmware declares a different mic we can't realize (gapped)
         mic = Peripheral(ref=alloc.next("MK"), type="SPH0645", lib_id=S["lib_id"],
-                         value="SPH0645LM4H", footprint=S["footprint"], origin="template")
+                         value="SPH0645LM4H", footprint=S["footprint"], origin=mic_origin)
         c = _cap(alloc, "100nF", K.FP_C_BYPASS)
         ex.components += [mic, c]
         ex.power += [("+3V3", Endpoint(ref=mic.ref, pin=S["vdd"])),

--- a/tests/fixtures/firmware/audio_inmp441/config.h
+++ b/tests/fixtures/firmware/audio_inmp441/config.h
@@ -1,0 +1,34 @@
+#pragma once
+// Part-resolution test fixture: the audio-node config (identical pins to
+// audio_s3) whose I2S microphone bus NAMES its part in a comment. The ONLY part
+// named here is the mic itself — naming any other part in a comment would (
+// correctly) feed the resolver too. See test_part_resolution_inmp441.py for what
+// this exercises.
+
+#if CONFIG_IDF_TARGET_ESP32S3
+// --- I2S output bus 0 (stereo amp pair) ---
+#define CMCA_I2S_BCLK         15
+#define CMCA_I2S_LRC          16
+#define CMCA_I2S_DIN          17
+#define CMCA_I2S_SAMPLE_RATE  22050   // config, NOT a pin (seam guard)
+// --- I2S output bus 1 ---
+#define CMCA_I2S2_BCLK        35
+#define CMCA_I2S2_LRC         36
+#define CMCA_I2S2_DIN         37
+// --- I2C OLED ---
+#define CMCA_OLED_SDA         47
+#define CMCA_OLED_SCL         48
+#define CMCA_OLED_ADDR        0x3C
+// --- UART presence sensor (LD2410) ---
+#define CMCA_PRESENCE_RX_PIN  18
+#define CMCA_PRESENCE_TX_PIN  21
+// --- I2S microphone: INMP441 ---
+#define CMCA_MIC_BCLK         8
+#define CMCA_MIC_WS           9
+#define CMCA_MIC_SD           10
+#else
+// legacy WROOM-32 prototype block (must be dropped by #if selection)
+#define CMCA_I2S_BCLK         26
+#define CMCA_I2S_LRC          25
+#define CMCA_I2S_DIN          27
+#endif

--- a/tests/fixtures/firmware/audio_inmp441/platformio.ini
+++ b/tests/fixtures/firmware/audio_inmp441/platformio.ini
@@ -1,0 +1,12 @@
+; Fixture platformio.ini for the S3 audio harness. Two envs (a legacy esp32dev
+; first, then the production S3) — exercises the multi-board= "prefer last known"
+; detection.
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino
+
+[env:esp32-s3]
+platform = espressif32
+board = esp32-s3-devkitc-1
+framework = arduino

--- a/tests/integration/test_firmware_pcb_pipeline.py
+++ b/tests/integration/test_firmware_pcb_pipeline.py
@@ -351,8 +351,21 @@ def test_audio_s3_to_routed_pcb(mcp_server, tmp_path):
     assert r1["board"] == "esp32-s3-devkitc-1"          # multi-board= prefers S3
     assert r1["summary"]["mcu"] == "ESP32-S3-WROOM-1"
 
+    # Part resolution (C4-C7): the firmware NAMES MAX98357A in a bus comment, so
+    # both I2S_OUT amp buses bind to it from the corpus (not invented). The mic
+    # bus names no part → a disclosed assumption, never a silent substitution.
+    rp = r1["resolved_parts"]
+    i2s_out = {v["part"] for k, v in rp.items() if v["via"] == "corpus"}
+    assert "MAX98357A" in i2s_out, f"MAX98357A not resolved from corpus: {rp}"
+    assert all(v["via"] == "corpus" for k, v in rp.items()
+               if v["part"] == "MAX98357A")
+
     r2 = design(operation="expand_templates", intent_path=str(intent))
     assert r2["status"] == "ok"
+    # The unnamed mic is realized as a DISCLOSED assumption at expand time, never a
+    # silent substitution — and expand surfaces the gap so the user sees it.
+    assert any(g["kind"] == "assumed_part" for g in r2["gaps"]), \
+        "the unnamed mic should surface a disclosed assumed_part gap"
 
     r3 = design(operation="generate_schematic", intent_path=str(intent),
                 schematic_path=str(sch))

--- a/tests/test_bus_part_resolver.py
+++ b/tests/test_bus_part_resolver.py
@@ -1,0 +1,80 @@
+"""Tests for bus→part resolution (C4). Pure, no KiCad.
+
+The core contract: resolve a bus to a part ONLY when exactly one corpus part
+serves that bus type; ambiguity (>1) is never silently broken, absence resolves
+to nothing, and a user override is honored. No proximity heuristics.
+"""
+from __future__ import annotations
+
+from kicad_mcp.utils.firmware.bus_part_resolver import resolve_bus_parts
+from kicad_mcp.utils.firmware.cards import part_serves_map
+from kicad_mcp.utils.firmware.intent import Bus
+from kicad_mcp.utils.firmware.part_extractor import PartEvidence
+
+_SERVES = {"INMP441": "I2S_IN", "SPH0645": "I2S_IN", "MAX98357A": "I2S_OUT"}
+
+
+def _ev(canonical: str) -> PartEvidence:
+    return PartEvidence(part_name=canonical, canonical=canonical,
+                        file="config.h", line=1, kind="source", raw_text="")
+
+
+def test_single_candidate_resolves_from_corpus():
+    bus = Bus(name="CMCA_MIC", type="I2S_IN")
+    res = resolve_bus_parts([bus], [_ev("INMP441")], _SERVES)
+    assert bus.resolved_part == "INMP441"
+    assert bus.part_provenance == "corpus"
+    assert res[0].reason == "resolved"
+
+
+def test_ambiguous_two_candidates_does_not_pick():
+    # Both INMP441 and SPH0645 serve I2S_IN and both appear → NEVER silently pick.
+    bus = Bus(name="CMCA_MIC", type="I2S_IN")
+    res = resolve_bus_parts([bus], [_ev("INMP441"), _ev("SPH0645")], _SERVES)
+    assert bus.resolved_part is None
+    assert res[0].reason == "ambiguous"
+    assert res[0].candidates == ["INMP441", "SPH0645"]   # sorted, for a stable gap message
+
+
+def test_no_serving_part_in_corpus_resolves_none():
+    # Corpus has an I2S_OUT part only; an I2S_IN bus has no candidate.
+    bus = Bus(name="CMCA_MIC", type="I2S_IN")
+    res = resolve_bus_parts([bus], [_ev("MAX98357A")], _SERVES)
+    assert bus.resolved_part is None
+    assert res[0].reason == "none"
+
+
+def test_two_same_type_buses_both_resolve():
+    # The audio node's two MAX98357A amps: two I2S_OUT buses, one serving part.
+    b1 = Bus(name="CMCA_I2S", type="I2S_OUT")
+    b2 = Bus(name="CMCA_I2S2", type="I2S_OUT")
+    resolve_bus_parts([b1, b2], [_ev("MAX98357A")], _SERVES)
+    assert b1.resolved_part == "MAX98357A" and b2.resolved_part == "MAX98357A"
+
+
+def test_user_override_is_honored_not_overwritten():
+    bus = Bus(name="CMCA_MIC", type="I2S_IN",
+              resolved_part="ICS43434", part_provenance="user")
+    # Even though INMP441 is the sole corpus candidate, the user's choice wins.
+    res = resolve_bus_parts([bus], [_ev("INMP441")], _SERVES)
+    assert bus.resolved_part == "ICS43434" and bus.part_provenance == "user"
+    assert res[0].reason == "user"
+
+
+def test_serves_type_must_match_bus_type():
+    # MAX98357A serves I2S_OUT, so it is NOT a candidate for an I2S_IN bus.
+    bus = Bus(name="CMCA_MIC", type="I2S_IN")
+    resolve_bus_parts([bus], [_ev("MAX98357A"), _ev("INMP441")], _SERVES)
+    assert bus.resolved_part == "INMP441"   # only the I2S_IN part matched
+
+
+# --- part_serves_map -------------------------------------------------------
+
+def test_part_serves_map_omits_cards_without_serves():
+    peripherals = {
+        "INMP441": {"type": "INMP441", "serves": "I2S_IN"},
+        "MAX98357A": {"type": "MAX98357A", "serves": "I2S_OUT"},
+        "MPU6050": {"type": "MPU6050"},               # no serves → omitted
+    }
+    assert part_serves_map(peripherals) == {
+        "INMP441": "I2S_IN", "MAX98357A": "I2S_OUT"}

--- a/tests/test_firmware_sidecar.py
+++ b/tests/test_firmware_sidecar.py
@@ -215,6 +215,7 @@ def test_known_keys_all_accepted(tmp_path):
         placement: {}
         placement_hints: {}
         mounting_holes: {count: 4}
+        bus_part_overrides: {}
     """))
     assert sc.power_source == "usb_c"
     assert sc.board_size_mm == [90, 75]
@@ -222,6 +223,46 @@ def test_known_keys_all_accepted(tmp_path):
     assert sc.placement == {}
     assert sc.placement_hints == {}
     assert sc.mounting_holes == {"count": 4}
+    assert sc.bus_part_overrides == {}
+
+
+# --- bus_part_overrides (C7) --------------------------------------------------
+
+def test_bus_part_override_loads(tmp_path):
+    sc = load_sidecar(_write(tmp_path, """\
+        bus_part_overrides:
+          CMCA_MIC: {part: INMP441}
+    """))
+    assert sc.bus_part_overrides == {"CMCA_MIC": {"part": "INMP441"}}
+
+
+@pytest.mark.parametrize("body,needle", [
+    ("bus_part_overrides: 5\n", "must be a mapping"),
+    ("bus_part_overrides: {B: 5}\n", "must be a mapping"),
+    ("bus_part_overrides: {B: {}}\n", "empty"),
+    ("bus_part_overrides: {B: {part: 7}}\n", "part must be"),
+    ("bus_part_overrides: {B: {prt: INMP441}}\n", "unknown key"),   # typo'd sub-key
+])
+def test_bus_part_override_rejected(tmp_path, body, needle):
+    with pytest.raises(SidecarError) as e:
+        load_sidecar(_write(tmp_path, body))
+    assert needle in str(e.value)
+
+
+def test_apply_bus_part_override_stamps_user_provenance():
+    from kicad_mcp.utils.firmware.intent import Bus
+    i = _intent()
+    i.buses.append(Bus(name="CMCA_MIC", type="I2S_IN"))
+    apply_sidecar(i, BoardSidecar(bus_part_overrides={"CMCA_MIC": {"part": "INMP441"}}))
+    bus = next(b for b in i.buses if b.name == "CMCA_MIC")
+    assert bus.resolved_part == "INMP441"
+    assert bus.part_provenance == "user" and bus.part_is_assumption is False
+
+
+def test_apply_bus_part_override_unknown_bus_gaps():
+    i = _intent()
+    apply_sidecar(i, BoardSidecar(bus_part_overrides={"NOPE": {"part": "INMP441"}}))
+    assert any(g.kind == "bus_part_override_unknown" for g in i.gaps)
 
 
 # --- mounting_holes -----------------------------------------------------------

--- a/tests/test_part_identity_guardrail.py
+++ b/tests/test_part_identity_guardrail.py
@@ -1,0 +1,83 @@
+"""Part-identity guardrail (C8): the invariant the whole feature exists to hold —
+a recognized device is NEVER placed as a silent substitute. Either the firmware
+named it (origin "imported") or the assumption is disclosed by an assumed_part /
+part_unavailable gap. No KiCad.
+"""
+from __future__ import annotations
+
+import asyncio
+import tempfile
+
+from kicad_mcp.server import create_server
+from kicad_mcp.utils.firmware.intent import Bus, load_intent
+from kicad_mcp.utils.firmware.templates import Expansion, _decide_part
+
+# The recognized device TYPES a template places (vs. generic R/C/HDR/CONN glue).
+_DEVICE_TYPES = {"MAX98357A", "SPH0645"}
+
+
+# --- _decide_part: the three honest cases, directly --------------------------
+
+def test_decide_unresolved_assumes_with_gap():
+    bus = Bus(name="B", type="I2S_IN")
+    ex = Expansion()
+    place, origin = _decide_part(bus, "SPH0645", ex)
+    assert place and origin == "template"
+    assert bus.resolved_part == "SPH0645" and bus.part_is_assumption
+    assert [g.kind for g in ex.gaps] == ["assumed_part"]
+
+
+def test_decide_match_is_imported_no_gap():
+    bus = Bus(name="B", type="I2S_OUT", resolved_part="MAX98357A",
+              part_provenance="corpus")
+    ex = Expansion()
+    place, origin = _decide_part(bus, "MAX98357A", ex)
+    assert place and origin == "imported"
+    assert not bus.part_is_assumption and ex.gaps == []
+
+
+def test_decide_mismatch_refuses_with_part_unavailable():
+    # Firmware declared INMP441; this template only builds SPH0645 → REFUSE to
+    # substitute (the bug), disclose part_unavailable, place nothing.
+    bus = Bus(name="B", type="I2S_IN", resolved_part="INMP441",
+              part_provenance="corpus")
+    ex = Expansion()
+    place, origin = _decide_part(bus, "SPH0645", ex)
+    assert place is False
+    assert any(g.kind == "part_unavailable" and "INMP441" in g.detail
+               for g in ex.gaps)
+    assert bus.resolved_part == "INMP441"   # the declared part is NOT overwritten
+
+
+# --- the invariant on a real expansion ---------------------------------------
+
+def _expand_audio() -> object:
+    mcp = create_server()
+    design = asyncio.run(mcp.get_tool("design")).fn
+    out = tempfile.mktemp(suffix=".yaml")
+    design(operation="import_firmware",
+           firmware_path="tests/fixtures/firmware/audio_s3/config.h", out_path=out)
+    design(operation="expand_templates", intent_path=out)
+    return load_intent(out)
+
+
+def test_no_recognized_device_placed_without_disclosure():
+    it = _expand_audio()
+    for p in it.peripherals:
+        if p.type not in _DEVICE_TYPES:
+            continue
+        if p.origin == "imported":
+            continue   # firmware named it — provenance, not a substitution
+        # Placed as a non-imported (assumed) device → MUST be disclosed by a gap.
+        assert any(g.kind in ("assumed_part", "part_unavailable") for g in it.gaps), (
+            f"{p.ref} ({p.type}) placed as a non-imported assumption with NO "
+            f"assumed_part/part_unavailable gap — a silent substitution")
+
+
+def test_assumed_bus_has_a_gap_naming_it():
+    it = _expand_audio()
+    for bus in it.buses:
+        if bus.part_is_assumption:
+            assert any(g.kind == "assumed_part" and bus.name in g.detail
+                       for g in it.gaps), \
+                f"assumed bus {bus.name!r} not disclosed by an assumed_part gap"

--- a/tests/test_part_resolution_inmp441.py
+++ b/tests/test_part_resolution_inmp441.py
@@ -1,0 +1,65 @@
+"""Part-resolution feature test, using the EOL INMP441 as the case study.
+
+The feature's job on a firmware-declared part that can't be built: recognize it,
+REFUSE to silently substitute, disclose it, and let the user pick a current
+replacement via board.yaml. No KiCad (import + expand only).
+"""
+from __future__ import annotations
+
+import asyncio
+import shutil
+
+from kicad_mcp.server import create_server
+from kicad_mcp.utils.firmware.intent import load_intent
+
+_FIX = "tests/fixtures/firmware/audio_inmp441"
+
+
+def _design():
+    return asyncio.run(create_server().get_tool("design")).fn
+
+
+def _stage(tmp_path, board_yaml: str | None = None):
+    """Copy the INMP441 fixture into tmp (so a board.yaml can sit beside it)."""
+    fw = tmp_path / "fw"
+    fw.mkdir()
+    shutil.copy(f"{_FIX}/config.h", fw / "config.h")
+    shutil.copy(f"{_FIX}/platformio.ini", fw / "platformio.ini")
+    if board_yaml is not None:
+        (fw / "board.yaml").write_text(board_yaml)
+    return str(fw / "config.h")
+
+
+def test_declared_inmp441_resolves_then_refuses_substitution(tmp_path):
+    design = _design()
+    cfg = _stage(tmp_path)
+    out = str(tmp_path / "intent.yaml")
+    r1 = design(operation="import_firmware", firmware_path=cfg, out_path=out)
+    # The firmware NAMES INMP441 → bound from the corpus (not invented/assumed).
+    assert r1["resolved_parts"]["CMCA_MIC"] == {"part": "INMP441", "via": "corpus"}
+
+    r2 = design(operation="expand_templates", intent_path=out)
+    # The template builds SPH0645; it must NOT silently substitute it for the
+    # declared INMP441 — instead disclose part_unavailable, place no mic.
+    assert any(g["kind"] == "part_unavailable" and "INMP441" in g["detail"]
+               for g in r2["gaps"])
+    it = load_intent(out)
+    assert not any(p.type == "SPH0645" for p in it.peripherals), \
+        "SPH0645 was silently substituted for the declared INMP441"
+
+
+def test_board_yaml_override_substitutes_current_replacement(tmp_path):
+    # The feature's handling: declare a current replacement for the EOL part. The
+    # user owns the choice (provenance "user"); the firmware naming is overridden.
+    design = _design()
+    cfg = _stage(tmp_path, "bus_part_overrides:\n  CMCA_MIC: {part: SPH0645}\n")
+    out = str(tmp_path / "intent.yaml")
+    r1 = design(operation="import_firmware", firmware_path=cfg, out_path=out)
+    assert r1["resolved_parts"]["CMCA_MIC"] == {"part": "SPH0645", "via": "user"}
+
+    design(operation="expand_templates", intent_path=out)
+    it = load_intent(out)
+    mics = [p for p in it.peripherals if p.type == "SPH0645"]
+    assert mics and mics[0].origin == "imported"   # user-chosen, placed, not assumed
+    mic_bus = next(b for b in it.buses if b.name == "CMCA_MIC")
+    assert mic_bus.resolved_part == "SPH0645" and mic_bus.part_provenance == "user"


### PR DESCRIPTION
Makes the firmware front end resolve the SPECIFIC part the firmware names and refuse to silently substitute (the SPH0645-for-INMP441 bug), building on the C1/C2 foundation already on main.

- **C4** Bus part-resolution schema + pure resolver + `part_serves_map`; wired into `import_firmware` (reports `resolved_parts`).
- **C2b** MAX98357A + SPH0645 device cards (`serves`), pin-verified on KiCad 9 & 10.
- **C6** templates consume `resolved_part` — firmware-named → `imported`; unnamed → disclosed assumption + gap; declared-but-unbuildable → **refuse + `part_unavailable`** (no silent swap). Load-bearing.
- **C7** board.yaml `bus_part_overrides` — user declares a bus's part (provenance `user`, wins over corpus).
- **C8** part-identity guardrail (no-silent-substitution invariant, all 3 cases).
- **C9** golden gate on audio_s3 (MAX98357A imported via corpus; unnamed mic = disclosed assumption); `expand_templates` now surfaces open gaps.
- **Test case (EOL INMP441):** recognition card + `audio_inmp441` fixture prove declare→resolve→refuse→override on a real discontinued part.

**Verified:** no-KiCad 2044, mypy clean (75 files), integration **24/24 on KiCad 9 AND 10**.

Genuinely-optional deferrals (in the plan doc): generalize `i2s_mic` to place any resolved card; C5 generate-level symbol-absent gap; C7 footprint-only swap. Real-board INMP441 replacement (SPH0645/ICS-43434) is a separate mr-esp32 effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)