### PR TITLE
Board compaction: multi-edge distribution + terminal centering + re-fit (all opt-in)

### DIFF
--- a/docs/SPEC_Multi_Edge_Terminal_Distribution.md
+++ b/docs/SPEC_Multi_Edge_Terminal_Distribution.md
@@ -1,0 +1,234 @@
+# SPEC — Multi-Edge Terminal Distribution (autoplacer RFE)
+
+> **STATUS: DRAFT — needs fresh-session cold review BEFORE implementation.**
+> Per the project's Spec Review Rule, this spec was authored in one session and must be
+> cold-read by a fresh context (with no memory of the authoring discussion) before any code is
+> written. The reviewer's first job is the **External-System Assumptions** section below — that
+> class invalidates whole mechanisms, not just numbers, and does not surface from cold reading
+> unless asked for explicitly.
+>
+> Authored against branch `claude/recursing-kowalevski-365bfb` @ `b4c8bb6`. Line numbers are from
+> that commit; re-confirm before editing.
+
+## 1. Context & motivation
+
+The human-rational autoplacer (shipped via PRs #58/#65) places **all** field-wiring screw
+terminals on the single board edge **opposite the MCU antenna** (an RFI rule — keep field wires
+away from the radio). On a board with several terminals this yields a wide **letterbox**:
+audio-remote auto-sizes to **129×65 mm** with both side (N-S / left-right) edges bare and a large
+empty interior band — roughly **45 cm² used of ~84 cm²**.
+
+`RFE #1` (axis-aware corner reservation, shipped this session as commit `4e6a267`) only shaved the
+vertical over-reservation; the dominant waste is the **single-edge shape itself**. This RFE
+distributes terminals across the antenna-opposite edge **and the two side edges** to produce a
+squarer, smaller board (the autoplacer memory estimated ~30–45% area reduction).
+
+The single-edge design was a *deliberate* earlier decision: side-edge terminal legends point
+**inboard** (toward the cluster) and crowd it, which is why one edge was chosen. This spec
+re-opens that decision and reserves an inboard silk gap to make side edges viable.
+
+**Intended outcome:** an opted-in board (audio-remote) comes out squarer and smaller, terminals
+correctly oriented (wire-entry outward) and silk-labelled on up to three edges, still routing
+0-unconnected — without changing the other three golden boards.
+
+## 2. Settled decisions (do not re-litigate in review)
+
+- **D1 — Opt-in flag, default `single_edge`.** New `board.yaml` key
+  `terminal_distribution: single_edge | multi_edge`, default `single_edge`. Only audio-remote
+  opts in. Rationale: the project rule forbids overfitting one board; defaulting on would perturb
+  the other three goldens and their gates, and multi-edge only pays off on a wide letterbox.
+- **D2 — Spec-then-cold-review.** No implementation in the authoring session (this one).
+
+## 3. Architecture — one source of truth (CLAUDE.md Rule 3)
+
+**Today the data flows placement → parent:** the embedded pcbnew script in `_step_smart_placement`
+decides each terminal's edge (`pcb_pipeline.py:1176-1196`), and the parent *reconstructs*
+`terminal_edges` from the script's `rotation_chosen` events (`pcb_pipeline.py:2091`) to feed the
+silk step. The board is sized **before** placement (`_estimate_board_size`/`_content_aware_size`)
+under the assumption that all terminals share one edge.
+
+**Invert it: decide in the pure parent layer, pass edges down as hints.**
+
+- New pure function in `src/kicad_mcp/utils/placement/edge_terminal.py`:
+
+  ```python
+  def distribute_terminals(
+      cluster_mm: float,
+      terminals: list[dict],         # [{"ref","w","h"}, …]  (w,h = body extents)
+      antenna_edge: str | None,      # "top"|"bottom"|"left"|"right"|None
+      *,
+      mode: str = "single_edge",     # "single_edge" | "multi_edge"
+      routing_factor, padding, spacing,
+      corner_inset_mm, corner_center_inset_mm, side_silk_gap_mm,
+  ) -> tuple[dict[str, str], dict]:  # (edge_of {ref:edge},  {"width_mm","height_mm"})
+  ```
+
+  It is the **single source** for BOTH (a) board dims and (b) per-terminal edge assignment.
+- `_content_aware_size` (`pcb_pipeline.py:404`) / `_estimate_board_size` (`:451`) consume it for
+  dims. `_estimate_board_size` already measures terminal `w/h` and derives `antenna_side`, so it
+  has all inputs.
+- The parent then passes the returned `edge_of` into `_step_smart_placement` as per-ref
+  `placement_hints[ref] = {"edge": E}`, **reusing the existing edge-hint branch** at
+  `pcb_pipeline.py:1159` (`elif hint.get("edge") in ("top","bottom","left","right")`). No new
+  placement code path; the per-edge layout (`natural_ref_key` order, WIRE_ENTRY → outward-normal
+  rotation) is unchanged and already handles all four edges.
+- **Delete** the script's own distribution loop (`pcb_pipeline.py:1176-1196`); terminals now
+  arrive pre-assigned. The `t2_terminals` collection (`:1166`) becomes a no-op for firmware
+  boards (they all carry an edge hint) but is kept as the fallback for any field terminal without
+  a hint.
+
+### 3.1 Antenna-edge frame agreement (a real subtlety — flagged for review)
+There are **two** independent antenna-edge derivations and they must agree:
+- the **script** computes `antenna_edge` from the tier-1 `keepout_overhang` decision, in the
+  **post-rotation board frame** (`pcb_pipeline.py:1176`);
+- `_estimate_board_size` derives `antenna_side` from the footprint's rule-area keepout in the
+  **footprint 0° frame** (`:~530`).
+
+They agree on every golden because the MCU is placed at 0° on the antenna-opposite edge. The
+distribution decision uses the parent's value. **Do not add a third computation.** Add an
+`antenna_frame_mismatch` decision/event if the script's post-rotation edge ever disagrees with the
+parent-provided one, so future drift is loud rather than silent. See External-System Assumption A4.
+
+## 4. Geometry
+
+Per terminal: `along = max(w,h) + spacing`, `depth = min(w,h)`.
+Cluster `C = max(sqrt(interior_area · routing_factor), max_interior_dim)`.
+`bottom := _OPP[antenna_edge]`; `sides :=` the perpendicular pair; the antenna edge is **never**
+assigned a terminal.
+
+```
+depth(E) = max(depth of terminals on E) + corner_center_inset_mm
+           + (side_silk_gap_mm  if E is a non-empty SIDE edge  else 0)
+along(E) = sum(along of terminals on E) + 2·padding + 2·corner_inset_mm     # only if E used
+
+width  = max( C + depth(left) + depth(right),   along(bottom) )
+height = max( C + depth(bottom),                 along(left),  along(right) )
+```
+
+When the antenna sits on a **vertical** edge the axes transpose (terminals march along height),
+exactly as today's `terminal_edge_horizontal` flag in `_content_aware_size` handles.
+
+**Regression lock:** `mode="single_edge"` ⇒ every terminal on `bottom` ⇒ `depth(left)=depth(right)
+=0`, `along(left)=along(right)=0` ⇒ the formula **reduces byte-for-byte to today's
+`_content_aware_size`**. A test must assert this exactly (§7).
+
+## 5. Distribution heuristic (deterministic, N ≤ ~12 terminals)
+
+1. `mode="single_edge"` → all terminals on `bottom` (today's behaviour). Done.
+2. `mode="multi_edge"` but the single-edge board is already **near-square**
+   (`width ≤ height · THRESH`, `THRESH ≈ 1.35`) → no-op, stay single-edge. (Protects boards that
+   don't need it even when the flag is on.)
+3. Otherwise: peel a contiguous **suffix** of terminals (in `natural_ref_key` order) off `bottom`
+   and split it **evenly across the two side edges**. For `k = 1 … N-1` peeled, compute
+   `(width, height)` and score `(max(width,height), area)`; take the argmin, tie-broken toward
+   **smaller k** (fewer wire faces). **Suffix-peeling preserves per-edge natural order**
+   (e.g. J1–J3 stay on bottom, J4/J5 go to sides) — required by the layout gate's ordering
+   assertion. Reuse `natural_ref_key` from `edge_terminal.py`.
+
+## 6. Silk on side edges
+
+`_step_silkscreen_legends` already places legends **inboard** for left/right edges (the
+`_INBOARD` `ix>0` / `ix<0` branches, plus this session's clearance-aware interior-header logic).
+The `side_silk_gap_mm` term in `depth()` (§4) reserves the inboard band so side-edge legends don't
+crowd the interior cluster. The exact value is **eyeball-tuned at implementation** (start ~2.5 mm)
+and is an External-System Assumption (A1) — it can only be validated by a real-KiCad render.
+
+## 7. Opt-in flag plumbing
+
+`src/kicad_mcp/utils/firmware/sidecar.py`:
+- Add `terminal_distribution: Optional[str] = None` to `BoardSidecar` (`:94`).
+- Add `"terminal_distribution"` to `_KNOWN_SIDECAR_KEYS` (`:116`) — unknown-key rejection already
+  exists at `:211`.
+- Add literal validation mirroring the `power_source` check (`:217-219`): value must be in
+  `{"single_edge","multi_edge"}` or it's a loud error.
+- Thread into `DesignIntent.source` (already how `board_size_mm` flows) → read in
+  `_estimate_board_size` → pass `mode=` to `distribute_terminals`. Default `single_edge` when
+  absent.
+
+Opt audio-remote in via its `board.yaml`: `terminal_distribution: multi_edge`.
+
+## 8. Tests
+
+### 8.1 Pure (`tests/test_board_sizing.py` + new `tests/test_terminal_distribution.py`)
+Boundary-focused per CLAUDE.md Threshold rule:
+- **0 terminals** → empty `edge_of`, size == no-terminal baseline.
+- **1 terminal** → never split (stays on bottom regardless of mode).
+- **all-fit / near-square** → `multi_edge` no-ops (heuristic step 2).
+- **forced-spill** → a deliberately wide letterbox spills to sides; assert squarer + area ≤
+  single-edge.
+- **antenna on each of the 4 sides** → opposite + perpendicular pair correct; antenna edge
+  **never** in `edge_of.values()`; axis transpose correct.
+- **`single_edge` ≡ today** → parametrize the existing `_content_aware_size` tests through the new
+  function in single-edge mode; assert identical dims (regression lock for §4).
+- determinism (same input → same output); corner insets applied per used edge.
+
+### 8.2 Integration (`tests/integration/test_firmware_pcb_pipeline.py`)
+- **KEEP** the existing single-edge gate (`_term_edges == {"bottom"}`, wide-letterbox window,
+  per-edge `natural_ref_key` order — currently ~lines 491-520). It now guards the **default**
+  path; do not weaken it.
+- **ADD** a multi-edge test on an opted-in board:
+  - `_term_edges ⊆ {"bottom","left","right"}`, `"top" ∉ _term_edges`, `len(_term_edges) ≥ 2`;
+  - per-edge `natural_ref_key` order still holds (the existing `by_edge` loop works unchanged);
+  - **squarer**: `abs(bw-bh)` smaller than the single-edge build of the same project;
+  - **area not worse** than single-edge;
+  - still routes (`_assert_mostly_routed`);
+  - side-edge legend bboxes don't overlap any pad (extend the existing silk-vs-pad check);
+  - **no `antenna_frame_mismatch`** event.
+
+## 9. External-system assumptions — REVIEW THESE FIRST (highest severity)
+
+A wrong assumption here invalidates the mechanism, not just a constant. None surface from cold
+reading unless explicitly checked.
+
+- **A1 — Side-edge silk renders readably on real KiCad.** The inboard left/right legend placement
+  plus `side_silk_gap_mm` must be validated by an actual `kicad-cli` render of an opted-in board,
+  not by geometry alone. (This is precisely the crowding that drove the original single-edge
+  decision.)
+- **A2 — WIRE_ENTRY rotation faces outward on left/right edges.** `rotation_to_face(vec,
+  outward_normal(edge))` must aim the MKDS wire entry **off-board** on side edges, not only on
+  top/bottom. Confirm `outward_normal` + the rotation snap behave for left/right, and that no pad
+  lands off-board (the rotation-sign bug class from PR #58 history —
+  `_refs_with_pads_off_board`).
+- **A3 — FreeRouter still routes ~complete** with terminals on three edges. Spreading terminals
+  changes net topology and FreeRouter's nondeterministic tail; the board may need a higher
+  best-of-N or pass count (per the documented rule: bump passes, never loosen the unconnected
+  bound).
+- **A4 — Parent (0° frame) vs script (post-rotation frame) antenna edge agree** on all four
+  goldens. Guarded by the `antenna_frame_mismatch` event, but confirm the assumption holds so the
+  guard never fires in normal use.
+
+## 10. Open design questions (for reviewer / implementer)
+
+- **R1** — squareness-vs-area objective weighting and the `THRESH ≈ 1.35` near-square cutoff
+  (§5). What does the reviewer think the objective should optimize?
+- **R2** — `side_silk_gap_mm` starting value (eyeball-tuned at impl; start 2.5).
+- **R3** — corner-hole clearance when terminals occupy **adjacent** edges: a corner hole is shared
+  by two edges (e.g. bottom-left by `bottom` and `left`). Verify the per-edge `along`/`depth`
+  reservations in §4 don't under- or double-count the shared corner. This is the subtlest part of
+  the geometry.
+
+## 11. Critical files (current locations @ `b4c8bb6`)
+
+| File | What changes |
+|---|---|
+| `src/kicad_mcp/utils/placement/edge_terminal.py` | NEW pure `distribute_terminals`; reuse `natural_ref_key`, `outward_normal`, `rotation_to_face` |
+| `src/kicad_mcp/tools/pcb_pipeline.py` | `_content_aware_size` (`:404`) + `_estimate_board_size` (`:451`) consume `distribute_terminals`; delete script distribution loop (`:1176-1196`); reuse edge-hint path (`:1159`); add `antenna_frame_mismatch`; parent passes `edge_of` as hints; `terminal_edges` reconstruction (`:2091`) unchanged |
+| `src/kicad_mcp/utils/firmware/sidecar.py` | `terminal_distribution` field (`:94`), `_KNOWN_SIDECAR_KEYS` (`:116`), literal validation (`:217` pattern) |
+| `tests/test_board_sizing.py`, NEW `tests/test_terminal_distribution.py` | regression lock + pure boundary tests (§8.1) |
+| `tests/integration/test_firmware_pcb_pipeline.py` | keep single-edge gate, add multi-edge gate (§8.2) |
+| audio-remote `board.yaml` (test fixture under `tests/fixtures/firmware/audio_s3/` + the inline `board.yaml` in `test_audio_remote_to_routed_pcb`) | `terminal_distribution: multi_edge` |
+
+## 12. Implementation order (post-review)
+
+1. **Lock** current sizing: parametrize existing `_content_aware_size` tests through
+   `distribute_terminals(mode="single_edge")` and assert identical (no behaviour change yet).
+2. Extract/refactor: `_content_aware_size` calls `distribute_terminals` internally (single-edge),
+   green.
+3. Add `multi_edge` heuristic + geometry; pure tests (§8.1).
+4. Plumb the flag through sidecar → intent → `_estimate_board_size`.
+5. Parent passes `edge_of` as placement hints; delete the script distribution loop; add
+   `antenna_frame_mismatch`.
+6. Add the integration multi-edge gate; opt audio-remote in.
+7. **Eyeball gate** (per the human-rational layout norm): build + render the opted-in board, tune
+   `side_silk_gap_mm`, confirm squarer/smaller, terminals oriented outward on side edges, silk
+   readable, routes 0-unconnected. Verify the other three goldens are byte-identical.

--- a/docs/SPEC_Multi_Edge_Terminal_Distribution.md
+++ b/docs/SPEC_Multi_Edge_Terminal_Distribution.md
@@ -1,14 +1,16 @@
 # SPEC — Multi-Edge Terminal Distribution (autoplacer RFE)
 
-> **STATUS: DRAFT — needs fresh-session cold review BEFORE implementation.**
-> Per the project's Spec Review Rule, this spec was authored in one session and must be
-> cold-read by a fresh context (with no memory of the authoring discussion) before any code is
-> written. The reviewer's first job is the **External-System Assumptions** section below — that
-> class invalidates whole mechanisms, not just numbers, and does not surface from cold reading
-> unless asked for explicitly.
+> **STATUS: COLD-REVIEWED 2026-06-02 (3 fresh-context agents) — findings folded in below.**
+> Authored, then cold-read by three independent clean-context reviewers (external-system
+> assumptions / internal-consistency+references / geometry+heuristic). Their blockers and
+> should-fixes are incorporated; the changed sections are tagged `[CR-fixed]`. Remaining items
+> the reviewers flagged as needing a real-KiCad render or a human call are listed in §9/§10.
+> Implementation may proceed per §12, treating §9's render-gated assumptions as must-verify.
 >
-> Authored against branch `claude/recursing-kowalevski-365bfb` @ `b4c8bb6`. Line numbers are from
-> that commit; re-confirm before editing.
+> Authored against `claude/recursing-kowalevski-365bfb` @ `b4c8bb6`; line numbers re-confirmed
+> accurate at review time (`_content_aware_size:404`, `_estimate_board_size:451`, single-edge
+> gate `:491-520`, `terminal_edges` reconstruct `:2091`, sidecar `_KNOWN_SIDECAR_KEYS:116`,
+> validation `:211/:217`). Re-confirm before editing.
 
 ## 1. Context & motivation
 
@@ -72,10 +74,14 @@ under the assumption that all terminals share one edge.
   `pcb_pipeline.py:1159` (`elif hint.get("edge") in ("top","bottom","left","right")`). No new
   placement code path; the per-edge layout (`natural_ref_key` order, WIRE_ENTRY → outward-normal
   rotation) is unchanged and already handles all four edges.
-- **Delete** the script's own distribution loop (`pcb_pipeline.py:1176-1196`); terminals now
-  arrive pre-assigned. The `t2_terminals` collection (`:1166`) becomes a no-op for firmware
-  boards (they all carry an edge hint) but is kept as the fallback for any field terminal without
-  a hint.
+- **Delete ONLY the assignment loop** (`pcb_pipeline.py:1179-1196` — the `pref_edges` build + the
+  greedy capacity `for` loop); terminals now arrive pre-assigned. **KEEP the `antenna_edge`
+  derivation at `:1176-1177`** (it reads the tier-1 `keepout_overhang` decision, not the
+  distribution loop) — the `antenna_frame_mismatch` guard (§3.1) needs it as the script-side value
+  to compare against. `[CR-fixed: deleting the whole block would remove the value the guard
+  compares, so the guard could never fire.]` The `t2_terminals` collection (`:1166`) becomes a
+  no-op for firmware boards (all carry an edge hint) but is kept as the fallback for any field
+  terminal without a hint.
 
 ### 3.1 Antenna-edge frame agreement (a real subtlety — flagged for review)
 There are **two** independent antenna-edge derivations and they must agree:
@@ -84,54 +90,110 @@ There are **two** independent antenna-edge derivations and they must agree:
 - `_estimate_board_size` derives `antenna_side` from the footprint's rule-area keepout in the
   **footprint 0° frame** (`:~530`).
 
-They agree on every golden because the MCU is placed at 0° on the antenna-opposite edge. The
-distribution decision uses the parent's value. **Do not add a third computation.** Add an
-`antenna_frame_mismatch` decision/event if the script's post-rotation edge ever disagrees with the
-parent-provided one, so future drift is loud rather than silent. See External-System Assumption A4.
+Both name the same physical edge — the one the antenna overhangs. `[CR-fixed: the earlier
+justification "MCU placed at 0°" was WRONG — the tier-1 placer ROTATES the MCU so its keepout
+faces the chosen edge's outward normal (pcb_pipeline.py:~1078-1110). Agreement holds because both
+derivations describe the antenna-overhang edge, NOT because the MCU stays at 0°. It could diverge
+if tier-1 falls back to a non-preferred edge.]* The distribution decision uses the parent's value.
+**Do not add a third computation.** Emit an `antenna_frame_mismatch` decision/event when the
+script's `antenna_edge` (`:1176`) disagrees with the parent-provided one — so the divergence case
+is loud rather than silent. See External-System Assumption A4.
 
-## 4. Geometry
+## 4. Geometry `[CR-fixed — the first cut did NOT reduce to `_content_aware_size`; two reviewers flagged it]`
 
-Per terminal: `along = max(w,h) + spacing`, `depth = min(w,h)`.
-Cluster `C = max(sqrt(interior_area · routing_factor), max_interior_dim)`.
-`bottom := _OPP[antenna_edge]`; `sides :=` the perpendicular pair; the antenna edge is **never**
-assigned a terminal.
-
+**Derive the multi-edge formula by GENERALIZING `_content_aware_size`, not approximating it.**
+The current code (single edge, `terminal_edge_horizontal=True`) is, verbatim:
 ```
-depth(E) = max(depth of terminals on E) + corner_center_inset_mm
-           + (side_silk_gap_mm  if E is a non-empty SIDE edge  else 0)
-along(E) = sum(along of terminals on E) + 2·padding + 2·corner_inset_mm     # only if E used
-
-width  = max( C + depth(left) + depth(right),   along(bottom) )
-height = max( C + depth(bottom),                 along(left),  along(right) )
+along = max(cluster, term_along) + 2·padding + 2·corner_inset_mm          → width
+depth = cluster + term_depth     + 2·padding + 2·corner_center_inset_mm   → height
 ```
+Key structural facts the first cut got wrong: padding + corner reservation are added **outside**
+the `max(...)` (not inside); the depth axis uses `2·corner_center_inset_mm` (**twice**, both ends);
+neither corner term nor the silk gap is folded into a per-edge `depth(E)`.
 
-When the antenna sits on a **vertical** edge the axes transpose (terminals march along height),
-exactly as today's `terminal_edge_horizontal` flag in `_content_aware_size` handles.
+**Generalized formula (antenna on top → `bottom` primary, `left`/`right` are the side edges):**
+Raw per-edge quantities (no padding/corner/silk folded in; `0` when E is unused):
+```
+along(E) = Σ over terminals on E of (max(w,h) + spacing)          # span along edge E
+depth(E) = max over terminals on E of min(w,h)
+           + (side_silk_gap_mm if E ∈ {left,right} and E is used else 0)
+```
+Board (corner reservation is **axis-aware**, per RFE #1 `4e6a267`: an axis that a terminal edge
+runs ALONG gets the FULL `corner_inset_mm`; an axis only crossed perpendicularly gets
+`corner_center_inset_mm`):
+```
+sides_used = (left used) or (right used)
 
-**Regression lock:** `mode="single_edge"` ⇒ every terminal on `bottom` ⇒ `depth(left)=depth(right)
-=0`, `along(left)=along(right)=0` ⇒ the formula **reduces byte-for-byte to today's
-`_content_aware_size`**. A test must assert this exactly (§7).
+width  = max( C + depth(left) + depth(right),  along(bottom) )
+         + 2·padding + 2·corner_inset_mm                       # bottom runs along width → FULL
+
+height = max( C + depth(bottom),  along(left),  along(right) )
+         + 2·padding + 2·(corner_inset_mm if sides_used else corner_center_inset_mm)
+```
+**Regression lock (now actually holds):** single-edge ⇒ `left`/`right` empty ⇒ `depth(left)=
+depth(right)=0`, `along(left)=along(right)=0`, `sides_used=False` ⇒
+`width = max(C, term_along)+2·padding+2·corner_inset`, `height = (C+term_depth)+2·padding+
+2·corner_center_inset` — **identical to the code**. A test asserts this exactly (§8.1). Implement
+single-edge mode by **calling the existing `_content_aware_size` unchanged**, and have the
+multi-edge branch generalize it — don't re-derive a parallel single-edge path.
+
+Antenna on a **vertical** edge → transpose axes (as the existing `terminal_edge_horizontal` flag
+already does).
+
+### 4.1 Adjacent-edge shared-corner rule `[CR-fixed — new blocker: terminal BODIES overlap, not just holes]`
+R3 (shared mounting hole) is the *minor* corner issue — the reservation above guards the hole
+because each axis independently reserves its corner. The **real** corner hazard the reviewers
+surfaced: when two used edges meet (e.g. `bottom` + `left`), a `bottom` terminal's body extends
+**up** by `depth(bottom)` and a `left` terminal's body extends **right** by `depth(left)`; near
+the shared corner those two *bodies* can physically overlap even though each clears the hole.
+
+**Rule:** on an edge `E` that shares a corner with a **used** perpendicular edge `F`, the terminal
+run on `E` must start that end inset by `max(corner_inset_mm, depth(F) + spacing)` (not just
+`corner_inset_mm`). Both the SIZING (the along-dimension must fit `along(E)` plus these possibly-
+enlarged end insets) and the placement layout (`layout_along_edge` start offset) must honor the
+same value — single-sourced through `distribute_terminals`. With ≤2 side terminals on audio-remote
+the enlargement is small, but the rule must exist or a dense board overlaps at a corner.
 
 ## 5. Distribution heuristic (deterministic, N ≤ ~12 terminals)
 
 1. `mode="single_edge"` → all terminals on `bottom` (today's behaviour). Done.
-2. `mode="multi_edge"` but the single-edge board is already **near-square**
-   (`width ≤ height · THRESH`, `THRESH ≈ 1.35`) → no-op, stay single-edge. (Protects boards that
-   don't need it even when the flag is on.)
-3. Otherwise: peel a contiguous **suffix** of terminals (in `natural_ref_key` order) off `bottom`
-   and split it **evenly across the two side edges**. For `k = 1 … N-1` peeled, compute
-   `(width, height)` and score `(max(width,height), area)`; take the argmin, tie-broken toward
-   **smaller k** (fewer wire faces). **Suffix-peeling preserves per-edge natural order**
-   (e.g. J1–J3 stay on bottom, J4/J5 go to sides) — required by the layout gate's ordering
-   assertion. Reuse `natural_ref_key` from `edge_terminal.py`.
+2. `mode="multi_edge"` but the single-edge board is already **near-square** → no-op, stay
+   single-edge. `[CR-fixed: the cutoff must be axis-independent — use the aspect ratio
+   `max(width,height) / min(width,height) ≤ THRESH` (THRESH ≈ 1.35), NOT `width ≤ height·THRESH`,
+   which is wrong when the antenna is on a vertical edge and the board is tall-and-narrow.]`
+3. Otherwise: peel a **suffix** (in `natural_ref_key` order) off `bottom`. For `k = 1 … N-1`
+   peeled, split the peeled suffix across the two sides with a **fixed deterministic rule**
+   `[CR-fixed: was underspecified]`: the **first ⌈k/2⌉ of the peeled refs → `left`, the rest →
+   `right`** (so each side's refs stay in `natural_ref_key` order — the layout gate only requires
+   per-edge sorted order, which this guarantees; a contiguous range is not required). The odd
+   terminal goes to `left` (the `⌈⌉`). Compute `(width, height)`, score `(max(width,height),
+   area)`, take the argmin tie-broken toward **smaller k** (fewer wire faces). Reuse
+   `natural_ref_key` from `edge_terminal.py`.
 
-## 6. Silk on side edges
+**Degenerate cases (must be covered by §8.1):** N=0 → empty assignment; N=1 → never peeled (k≥1
+would empty `bottom`, allowed only if scoring wins, but a 1-terminal board is near-square so step 2
+no-ops first); when a candidate `k` empties `bottom` entirely, `along(bottom)=0` and the
+`max(...)` simply drops that branch — `width`/`height` still well-defined (the `+2·padding+corner`
+terms remain). `[CR-fixed: "only if E used" was ambiguous — along(E)=0 for an unused edge and the
+padding/corner terms stay on the axis regardless.]`
 
-`_step_silkscreen_legends` already places legends **inboard** for left/right edges (the
-`_INBOARD` `ix>0` / `ix<0` branches, plus this session's clearance-aware interior-header logic).
-The `side_silk_gap_mm` term in `depth()` (§4) reserves the inboard band so side-edge legends don't
-crowd the interior cluster. The exact value is **eyeball-tuned at implementation** (start ~2.5 mm)
-and is an External-System Assumption (A1) — it can only be validated by a real-KiCad render.
+## 6. Silk on side edges `[CR-fixed — labels render HORIZONTAL; the gap was under-sized]`
+
+`_step_silkscreen_legends` places legends **inboard** for left/right edges (the `_INBOARD`
+`ix>0`/`ix<0` branches) — BUT the reviewer found it never calls `SetTextAngle`, so **every label
+is drawn horizontal**. On a LEFT/RIGHT edge a horizontal label extends inboard by its **text
+width** (`≈ len(label)·char_width`, ~3–5 mm for `+3V3`/`BCLK`), not by the glyph height. So the
+naïve `side_silk_gap_mm ≈ 2.5` (sized for a glyph height) is **too small**. Two options, decide at
+implementation (this is the §9-A1 render-gated call):
+- **(preferred)** rotate side-edge legend text 90° (`SetTextAngle`) so it reads along the edge like
+  the terminal — then the inboard reach is the glyph height again and `side_silk_gap_mm ≈ 2.5`
+  holds; OR
+- keep horizontal text and set `side_silk_gap_mm = max_label_len · char_width + margin` (measure
+  it, don't guess).
+
+Either way `side_silk_gap_mm` enters `depth(E)` for side edges (§4) and is **eyeball-verified on a
+real render** (A1). The integration gate (§8.2) must assert side-edge legend bboxes don't overlap
+pads OR the cluster.
 
 ## 7. Opt-in flag plumbing
 
@@ -180,43 +242,45 @@ Boundary-focused per CLAUDE.md Threshold rule:
 A wrong assumption here invalidates the mechanism, not just a constant. None surface from cold
 reading unless explicitly checked.
 
-- **A1 — Side-edge silk renders readably on real KiCad.** The inboard left/right legend placement
-  plus `side_silk_gap_mm` must be validated by an actual `kicad-cli` render of an opted-in board,
-  not by geometry alone. (This is precisely the crowding that drove the original single-edge
-  decision.)
-- **A2 — WIRE_ENTRY rotation faces outward on left/right edges.** `rotation_to_face(vec,
-  outward_normal(edge))` must aim the MKDS wire entry **off-board** on side edges, not only on
-  top/bottom. Confirm `outward_normal` + the rotation snap behave for left/right, and that no pad
-  lands off-board (the rotation-sign bug class from PR #58 history —
-  `_refs_with_pads_off_board`).
-- **A3 — FreeRouter still routes ~complete** with terminals on three edges. Spreading terminals
-  changes net topology and FreeRouter's nondeterministic tail; the board may need a higher
-  best-of-N or pass count (per the documented rule: bump passes, never loosen the unconnected
-  bound).
-- **A4 — Parent (0° frame) vs script (post-rotation frame) antenna edge agree** on all four
-  goldens. Guarded by the `antenna_frame_mismatch` event, but confirm the assumption holds so the
-  guard never fires in normal use.
+- **A1 — Side-edge silk renders readably `[CR: confirmed UNVERIFIED + worse than thought]`.** The
+  reviewer found `_step_silkscreen_legends` draws labels **horizontal** (no `SetTextAngle`), so a
+  left/right label reaches inboard by its *text width*, not glyph height → `side_silk_gap_mm` must
+  be resized or the text rotated (§6). MUST validate with an actual `kicad-cli` render of an
+  opted-in board. (This is precisely the crowding that drove the original single-edge decision.)
+- **A2 — WIRE_ENTRY rotation faces outward on left/right edges `[CR: VERIFIED-OK (math)]`.** The
+  reviewer confirmed `rotation_to_face(vec, outward_normal(edge))` gives left θ=90 / right θ=270
+  with outward dot = 1.0. Still confirm at impl that **no pad lands off-board** on side edges
+  (the PR #58 rotation-sign bug class — assert `_refs_with_pads_off_board` empty).
+- **A3 — FreeRouter still routes ~complete** with terminals on three edges `[CR: UNVERIFIED, no
+  3-edge test exists]`. Spreading terminals changes net topology and FreeRouter's nondeterministic
+  tail; the board may need a higher best-of-N or pass count (documented rule: bump passes, never
+  loosen the unconnected bound).
+- **A4 — Parent vs script antenna edge agree `[CR: justification was WRONG, see §3.1]`.** They are
+  in **different frames** and agreement does NOT come from "MCU at 0°" (the tier-1 placer rotates
+  the MCU); it comes from both naming the antenna-overhang edge, which can diverge if tier-1 falls
+  back to a non-preferred edge. The `antenna_frame_mismatch` event is therefore **essential**, not
+  belt-and-braces — confirm it fires on a constructed divergence and is silent on all 4 goldens.
 
 ## 10. Open design questions (for reviewer / implementer)
 
 - **R1** — squareness-vs-area objective weighting and the `THRESH ≈ 1.35` near-square cutoff
   (§5). What does the reviewer think the objective should optimize?
 - **R2** — `side_silk_gap_mm` starting value (eyeball-tuned at impl; start 2.5).
-- **R3** — corner-hole clearance when terminals occupy **adjacent** edges: a corner hole is shared
-  by two edges (e.g. bottom-left by `bottom` and `left`). Verify the per-edge `along`/`depth`
-  reservations in §4 don't under- or double-count the shared corner. This is the subtlest part of
-  the geometry.
+- **R3 — `[CR-resolved → §4.1]`** the shared mounting *hole* is safe (each axis reserves its
+  corner independently; the double-reservation is slightly generous, never unsafe). The reviewer
+  promoted the *real* corner hazard — adjacent-edge terminal **body** overlap — to a sizing+layout
+  rule in §4.1. Implement and test that rule.
 
 ## 11. Critical files (current locations @ `b4c8bb6`)
 
 | File | What changes |
 |---|---|
 | `src/kicad_mcp/utils/placement/edge_terminal.py` | NEW pure `distribute_terminals`; reuse `natural_ref_key`, `outward_normal`, `rotation_to_face` |
-| `src/kicad_mcp/tools/pcb_pipeline.py` | `_content_aware_size` (`:404`) + `_estimate_board_size` (`:451`) consume `distribute_terminals`; delete script distribution loop (`:1176-1196`); reuse edge-hint path (`:1159`); add `antenna_frame_mismatch`; parent passes `edge_of` as hints; `terminal_edges` reconstruction (`:2091`) unchanged |
+| `src/kicad_mcp/tools/pcb_pipeline.py` | `_content_aware_size` (`:404`) + `_estimate_board_size` (`:451`) consume `distribute_terminals`; delete **only** the assignment loop (`:1179-1196`), KEEP `antenna_edge` at `:1176`; reuse edge-hint path (`:1159`); add `antenna_frame_mismatch`; if rotating side silk, `SetTextAngle` in `_step_silkscreen_legends` (`:~1665`); parent passes `edge_of` as hints; `terminal_edges` reconstruction (`:2091`) unchanged |
 | `src/kicad_mcp/utils/firmware/sidecar.py` | `terminal_distribution` field (`:94`), `_KNOWN_SIDECAR_KEYS` (`:116`), literal validation (`:217` pattern) |
 | `tests/test_board_sizing.py`, NEW `tests/test_terminal_distribution.py` | regression lock + pure boundary tests (§8.1) |
 | `tests/integration/test_firmware_pcb_pipeline.py` | keep single-edge gate, add multi-edge gate (§8.2) |
-| audio-remote `board.yaml` (test fixture under `tests/fixtures/firmware/audio_s3/` + the inline `board.yaml` in `test_audio_remote_to_routed_pcb`) | `terminal_distribution: multi_edge` |
+| audio-remote `board.yaml` — **`[CR-fixed]` it is NOT a fixture file**; it's written **inline** via `(fw/"board.yaml").write_text(...)` at `test_firmware_pcb_pipeline.py:424` (and again `:614` in `test_approval_gate_audio_remote`). Opting in = adding `terminal_distribution: multi_edge` to that inline string (or, better, a NEW dedicated multi-edge test so the existing single-edge gate keeps exercising the default) | add the flag |
 
 ## 12. Implementation order (post-review)
 
@@ -226,9 +290,12 @@ reading unless explicitly checked.
    green.
 3. Add `multi_edge` heuristic + geometry; pure tests (§8.1).
 4. Plumb the flag through sidecar → intent → `_estimate_board_size`.
-5. Parent passes `edge_of` as placement hints; delete the script distribution loop; add
-   `antenna_frame_mismatch`.
-6. Add the integration multi-edge gate; opt audio-remote in.
+5. Parent passes `edge_of` as placement hints; delete **only** the assignment loop (`:1179-1196`),
+   keep `antenna_edge` (`:1176`); add `antenna_frame_mismatch` (test it fires on a constructed
+   divergence); enforce the §4.1 adjacent-corner start-offset in both sizing and `layout_along_edge`.
+6. Add the integration multi-edge gate (§8.2) as a NEW test so the existing single-edge gate keeps
+   guarding the default; opt that new test's board in via its inline `board.yaml`. Resolve the §6
+   horizontal-silk choice (rotate text vs. measured gap) against a real render.
 7. **Eyeball gate** (per the human-rational layout norm): build + render the opted-in board, tune
    `side_silk_gap_mm`, confirm squarer/smaller, terminals oriented outward on side edges, silk
    readable, routes 0-unconnected. Verify the other three goldens are byte-identical.

--- a/docs/SPEC_Post_Placement_Board_Refit.md
+++ b/docs/SPEC_Post_Placement_Board_Refit.md
@@ -1,0 +1,283 @@
+# SPEC — Post-Placement Board Re-Fit (autoplacer RFE)
+
+> **STATUS: COLD-REVIEWED 2026-06-02 (3 fresh-context agents) — findings folded in.** The review
+> caught FOUR mechanism-breaking blockers in the first draft (board-wipe on re-outline, holes not
+> classified as terminals, no `comps` cache, no board backup for the fallback) and corrected an
+> over-optimistic payoff estimate. Changed sections tagged `[CR-fixed]`. Authored against
+> `claude/recursing-kowalevski-365bfb` @ `e27a3b6`. Re-confirm line numbers before editing.
+>
+> **Payoff is partial — decide if it's worth it.** The refit recovers the *sizing over-estimate*
+> only: ≈ `C − measured_cluster` minus routing slack ≈ **~8–12 mm** of height on audio-remote
+> (72 → ~62–64 mm, not the ~55 the draft claimed). The rest of the visible ~21 mm band is
+> structural padding/reserve + the cluster being *placed high* — that latter part is the separate
+> **cluster-centering** nit. Refit + cluster-centering together would close most of the gap; refit
+> alone is a modest ~10–15 % area win. See §1.
+
+## 1. Context & motivation (measured)
+
+The auto-sizer over-estimates the board, leaving an internal empty band. On the audio-remote
+**multi_edge** board (88×72 mm, the best we get today):
+
+- interior cluster (U/R/C parts) actually occupies **y 0–39 mm** (plus the MCU antenna overhanging
+  *above* the top edge);
+- the bottom field-wiring terminal row sits at the bottom edge, **y ~60–72**;
+- → a **~21 mm empty band (y 39–60)** between them.
+
+The placed-content bounding box already fills 0–88 × 0–72 (terminals touch every edge, the cluster
+touches the top), so a **naive crop does nothing** — the waste is *internal*, between the cluster
+(top) and the terminal rows (anchored to the far edges). Single-edge boards have the same vertical
+gap.
+
+**Root cause:** the sizer models the cluster as a **square** `C = max(√(interior_area ·
+routing_factor), max_interior_dim)`, `routing_factor = 2.5` (`_content_aware_size`,
+`pcb_pipeline.py:~419`; mirrored in `_size_from_assignment`, `edge_terminal.py:~325`). For
+audio-remote `C ≈ 50 mm`, but the cluster's *actual placed* height is ~39 mm. The height formula
+reserves the full `C`; edge terminals + corner holes anchor to the over-reserved edges → the gap.
+`routing_factor = 2.5` is deliberately generous for routability, so it cannot be lowered globally.
+
+**Outcome:** measure the cluster *after* placement and re-size+re-place against a board that hugs
+it. `[CR-fixed: realistic estimate]` The recoverable height is bounded by `C − measured_cluster_h`
+(≈ 50 − 39 ≈ 11 mm) MINUS the routing slack added back — so audio-remote ≈ **88×72 → ~88×62–64 mm**
+(~10–15 % area), not the ~55 mm the draft over-claimed. The residual gap is structural
+(padding + corner reserve between cluster and terminal band) plus the cluster being placed high
+(the separate cluster-centering nit). The exact figure is **measured at the eyeball gate** (§12).
+Helps single_edge boards equally.
+
+## 2. Settled decisions
+
+- **D1 — Opt-in flag, default OFF.** New `board.yaml board_refit: true|false`, default `false`
+  (resolved exactly like `terminal_distribution`). Re-fit moves *every auto-sized board's*
+  dimensions, which would force re-baselining every integration dimension-window at once; a flag
+  lets the audio-remote tests opt in and pin the new tighter windows while the other three goldens
+  stay **byte-identical** (flag off → no second pass → zero diff). Flipping the default ON later is
+  a *separate, deliberate* change with its own window re-baseline (the no-op guard, §3, already
+  makes a future flip safe for already-tight boards). Matches the multi-edge precedent.
+- **D2 — Re-fit only when `auto_sized`.** Never re-fit a board the user/intent dimensioned (they
+  may have sized it for an enclosure). `_resolve_board_size` already says when dims came from the
+  user vs auto.
+- **D3 — Spec-then-cold-review**, no implementation in the authoring session.
+
+## 3. Architecture — two-pass (chosen over crop-and-translate)
+
+**Why not crop-and-translate.** Every downstream position is *derived from* the board dims, not
+stored independently: edge terminals via `layout_along_edge` anchored to
+`GetBoardEdgesBoundingBox()`; corner holes at the bbox corners; the antenna overhang relative to
+the board edge; silk offsets keyed off `terminal_edges` + board size. Translating would have to
+re-derive all four by hand (and re-run per-edge layout anyway, since a shrunk along-axis may
+overflow a side) — i.e. re-implement the placement engine's invariants in a second, untested
+location. Two-pass instead reuses `_step_smart_placement` **verbatim** for pass 2, so every
+invariant the integration gates assert (pads-on-board, antenna overhang, holes-at-corners, natural
+order, wire-entry-outward, silk-clear) is re-established by the *same* engine on the *final*
+outline; routing then runs once, on that outline.
+
+**Sequence** (in `build_pcb_from_schematic`, between smart_placement and the `terminal_edges`
+extraction):
+
+1. **Pass 1** — create+outline → holes → load → nets → merge hints → smart_placement, exactly as
+   today. **Capture `auto_sized = step.get("auto_sized")`** into a local var (today it's only read
+   for a warning and dropped — `[CR-fixed]`); re-fit needs it for D2. Also have pass-1's
+   `_estimate_board_size` **return `comps`** (the measured footprint list) so pass 2 can reuse it
+   without re-running the bridge script — `[CR-fixed: the function doesn't expose comps today; add
+   it to the return dict and thread it through `_step_create_pcb_and_outline`'s result]`.
+2. **Measure** — new `_step_measure_cluster(pcb_path, edge_placed_refs)`: union the body bboxes
+   (reuse `BODY_EXTENT_HELPER`/`body_bbox`, antenna keepout excluded) of the footprints that are
+   the **interior cluster** → `cluster_w × cluster_h`. `[CR-fixed: define "cluster" by EXCLUSION,
+   not by is_terminal]` Exclude (a) the **edge-placed terminals** — pass the set of refs that got a
+   `rotation_chosen` edge from pass-1's `placement_decisions`, NOT a designator-class test; and
+   (b) **mounting holes** — `_ref_class(ref) == "H"` explicitly (H is NOT in
+   `_EDGE_DESIGNATOR_CLASSES`, so an `is_terminal` filter would wrongly KEEP the corner holes and
+   inflate the bbox to the full board → the no-op guard fires → feature silently does nothing).
+   Everything else is cluster — crucially this **INCLUDES interior module headers** (J6 the OLED,
+   `edge:"none"`, spiral-placed inside the cluster): they're `is_terminal=True` for sizing but
+   physically sit in the cluster, so the measure must count them or it under-sizes.
+3. **Recompute dims** — call `_estimate_board_size(cluster_wh=(cluster_w, cluster_h), comps=<pass-1
+   comps>)` (§4); with `comps` supplied it SKIPS the bridge script and reuses the cached terminal
+   `w/h` + `antenna_side`. **No-op guard:** if the new dims aren't meaningfully smaller (within
+   ~1 mm on both axes), **skip re-fit** — board unchanged, no second pass (declines on already-tight
+   boards, protecting the other goldens even with the flag on).
+4. **Pass 2** (only if smaller) — `[CR-fixed: DO NOT reuse `_step_create_pcb_and_outline` — its
+   first sub-script calls `CreateEmptyBoard()` and WIPES all footprints+nets]`. First
+   **`shutil.copy2(pcb_path, pcb_path + ".pass1")`** (the fallback backup, §5). Then a NEW
+   **`_step_redraw_outline(pcb_path, w, h)`** that runs ONLY the Edge.Cuts removal+redraw sub-script
+   (the second half of `_step_create_pcb_and_outline`, via `LoadBoard` — never `CreateEmptyBoard`),
+   so placed footprints/nets survive. Then **re-place holes** (§6). Then re-run
+   `_step_smart_placement` against the tighter board with fresh `edge_of` hints from the pass-2
+   `distribute_terminals`. Footprints persist (placement only `SetPosition`s them), so
+   load/nets need NOT repeat.
+5. **Fit-fallback guard** — restore pass-1 (copy `pcb_path + ".pass1"` back) and record an event if
+   pass-2 reports ANY of: non-empty `failed_placements`, a `terminal_edge_crowded` event, or a
+   `keepout_fallback_interior` event (the MCU dropped to the interior → antenna no longer overhangs)
+   — `[CR-fixed: failed_placements alone misses these soft regressions]`. This makes re-fit
+   **monotone FOR PLACEMENT** — it never ships a board that doesn't seat. `[CR-fixed: it does NOT
+   guarantee routing]` — pass-2 routing completeness is gated only by the integration test (§9-A3),
+   so the "monotone" claim is placement-only.
+
+The existing `terminal_edges` extraction, `antenna_frame_mismatch` guard, silk, and autoroute then
+run on whichever board won (they read from `step["placement_decisions"]`). **GND copper zones must
+not be added before pass 2** (they'd be silently dropped by the autoroute DSN export anyway; zones
+already run after autoroute, so this holds — `[CR-noted]`).
+
+## 4. The `cluster_wh` override (size-formula feedback)
+
+The cluster term lives in two places that must stay consistent: `_content_aware_size`
+(`pcb_pipeline.py:~444`) and `_size_from_assignment` (`edge_terminal.py:~337`) — both model the
+cluster as a square `C`. The measured cluster is a **rectangle**.
+
+- **`_size_from_assignment`** (`edge_terminal.py:~325`): add `cluster_wh: Optional[tuple] = None`.
+  When set, replace the square with axis-specific values in the canonical ALONG/CROSS frame:
+  ```
+  along_cluster, cross_cluster = (cluster_w, cluster_h) if horizontal else (cluster_h, cluster_w)
+  along_dim = max(along_cluster, _along(p_ts)) + d_a + d_b + 2·padding + 2·corner_inset
+  cross_dim = max(cross_cluster, _along(a_ts), _along(b_ts)) + d_p + 2·padding + 2·cross_corner
+  ```
+  Keep the `max(cluster_dim, max_interior)` floor. **`cluster_wh is None` ⇒ the square-`C` path is
+  byte-identical to today** (the regression lock — assert it).
+- **`distribute_terminals`** (`edge_terminal.py:~368`): add `cluster_wh=None`, thread into the
+  `_size` closure.
+- **`_estimate_board_size`** (`pcb_pipeline.py:~466`): add `cluster_wh=None` AND `comps=None`. When
+  `comps` is supplied (pass 2), **skip the bridge measurement script entirely** and use those
+  cached comps; pass `cluster_wh` into `distribute_terminals`. Pass 1 calls it with neither
+  (byte-identical to today) and now **returns `comps` in its result dict** so the orchestration can
+  hand them to pass 2. `[CR-fixed: the function didn't expose comps; this is the plumbing that makes
+  "don't re-run the bridge script" actually possible]`.
+
+**Routing slack — the key tunable.** Do NOT pass the raw measured `cluster_h`: routing still happens
+*inside* the cluster. Inflate the measured dimensions by a modest `cluster_routing_margin_mm` per
+side (new tunable, start generous) — NOT the full 2.5× area factor, since the measured bbox already
+reflects the spacing the placer actually used. The right value is **empirical against the golden
+routing counts** (§9-A3, §10-R1).
+
+## 5. Multi-edge interaction
+
+The sizer is already unified through `distribute_terminals`/`_size_from_assignment`, so the
+`cluster_wh` override feeds **both** modes for free:
+- **single_edge** audio-remote: the gap is the CROSS-axis `cluster` term; measured `cluster_h≈39`
+  replaces `C≈50` → shrinks vertically. Primary target.
+- **multi_edge**: the cluster square over-reserves both axes; measured `cluster_w×cluster_h` tightens
+  both. The peel search re-runs in pass 2 with the measured cluster, so pass-2 `edge_of` may differ
+  (tighter) — consistent end-to-end since pass 2 re-places with the pass-2 hints. **Flag:** the
+  multi-edge dimension-window gate (`max/min < 1.6`, `area < 129·65`) shifts *strictly better*
+  (squarer+smaller) but must be re-validated, not assumed.
+
+## 6. Mounting holes in pass 2
+
+Holes are added *before* placement in pass 1, and their keepout **ZONE** objects are standalone
+`board.Add(z)` rule-areas (NOT footprint children, so they don't move with `SetPosition`). On pass 2,
+naively re-adding holes would duplicate them (H5–H8) and leave stale keepout zones. **Decision:**
+add a small `_step_remove_mounting_holes` (delete `H*` footprints + their rule-area zones) and
+**remove + re-add** via the existing `_step_add_mounting_holes` on the new outline. This keeps holes
+flowing through the single tested code path and avoids stale keepouts. (Do NOT "optimize" this into
+a translate — that reintroduces the stale-zone bug; see §9-A5.)
+
+`[CR-fixed: the keepout zones have NO ref linkage to their H* footprint — they're anonymous
+rule-area ZONEs.]` `_step_remove_mounting_holes` must therefore identify them by type+geometry:
+delete every footprint whose `_ref_class == "H"`, and every **rule-area** zone (`GetIsRuleArea()`)
+whose centre is near a current hole position (or, simpler and robust: delete ALL rule-area zones
+that are NOT the MCU antenna keepout — but the antenna keepout lives on the MCU footprint, not as a
+board-level zone, so "delete all board-level rule-area zones" is in fact safe here; verify no other
+board-level rule-area zones exist before relying on that).
+
+## 7. Opt-in flag plumbing
+
+`board.yaml board_refit: true|false` → `BoardSidecar` field + `_KNOWN_SIDECAR_KEYS` + bool
+validation + `intent.source["board_refit"]` (mirror `terminal_distribution` exactly,
+`sidecar.py`). Read in the orchestration: `_refit = design_intent.source.get("board_refit", False)`;
+attempt re-fit only when `_refit and auto_sized`.
+
+## 8. Tests
+
+### 8.1 Pure (`tests/test_terminal_distribution.py`, `tests/test_board_sizing.py`)
+- **Regression lock (critical):** `_size_from_assignment(cluster_wh=None)` ≡ today's square path,
+  across the existing parametrization — no drift.
+- `cluster_wh=(w,h)` with an oblong cluster shrinks the CROSS dim to a hand-computed value;
+  width within tolerance.
+- Reduction property: audio-remote interior set, `cluster_wh=(measured)` → height strictly below the
+  square-`C` height.
+- Both modes consume `cluster_wh`; multi-edge peel still yields valid per-edge assignments + a
+  smaller board.
+- **No-op guard:** measured cluster ≈ square `C` → recomputed dims within skip tolerance → re-fit
+  declines.
+- The embedded-script **drift test** still passes (`cluster_wh` is parent-side only; the placement
+  helper string is untouched).
+
+### 8.2 Integration (`tests/integration/test_firmware_pcb_pipeline.py`)
+New `board_refit: true` audio-remote variant (mirror the multi-edge test):
+- board shrinks (new `bh` strictly below the pass-1 height; area below pass-1);
+- **still routes** within `_assert_mostly_routed(max_unrouted=…)` — the key empirical check that
+  slack tuning didn't starve routing;
+- terminals still on their assigned edges, natural order, wire-entry **outward**;
+- `_refs_with_pads_off_board` empty (rotation-sign invariant on the new outline);
+- the MCU still in `_refs_with_keepout_overhang` (antenna overhangs the *new* edge);
+- exactly **4** holes, at the *new* corners (no H5–H8 — pins §6);
+- silk legends added, `_op_check_silkscreen_overlaps` clear of pads;
+- `failed_placements` empty (fit guard held);
+- a synthetic already-tight board → re-fit declines (dims == flag-off).
+- **Regression:** the three non-audio-remote goldens with the flag absent are byte-identical.
+
+## 9. External-system assumptions — REVIEW FIRST (highest severity)
+
+- **A1 — Re-drawing Edge.Cuts mid-pipeline `[CR-fixed: the draft said "reuse
+  _step_create_pcb_and_outline" — that calls `CreateEmptyBoard()` FIRST and WIPES the board]`.**
+  Pass 2 must use the NEW `_step_redraw_outline` (the Edge.Cuts removal+redraw via `LoadBoard`
+  only). Verified-OK: that sub-script touches only drawings (footprint positions/nets intact), and
+  each pcbnew sub-script `LoadBoard`s fresh so the pass-2 placement script sees the NEW outline via
+  `GetBoardEdgesBoundingBox()`. Confirm `_step_redraw_outline` never calls `CreateEmptyBoard`.
+- **A2 — Moving placed footprints in pass 2.** Assumes `SetPosition`/`SetOrientationDegrees` on
+  net-assigned footprints preserves pad-net connectivity (nets live on pads, independent of
+  position) — pass 2 runs after nets are assigned, so routing sees the same netlist.
+- **A3 — FreeRouter on the smaller outline (HIGHEST RISK).** Routing runs once, on the final
+  (smaller) board. A too-aggressive shrink starves routing. The slack margin + `failed_placements`
+  fallback guard *placement* fit, NOT routing completeness — only the integration gate catches a
+  routing regression. **Run the audio-remote build several times (FreeRouter is stochastic) when
+  tuning the slack**; bump passes, never loosen the unconnected bound.
+- **A4 — Antenna keepout DRC-clean overhanging the NEW edge.** The MCU keepout must overhang the
+  closer edge cleanly with no new collision on the tighter board. Gated by
+  `_refs_with_keepout_overhang` + `failed_placements`, but **DRC isn't in the gate** — manual DRC
+  spot-check on the re-fit audio-remote during bring-up.
+- **A5 — Hole keepout zones are ZONEs, not moved by `SetPosition`.** The §6 remove+re-add avoids
+  stale zones; flag so a reviewer doesn't refactor it into a translate.
+- **A6 — Autoroute DSN export preserves rule-area zones `[CR-added]`.** `_export_dsn`
+  (`pcb_autoroute.py:~178`) removes only non-rule-area (copper pour) zones; the mounting-hole
+  keepouts (rule-area) survive into the DSN so FreeRouter routes around them. The refit relies on
+  this (re-added hole keepouts must still be honored). Currently true but unnamed/un-tested — add a
+  test that rule-area zones survive the DSN export, so a future "remove all zones" change can't
+  silently let routing cross the hole keepouts.
+
+## 10. Open design questions
+
+- **R1 — `cluster_routing_margin_mm`** (the routing slack on the measured cluster): empirical,
+  per-golden, gates on routing completeness the unit tests can't cover. Start generous, tighten.
+- **R2 — Default off now; flip to default-on later?** Recommend off; flipping is a separate
+  window-rebaseline change.
+- **R3 — Pass-2 placement non-determinism.** Placement is connectivity-driven and not guaranteed
+  identical between passes; the fit-fallback makes it *safe* (never ships under-fit) but means
+  re-fit occasionally *declines*. Confirm decline-silently is the desired UX vs. erroring.
+
+## 11. Critical files (@ `e27a3b6`)
+
+| File | Change |
+|---|---|
+| `src/kicad_mcp/tools/pcb_pipeline.py` | new `_step_measure_cluster(pcb_path, edge_placed_refs)`, `_step_redraw_outline(pcb_path,w,h)` (Edge.Cuts-only, NO `CreateEmptyBoard`), `_step_remove_mounting_holes`; `_estimate_board_size` gains `cluster_wh`+`comps` AND returns `comps` (:~466); the pass-2 block + backup/restore + fit-fallback in `build_pcb_from_schematic` (~2125→2150); capture `auto_sized`; `board_refit` resolve (next to `terminal_distribution` :~2048) |
+| `src/kicad_mcp/utils/placement/edge_terminal.py` | `cluster_wh` override in `_size_from_assignment` (:~325) + `distribute_terminals` (:~368) |
+| `src/kicad_mcp/utils/firmware/sidecar.py` | `board_refit` bool field + `_KNOWN_SIDECAR_KEYS` + validation + `intent.source` |
+| `tests/test_terminal_distribution.py`, `tests/test_board_sizing.py` | `cluster_wh` math + regression-lock no-drift (§8.1) |
+| `tests/integration/test_firmware_pcb_pipeline.py` | `board_refit: true` gate + window re-baseline (§8.2) |
+| audio-remote inline `board.yaml` (test, `:424`) | `board_refit: true` (a new test variant; keep the existing ones for the no-refit default) |
+
+## 12. Implementation order (post-review)
+
+1. `cluster_wh` override in `_size_from_assignment`/`distribute_terminals` + pure tests incl. the
+   `cluster_wh=None` regression lock (no behaviour change yet).
+2. `_estimate_board_size(cluster_wh=…, comps=…)` consuming it (skip-measure when comps supplied) AND
+   returning `comps`; thread comps out through `_step_create_pcb_and_outline`'s result.
+3. `_step_redraw_outline` (Edge.Cuts-only), `_step_measure_cluster(edge_placed_refs, exclude H*,
+   include interior J6)`, `_step_remove_mounting_holes`.
+4. Pass-2 block in the orchestration: capture `auto_sized`; backup (`shutil.copy2 …".pass1"`);
+   no-op guard; fit-fallback on `failed_placements ∪ terminal_edge_crowded ∪
+   keepout_fallback_interior`; the `board_refit` flag through sidecar→intent.
+5. Integration gate + opt audio-remote variant in; re-baseline the multi-edge/refit dimension
+   windows; add the rule-area-survives-DSN test (A6).
+6. **Eyeball + DRC gate:** build+render the re-fit audio-remote, tune `cluster_routing_margin_mm`,
+   confirm the gap closes, routes 0–few unconnected across several FreeRouter runs, antenna still
+   overhangs, holes at new corners, silk clear, DRC clean. Verify the other three goldens
+   byte-identical.

--- a/docs/SPEC_Post_Placement_Board_Refit.md
+++ b/docs/SPEC_Post_Placement_Board_Refit.md
@@ -1,17 +1,24 @@
-# SPEC — Post-Placement Board Re-Fit (autoplacer RFE)
+# SPEC — Board Re-Fit + Terminal Centering (autoplacer RFE)
 
-> **STATUS: COLD-REVIEWED 2026-06-02 (3 fresh-context agents) — findings folded in.** The review
-> caught FOUR mechanism-breaking blockers in the first draft (board-wipe on re-outline, holes not
-> classified as terminals, no `comps` cache, no board backup for the fallback) and corrected an
-> over-optimistic payoff estimate. Changed sections tagged `[CR-fixed]`. Authored against
-> `claude/recursing-kowalevski-365bfb` @ `e27a3b6`. Re-confirm line numbers before editing.
+> **TWO independent, composing features** that together tighten + balance the auto-placed board:
+> **Part A — Board Re-Fit** (size the board to the *measured* cluster, not the over-estimate) and
+> **Part B — Terminal Centering** (center each edge's terminal group instead of packing it at one
+> end). Audio-remote opts into both. **BOTH COLD-REVIEWED** (Part A: 3 agents, 4 blockers; Part B:
+> 2 agents, 2 blockers — extend the drift test to cover `anchor="center"`, and don't claim to fix
+> the pre-existing §4.1 layout gap). All `[CR-fixed]` inline.
 >
-> **Payoff is partial — decide if it's worth it.** The refit recovers the *sizing over-estimate*
-> only: ≈ `C − measured_cluster` minus routing slack ≈ **~8–12 mm** of height on audio-remote
-> (72 → ~62–64 mm, not the ~55 the draft claimed). The rest of the visible ~21 mm band is
-> structural padding/reserve + the cluster being *placed high* — that latter part is the separate
-> **cluster-centering** nit. Refit + cluster-centering together would close most of the gap; refit
-> alone is a modest ~10–15 % area win. See §1.
+> Authored against `claude/recursing-kowalevski-365bfb` @ `e27a3b6` (multi-edge, just shipped).
+> Re-confirm line numbers before editing.
+>
+> **Why both — neither alone closes the gap.** *Cluster-centering is NOT viable*: the MCU antenna
+> keepout overhangs the top edge by design, pinning the cluster there — moving it down un-overhangs
+> the antenna. So the gap is attacked two other ways: **Re-fit** recovers the *sizing over-estimate*
+> (≈ `C − measured_cluster` − routing slack ≈ ~8–12 mm height on audio-remote, 72 → ~62–64 mm,
+> ~10–15 % area). **Terminal-centering** does NOT shrink the board — it fixes the *look*: today
+> terminals pack at one end of their edge (bottom row left-packed, side terminals top-packed),
+> leaving the far ends empty; centering fills the edges symmetrically. Together: a tighter board
+> that also reads as balanced. The residual ~9 mm reserve gap (routing margin + corner-hole inset
+> between cluster and terminal band) is structural and not recoverable without routing risk.
 
 ## 1. Context & motivation (measured)
 
@@ -281,3 +288,108 @@ New `board_refit: true` audio-remote variant (mirror the multi-edge test):
    confirm the gap closes, routes 0–few unconnected across several FreeRouter runs, antenna still
    overhangs, holes at new corners, silk clear, DRC clean. Verify the other three goldens
    byte-identical.
+
+---
+
+# PART B — Terminal Centering (NEW — needs cold review)
+
+## 13. Terminal centering
+
+**Problem.** `layout_along_edge` (`edge_terminal.py:218`) anchors the cursor at `edge_start +
+margin` and packs terminals from the START of each edge, so a group shorter than the edge leaves
+the FAR end empty: on audio-remote the bottom row (J1–J3) is left-packed and the side terminals
+(J4/J5 left, J7 right) are top-packed. The board reads as lopsided even when correctly sized. This
+is a **layout-quality / balance** change — it does NOT shrink the board (the edge length is fixed by
+sizing; centering only repositions the group within it).
+
+### 13.1 Design — `anchor="center"` in `layout_along_edge`
+Add an `anchor: str = "start"` parameter (values `"start"` | `"center"`). `"start"` is today's
+behaviour byte-for-byte (the regression lock). `"center"` works ENTIRELY within the `board_box`
+`layout_along_edge` already receives — `[CR-fixed: the hole corner-clear is ALREADY baked into that
+box by the caller (`lay_box = board ± corner_clear`, pcb_pipeline.py:~1293); centring must NOT
+re-apply a corner offset — it uses the span as handed in]`:
+```
+edge_lo = board_box edge-start + margin        # exactly today's start cursor
+edge_hi = board_box edge-end   − margin        # exactly today's `fits` limit
+usable  = edge_hi − edge_lo                     # SCALAR span (CR-fixed: not len() of a 2-list)
+total   = Σ items' along-extent + spacing·(n−1)
+cursor0 = edge_lo + max(0, (usable − total) / 2)    # centre the group within usable
+```
+then advance exactly as today (`cursor += along-extent + spacing`). **Only the along-axis START
+moves**; cross-axis anchoring (overhang pad-inside / body-outside), rotation, order, and the `fits`
+overflow check are untouched. If `total > usable` (won't fit centred), `max(0,…)` keeps `cursor0 =
+edge_lo` → falls back to start (never a negative offset, never past a corner).
+
+`[CR-noted — PRE-EXISTING gap, NOT introduced by centring, NOT in this spec's scope]:` the multi-edge
+**§4.1 adjacent-edge band** (a side terminal must clear the bottom band's depth at a shared corner)
+is reserved in SIZING but is NOT yet enforced in `layout_along_edge` — `lay_box` insets only by the
+hole `corner_clear` (~6.6 mm), not `max(corner_clear, depth(F)+spacing)`. This affects START anchoring
+identically (both start at `edge_lo`), so centring neither causes nor cures it; on audio-remote the
+side group has ~4.9 mm of slack so no overlap manifests. Fixing it (pre-adjust `lay_box` per shared
+corner, or pass adjacent-band depths into `layout_along_edge`) is a separate follow-up — see
+`SPEC_Multi_Edge_Terminal_Distribution.md` step 5. **Centring composes with whatever `lay_box` it is
+handed**, so it picks up that fix for free once landed.
+
+### 13.2 Composition with re-fit + multi-edge
+Orthogonal. Centering is a pure repositioning inside `_step_smart_placement`'s edge layout; it runs
+in BOTH passes of a re-fit (pass 2 centres on the tighter edges) and on every used edge of a
+multi-edge board (each of bottom/left/right is centred independently within its `lay_box`). No
+interaction with `cluster_wh` sizing. The only data dependency is the `lay_box` corner inset, which
+the caller computes per-edge (and, once the §4.1 follow-up lands, per pass-2 `edge_of`).
+
+### 13.3 Flag
+`board.yaml terminal_centering: true|false`, default `false` (mirror `terminal_distribution` /
+`board_refit`: field + `_KNOWN_SIDECAR_KEYS` + bool validation + `intent.source`). Read in the
+orchestration and threaded to `_step_smart_placement` → `layout_along_edge(anchor=…)`. **Default-off
+rationale:** centering repositions terminals on EVERY board, which changes FreeRouter's net topology
+(stochastic) and could nudge a golden over its unrouted bound — so opt-in keeps the other three
+goldens' routing untouched, even though the position checks (edge membership, natural order,
+wire-entry outward, pads-on-board, silk-clear) would all still pass (they don't assert exact x/y).
+Audio-remote opts into `board_refit` AND `terminal_centering`. *(Open: could be merged with
+`board_refit` into one "tidy board" flag — see §15-R4.)*
+
+### 13.4 Tests
+- **Pure** (`tests/test_edge_terminal_placement.py`): `anchor="start"` ≡ today (regression lock,
+  parametrize existing `layout_along_edge` tests). `anchor="center"`: a short group on a long edge
+  gets equal margins both ends; a group that exactly fills the edge is unchanged; an over-long group
+  falls back to start (no negative offset, no corner overlap).
+- **Drift test MUST be EXTENDED to exercise `anchor="center"`** `[CR-fixed: BLOCKER — the existing
+  drift test (`test_edge_terminal_placement.py:~367`) calls `layout_along_edge` with NO `anchor`, so
+  it runs only the default `"start"` path and would NOT catch a centring bug present in only ONE
+  copy. Add an `anchor="center"` case to the exec-compare so a helper-string-only divergence is
+  caught at unit time, not just at the integration test.]`
+- **Integration** (`tests/integration/test_firmware_pcb_pipeline.py`, the `terminal_centering: true`
+  variant): each used edge's terminal group is centred (group centre within ~margin of the edge
+  centre, between the corner reserves); terminals still on their edges, natural order, wire-entry
+  outward, pads-on-board, silk clear; still routes within `_assert_mostly_routed`. The three other
+  goldens with the flag absent are byte-identical.
+
+### 13.5 External-system assumptions (Part B)
+- **B1 — `layout_along_edge` is in `EDGE_TERMINAL_HELPER`** (the injected pcbnew-script string), so
+  the `anchor` param + centring logic must be added to BOTH copies (Python `:218` + helper string
+  `:549`). `[CR-fixed: the drift test does NOT currently guard this — it must be extended to pass
+  `anchor="center"` (§13.4); without that, a half-updated helper surfaces only as a `TypeError` at
+  integration time.]` HIGHEST Part-B risk. (Re-fit's `cluster_wh` was parent-side only; centering
+  runs INSIDE the placement script, hence the two-copy exposure.)
+- **B2 — Repositioning changes FreeRouter topology** (stochastic) — only the integration routing
+  gate catches a regression; run the build several times when validating. Same class as re-fit A3.
+
+## 14. Critical files (Part B, @ `e27a3b6`)
+
+| File | Change |
+|---|---|
+| `src/kicad_mcp/utils/placement/edge_terminal.py` | `anchor` param + centring in `layout_along_edge` (`:218`) AND in the `EDGE_TERMINAL_HELPER` string copy (`:549`, the helper assignment is at `:444`) — keep them drift-identical |
+| `src/kicad_mcp/tools/pcb_pipeline.py` | `[CR-fixed: name the plumbing]` add `anchor` param to `_step_smart_placement` (`:~790`) → put it in the `run_pcbnew_script(params={…})` dict (`:~1444`, exactly how `corner_clear_mm` flows) → embedded script reads `params.get("anchor","start")` and passes it to the `layout_along_edge` call (`:~1298`); orchestration resolves `terminal_centering` from `design_intent.source` next to `board_refit` and passes `anchor="center" if _tc else "start"` |
+| `src/kicad_mcp/utils/firmware/sidecar.py` | `terminal_centering` bool field + `_KNOWN_SIDECAR_KEYS` + validation + `intent.source` |
+| `tests/test_edge_terminal_placement.py` | `anchor="center"` math + `anchor="start"` regression lock + drift test |
+| `tests/integration/test_firmware_pcb_pipeline.py` | `terminal_centering: true` gate |
+
+## 15. Combined open questions
+
+- (Part A) R1 `cluster_routing_margin_mm`; R2 default-on later; R3 pass-2 non-determinism (above).
+- **R4 — One flag or two?** `board_refit` + `terminal_centering` are orthogonal and independently
+  testable, but a user wanting a "tidy compact board" must set both. Consider a single
+  `compact_layout: true` umbrella, or keep them separate. Cold reviewer / Brian to decide.
+- **R5 — Order of implementation.** Part B (centering) is smaller, lower-risk, and independently
+  shippable — recommend doing it FIRST (it's a contained `layout_along_edge` change with no
+  two-pass/routing-shrink risk), then Part A (re-fit). They compose regardless of order.

--- a/docs/SPEC_Post_Placement_Board_Refit.md
+++ b/docs/SPEC_Post_Placement_Board_Refit.md
@@ -1,5 +1,38 @@
 # SPEC — Board Re-Fit + Terminal Centering (autoplacer RFE)
 
+> ## ⚠️ 0. IMPLEMENTATION OUTCOME (2026-06-02) — Part A is a VERIFIED NO-OP on audio-remote
+>
+> Part A shipped (opt-in `board_refit`, default off) and is **correct + safe**, but the real-KiCad
+> eyeball gate (§12 step 6) showed the **motivating measurement in §1 was wrong**, so the size win
+> does not materialize on audio-remote:
+>
+> | quantity | §1 ASSUMED | **MEASURED** |
+> |---|---|---|
+> | square-cluster estimate `C` = √(area·2.5) | ~50 mm | **~42 mm** |
+> | actual placed cluster height | ~39 mm | **37.9 mm** ✓ |
+> | recoverable over-estimate (`C − cluster`) | ~8–12 mm | **~4 mm** |
+>
+> And that ~4 mm is **not free** — it is the slack the bottom terminal band needs. Empirically, across
+> the whole margin range: margin ≥ 2 mm → recomputed board ≥ original → **no-op guard declines**;
+> margin 0–1 mm → 2–4 mm tighter → pass-2 placement trips **`terminal_edge_crowded`** → **fit-fallback
+> reverts**. *No margin value yields a smaller, seating board.* The board was already minimal for its
+> terminals + corner holes; the "21 mm empty band" of §1 is **structural** (corner-hole reserve +
+> terminal depth + padding), not a recoverable cluster over-estimate.
+>
+> **Decision (Brian):** KEEP Part A — the mechanism is sound and would help a *denser-interior /
+> lighter-terminal* board where `C` genuinely over-estimates; on the current goldens it correctly
+> declines and ships a byte-identical board. The integration test
+> (`test_audio_remote_board_refit`) forces the pass-2 path (margin→0) and pins the **safety contract**
+> (every bridge step runs clean; fallback restores a valid routed board), NOT a shrink. Default margin
+> `_CLUSTER_ROUTING_MARGIN_MM = 2.0` (clean-decline on the goldens).
+>
+> A real bug was found + fixed en route: `_step_remove_mounting_holes` crashed on
+> `list(board.Zones())` (SWIG yields raw pointers) — fixed to the collect-then-remove pattern that
+> `pcb_autoroute._export_dsn` uses.
+>
+> Everything below is the original spec, preserved for the design rationale. Read §1's numbers as the
+> (wrong) hypothesis that motivated the work, corrected by this section.
+
 > **TWO independent, composing features** that together tighten + balance the auto-placed board:
 > **Part A — Board Re-Fit** (size the board to the *measured* cluster, not the over-estimate) and
 > **Part B — Terminal Centering** (center each edge's terminal group instead of packing it at one

--- a/src/kicad_mcp/tools/pcb_pipeline.py
+++ b/src/kicad_mcp/tools/pcb_pipeline.py
@@ -322,7 +322,7 @@ _HOLE_DEFAULTS = {"count": 4, "drill_mm": 3.2, "inset_mm": 3.5, "keepout_mm": 1.
 # routing channels at the cluster boundary. Empirical — tuned against the golden
 # routing counts at the eyeball/integration gate; bump it (less shrink) if routing
 # starves, never loosen the unrouted bound.
-_CLUSTER_ROUTING_MARGIN_MM = 3.0
+_CLUSTER_ROUTING_MARGIN_MM = 2.0
 
 
 class _RefitDecline(Exception):
@@ -554,19 +554,26 @@ def _ref_class(ref):
             return ref[:i]
     return ref
 
-removed_fps = []
-for fp in list(board.GetFootprints()):
+# Collect-then-remove (a SWIG container must NOT be mutated while iterating, and
+# wrapping it in list() yields raw SwigPyObjects with no typed methods — so iterate
+# cleanly first, gather, then Remove). Mirrors pcb_autoroute._export_dsn's zone loop.
+fps_to_remove = []
+for fp in board.GetFootprints():
     if _ref_class(fp.GetReference()) == "H":
-        removed_fps.append(fp.GetReference())
-        board.Remove(fp)
+        fps_to_remove.append(fp)
+removed_fps = [fp.GetReference() for fp in fps_to_remove]
+for fp in fps_to_remove:
+    board.Remove(fp)
 
 # Anonymous board-level rule-area keepouts (the hole keepouts). The antenna keepout
 # is a FOOTPRINT child zone, not board-level, so it is untouched here.
-removed_zones = 0
-for z in list(board.Zones()):
+zones_to_remove = []
+for z in board.Zones():
     if z.GetIsRuleArea():
-        board.Remove(z)
-        removed_zones += 1
+        zones_to_remove.append(z)
+removed_zones = len(zones_to_remove)
+for z in zones_to_remove:
+    board.Remove(z)
 
 board.Save(params["pcb_path"])
 print(json.dumps({"status": "ok", "removed_footprints": removed_fps,
@@ -2331,6 +2338,7 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
         if _refit and auto_sized and measured_comps:
             _backup = pcb_path + ".pass1"
             _old_w, _old_h = actual_width, actual_height
+            _refit_tel: Dict[str, Any] = {}   # telemetry, merged into every outcome
             try:
                 # Cluster = everything NOT edge-placed and NOT a mounting hole (§2:
                 # includes interior J6, excludes H* + the edge-anchored terminals).
@@ -2353,6 +2361,14 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
                     raise _RefitDecline("re-estimate failed: %s" % _resize.get("error"))
                 _new_w = _resize["size"]["width_mm"]
                 _new_h = _resize["size"]["height_mm"]
+                # Telemetry (data-capture rule: never drop the measurement) — merged
+                # into EVERY outcome record so a decline is diagnosable without a rebuild.
+                _refit_tel = {
+                    "cluster_w": _cw, "cluster_h": _ch, "margin_mm": _m,
+                    "from_width_mm": _old_w, "from_height_mm": _old_h,
+                    "recomputed_width_mm": _new_w, "recomputed_height_mm": _new_h,
+                    "recomputed_edge_of": _resize.get("edge_of"),
+                }
                 # No-op guard: meaningfully smaller on ≥1 axis, growing on neither.
                 _TOL = 1.0
                 _dw, _dh = _old_w - _new_w, _old_h - _new_h
@@ -2399,6 +2415,7 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
 
                 # Pass 2 won — adopt its board, dims, holes, placement, hints.
                 step = _step2
+                _record("smart_placement", _step2)   # returned telemetry = shipped board
                 actual_width, actual_height = _new_w, _new_h
                 hole_positions = _hole_positions2
                 clean_hints, hint_warnings = _clean2, _warns2
@@ -2416,7 +2433,8 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
                 except OSError:
                     pass
             except _RefitDecline as _decl:
-                _record("board_refit", {"status": "declined", "reason": str(_decl)})
+                _record("board_refit", {"status": "declined",
+                                        "reason": str(_decl), **_refit_tel})
             except Exception as _f:  # noqa: BLE001 — re-fit is an optimization, never fatal
                 # Restore the pass-1 board if we had committed, so disk matches `step`.
                 try:

--- a/src/kicad_mcp/tools/pcb_pipeline.py
+++ b/src/kicad_mcp/tools/pcb_pipeline.py
@@ -19,7 +19,11 @@ from kicad_mcp.utils.kicad_cli import KiCadCLIError, get_kicad_cli_path
 from kicad_mcp.utils.net_injection import existing_net_codes, inject_net_definitions
 from kicad_mcp.utils.netlist_parser import POWER_NET_HELPER, extract_netlist_via_cli
 from kicad_mcp.utils.pcbnew_bridge import run_pcbnew_script
-from kicad_mcp.utils.placement.edge_terminal import EDGE_TERMINAL_HELPER, normalize_hint
+from kicad_mcp.utils.placement.edge_terminal import (
+    EDGE_TERMINAL_HELPER,
+    distribute_terminals,
+    normalize_hint,
+)
 from kicad_mcp.utils.placement.wire_entry import WIRE_ENTRY, WIRE_ENTRY_HELPER
 
 logger = logging.getLogger(__name__)
@@ -171,15 +175,21 @@ def _step_create_pcb_and_outline(
     height_mm: float,
     components: Dict[str, Dict],
     holes: Optional[Dict[str, Any]] = None,
+    terminal_distribution: str = "single_edge",
 ) -> Dict[str, Any]:
     """Step 2: Create PCB file and add board outline.
 
     If width/height are 0, auto-estimates from component footprints. When
     ``holes`` requests corner mounting holes, the estimate reserves a
     per-side inset so the holes don't crowd the content (spec §3 / Phase 5).
+    ``terminal_distribution`` ("single_edge"/"multi_edge") chooses whether the
+    auto-size spreads field terminals across the side edges; the resulting
+    per-terminal ``edge_of`` is returned for the caller to feed to placement.
     """
     # Build footprint list for size estimation if needed
     auto_sized = False
+    edge_of: Dict[str, str] = {}
+    antenna_side: Optional[str] = None
     if width_mm <= 0 or height_mm <= 0:
         fp_specs = []
         for ref, info in components.items():
@@ -197,13 +207,16 @@ def _step_create_pcb_and_outline(
         # both axes made the board taller than its content.
         size_result = _estimate_board_size(
             fp_specs, corner_inset_mm=_hole_corner_clear(holes),
-            corner_center_inset_mm=_hole_center_inset(holes))
+            corner_center_inset_mm=_hole_center_inset(holes),
+            terminal_distribution=terminal_distribution)
         if "error" in size_result:
             return size_result
 
         chosen = size_result["size"]   # content-aware (layout fixes the aspect)
         width_mm = chosen["width_mm"]
         height_mm = chosen["height_mm"]
+        edge_of = size_result.get("edge_of", {})        # per-terminal edge → hints
+        antenna_side = size_result.get("antenna_side")  # for the frame-mismatch guard
         auto_sized = True
 
     # Create the PCB file
@@ -270,6 +283,8 @@ print(json.dumps({"status": "ok"}))
         "width_mm": width_mm,
         "height_mm": height_mm,
         "auto_sized": auto_sized,
+        "edge_of": edge_of,          # {} unless auto-sized; multi_edge → spans 2-3 edges
+        "antenna_side": antenna_side,
     }
 
 
@@ -450,7 +465,8 @@ def _content_aware_size(
 
 def _estimate_board_size(
     fp_specs: List[Dict[str, str]], corner_inset_mm: float = 0.0,
-    corner_center_inset_mm: float = 0.0,
+    corner_center_inset_mm: float = 0.0, terminal_distribution: str = "single_edge",
+    side_silk_gap_mm: float = 2.5,
 ) -> Dict[str, Any]:
     """Estimate board dimensions from footprint specs. The bridge script only
     MEASURES (body w/h + whether the ref is an edge terminal); the content-aware
@@ -513,6 +529,7 @@ for spec in fp_specs:
         em = {"left": abs(dxn), "right": abs(dxp), "top": abs(dyn), "bottom": abs(dyp)}
         keepout_side = max(em, key=em.get)
     components.append({"footprint": fp_name, "w": w, "h": h,
+                       "ref": spec.get("ref", ""),
                        "is_terminal": _is_terminal(spec.get("ref", "")),
                        "keepout_side": keepout_side})
 
@@ -525,15 +542,22 @@ print(json.dumps({"components": components, "errors": errors}))
     comps = result.get("components", [])
     if not comps:
         return {"error": "No valid footprints found", "details": result.get("errors", [])}
-    # Terminal edge = opposite the antenna, on the SAME axis. Antenna top/bottom
-    # -> terminals on a horizontal (top/bottom) edge -> they fit along WIDTH.
+    # Distribute terminals across edge(s) — the SINGLE source for BOTH the board
+    # size and the per-terminal edge assignment (single_edge collapses to today's
+    # _content_aware_size; the regression-lock test pins this). The returned
+    # ``edge_of`` is threaded to placement as {"edge": E} hints (parent-side, so it
+    # never re-encodes the rule in the embedded script — Rule 3).
     antenna_side = next((c["keepout_side"] for c in comps if c.get("keepout_side")), None)
-    terminal_edge_horizontal = antenna_side in ("top", "bottom") if antenna_side else True
+    dist = distribute_terminals(
+        comps, antenna_side, mode=terminal_distribution,
+        corner_inset_mm=corner_inset_mm,
+        corner_center_inset_mm=corner_center_inset_mm,
+        side_silk_gap_mm=side_silk_gap_mm)
     return {
         "status": "ok",
-        "size": _content_aware_size(comps, terminal_edge_horizontal,
-                                    corner_inset_mm=corner_inset_mm,
-                                    corner_center_inset_mm=corner_center_inset_mm),
+        "size": dist["size"],
+        "edge_of": dist["edge_of"],
+        "primary_edge": dist["primary_edge"],
         "antenna_side": antenna_side,
         "errors": result.get("errors", []),
         "error_count": len(result.get("errors", [])),
@@ -2016,15 +2040,25 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
                 f"Board sized to {eff_width_mm}x{eff_height_mm}mm from design intent"
             )
 
-        # Step 2: Create PCB + board outline (sizing reserves the hole inset)
+        # Step 2: Create PCB + board outline (sizing reserves the hole inset).
+        # terminal_distribution (board.yaml, default single_edge) decides whether the
+        # auto-size spreads field terminals across the side edges.
+        _term_dist = "single_edge"
+        if design_intent is not None:
+            _term_dist = design_intent.source.get("terminal_distribution", "single_edge")
         step = _step_create_pcb_and_outline(
             pcb_path, eff_width_mm, eff_height_mm, components, holes=holes,
+            terminal_distribution=_term_dist,
         )
         if not _record("create_pcb", step):
             return pipeline_result
 
         actual_width = step["width_mm"]
         actual_height = step["height_mm"]
+        # Per-terminal edge assignment from the distributor (empty unless auto-sized).
+        # Passed to placement as the LOWEST-priority {"edge": E} hints below.
+        terminal_edge_of = step.get("edge_of") or {}
+        antenna_side_est = step.get("antenna_side")
         pipeline_result["board_width_mm"] = actual_width
         pipeline_result["board_height_mm"] = actual_height
         if step.get("auto_sized"):
@@ -2060,11 +2094,18 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
 
         pipeline_result["pads_assigned"] = step.get("pads_assigned", 0)
 
-        # Merge placement hints: intent-carried first, explicit param wins.
-        # normalize_hint (via _merge_placement_hints) is the single validation
-        # source — invalid keys/values are dropped + surfaced, never substituted.
+        # Merge placement hints, lowest → highest priority:
+        #   auto terminal distribution  <  intent-carried  <  explicit param.
+        # The distributor's {ref: edge} is the BASE so an explicit user/intent hint
+        # on a terminal still wins; terminals with no hint fall to the script's
+        # antenna-opposite rule (single_edge boards pass NO distribution hints, so
+        # they stay byte-identical). normalize_hint validates every directive.
+        _dist_hints = {ref: {"edge": e} for ref, e in terminal_edge_of.items()}
+        _base_hints = dict(_dist_hints)
+        if design_intent is not None and design_intent.placement_hints:
+            _base_hints.update(design_intent.placement_hints)
         clean_hints, hint_warnings = _merge_placement_hints(
-            design_intent.placement_hints if design_intent is not None else None,
+            _base_hints,
             placement_hints,
         )
         # Mounting holes are physical fixtures we already placed — pin them at the
@@ -2093,6 +2134,22 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
             for d in (step.get("placement_decisions") or [])
             if d.get("event") == "rotation_chosen" and d.get("edge")
         }
+
+        # antenna_frame_mismatch guard (SPEC §3.1): the distributor assigned side
+        # edges relative to the antenna it derived in the FOOTPRINT 0° frame
+        # (antenna_side_est); the placer overhangs the antenna on some board edge in
+        # the POST-ROTATION frame (the keepout_overhang decision). They agree on
+        # every golden — if they ever diverge the distribution is relative to the
+        # wrong axis, so surface it loudly rather than silently mis-placing.
+        if antenna_side_est:
+            _placed_antenna = next(
+                (d["edge"] for d in (step.get("placement_decisions") or [])
+                 if d.get("event") == "keepout_overhang" and d.get("edge")), None)
+            if _placed_antenna and _placed_antenna != antenna_side_est:
+                pipeline_result.setdefault("warnings", []).append(
+                    f"antenna_frame_mismatch: distributor sized for antenna on "
+                    f"{antenna_side_est!r} but the placer overhung it on "
+                    f"{_placed_antenna!r} — terminal distribution may be off-axis")
 
         def _run_silk_legends() -> None:
             """Silk-legend pass (single source — used by the approval gate AND the

--- a/src/kicad_mcp/tools/pcb_pipeline.py
+++ b/src/kicad_mcp/tools/pcb_pipeline.py
@@ -190,10 +190,14 @@ def _step_create_pcb_and_outline(
         if not fp_specs:
             return {"error": "No footprints to estimate board size from"}
 
-        # Reserve the FULL corner clearance (center inset + keepout), not just the
-        # hole-center inset, so terminals laid out past the corner holes still fit.
+        # Axis-aware corner reservation (RFE #1): the FULL corner clearance along
+        # the terminal edge (so terminals laid out past the corner holes still
+        # fit), but only the hole-CENTER inset on the perpendicular depth axis
+        # (the holes sit in the empty corner columns there) — full clearance on
+        # both axes made the board taller than its content.
         size_result = _estimate_board_size(
-            fp_specs, corner_inset_mm=_hole_corner_clear(holes))
+            fp_specs, corner_inset_mm=_hole_corner_clear(holes),
+            corner_center_inset_mm=_hole_center_inset(holes))
         if "error" in size_result:
             return size_result
 
@@ -298,12 +302,25 @@ def _hole_corner_clear(holes: Optional[Dict[str, Any]]) -> float:
     """Along-edge distance from a board corner that a mounting hole occupies: the
     hole CENTER is ``inset`` in, and its keepout extends ``drill/2 + keepout``
     further, so the corner is occupied out to their sum. 0 when holes are off.
-    SINGLE SOURCE for both board sizing (reserve this much at each corner) and
-    terminal layout (start the run past it) — so the two never disagree and a
-    terminal can't land on a hole."""
+    SINGLE SOURCE for the ALONG-the-terminal-edge sizing reserve (a corner hole
+    eats the seating span) AND terminal layout (start the run past it) — so the
+    two never disagree and a terminal can't land on a hole. The PERPENDICULAR
+    (depth) sizing axis uses :func:`_hole_center_inset` instead (RFE #1)."""
     if not holes or holes.get("count", 0) <= 0:
         return 0.0
     return float(holes["inset_mm"] + holes["drill_mm"] / 2.0 + holes["keepout_mm"])
+
+
+def _hole_center_inset(holes: Optional[Dict[str, Any]]) -> float:
+    """Hole-CENTER inset from each edge — the depth-axis sizing reserve (RFE #1).
+    Perpendicular to the terminal edge the holes sit in the empty corner columns,
+    away from the centered cluster and the terminal band, so only the center inset
+    (not the full keepout clearance :func:`_hole_corner_clear` gives) needs
+    reserving; the full clearance there made the board taller than its content.
+    0 when holes are off (mirrors ``_hole_corner_clear`` so both vanish together)."""
+    if not holes or holes.get("count", 0) <= 0:
+        return 0.0
+    return float(holes["inset_mm"])
 
 
 def _step_add_mounting_holes(pcb_path: str, holes: Dict[str, Any]) -> Dict[str, Any]:
@@ -391,6 +408,7 @@ def _content_aware_size(
     padding: float = 2.0,
     spacing: float = 1.0,
     corner_inset_mm: float = 0.0,
+    corner_center_inset_mm: float = 0.0,
 ) -> Dict[str, Any]:
     """Content-aware board size (spec §4) — pure, unit-tested without KiCad.
 
@@ -413,11 +431,16 @@ def _content_aware_size(
     # Terminals: total span ALONG their shared edge, and their inward DEPTH.
     term_along = sum(max(c["w"], c["h"]) + spacing for c in terminals)
     term_depth = max((min(c["w"], c["h"]) for c in terminals), default=0.0)
-    # Corner mounting holes reserve real estate on every side (a hole sits inset
-    # from each edge with its own keepout), so both dimensions grow by 2×inset.
-    pad2 = 2 * padding + 2 * corner_inset_mm
-    along = max(cluster, term_along) + pad2             # edge must seat all terminals
-    depth = cluster + term_depth + pad2                 # cluster + one terminal band
+    # Corner mounting holes reserve real estate ASYMMETRICALLY (RFE #1). ALONG the
+    # terminal edge a corner hole's full keepout footprint eats into the seating
+    # span, so the edge grows by the FULL corner clearance at each end
+    # (``corner_inset_mm`` = inset + drill/2 + keepout). On the PERPENDICULAR depth
+    # axis the holes sit in the empty corner columns — clear of the centered cluster
+    # and the terminal band — so only the hole-CENTER inset is reserved
+    # (``corner_center_inset_mm`` = inset). Reserving the full clearance on BOTH
+    # axes (the old behaviour) made the board taller than its content needed.
+    along = max(cluster, term_along) + 2 * padding + 2 * corner_inset_mm
+    depth = cluster + term_depth + 2 * padding + 2 * corner_center_inset_mm
     if terminal_edge_horizontal:
         w, h = along, depth
     else:
@@ -427,6 +450,7 @@ def _content_aware_size(
 
 def _estimate_board_size(
     fp_specs: List[Dict[str, str]], corner_inset_mm: float = 0.0,
+    corner_center_inset_mm: float = 0.0,
 ) -> Dict[str, Any]:
     """Estimate board dimensions from footprint specs. The bridge script only
     MEASURES (body w/h + whether the ref is an edge terminal); the content-aware
@@ -508,7 +532,8 @@ print(json.dumps({"components": components, "errors": errors}))
     return {
         "status": "ok",
         "size": _content_aware_size(comps, terminal_edge_horizontal,
-                                    corner_inset_mm=corner_inset_mm),
+                                    corner_inset_mm=corner_inset_mm,
+                                    corner_center_inset_mm=corner_center_inset_mm),
         "antenna_side": antenna_side,
         "errors": result.get("errors", []),
         "error_count": len(result.get("errors", [])),

--- a/src/kicad_mcp/tools/pcb_pipeline.py
+++ b/src/kicad_mcp/tools/pcb_pipeline.py
@@ -4,10 +4,11 @@ import logging
 import math
 import os
 import re
+import shutil
 import subprocess
 import time
 import zipfile
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from fastmcp import FastMCP
 from mcp_events import emit_event, event_context
@@ -169,72 +170,13 @@ def _step_extract_netlist(sch_path: str) -> Dict[str, Any]:
     }
 
 
-def _step_create_pcb_and_outline(
-    pcb_path: str,
-    width_mm: float,
-    height_mm: float,
-    components: Dict[str, Dict],
-    holes: Optional[Dict[str, Any]] = None,
-    terminal_distribution: str = "single_edge",
-) -> Dict[str, Any]:
-    """Step 2: Create PCB file and add board outline.
-
-    If width/height are 0, auto-estimates from component footprints. When
-    ``holes`` requests corner mounting holes, the estimate reserves a
-    per-side inset so the holes don't crowd the content (spec §3 / Phase 5).
-    ``terminal_distribution`` ("single_edge"/"multi_edge") chooses whether the
-    auto-size spreads field terminals across the side edges; the resulting
-    per-terminal ``edge_of`` is returned for the caller to feed to placement.
-    """
-    # Build footprint list for size estimation if needed
-    auto_sized = False
-    edge_of: Dict[str, str] = {}
-    antenna_side: Optional[str] = None
-    if width_mm <= 0 or height_mm <= 0:
-        fp_specs = []
-        for ref, info in components.items():
-            fp_str = info["footprint"]
-            lib, name = fp_str.split(":", 1)
-            fp_specs.append({"library": lib, "footprint_name": name, "ref": ref})
-
-        if not fp_specs:
-            return {"error": "No footprints to estimate board size from"}
-
-        # Axis-aware corner reservation (RFE #1): the FULL corner clearance along
-        # the terminal edge (so terminals laid out past the corner holes still
-        # fit), but only the hole-CENTER inset on the perpendicular depth axis
-        # (the holes sit in the empty corner columns there) — full clearance on
-        # both axes made the board taller than its content.
-        size_result = _estimate_board_size(
-            fp_specs, corner_inset_mm=_hole_corner_clear(holes),
-            corner_center_inset_mm=_hole_center_inset(holes),
-            terminal_distribution=terminal_distribution)
-        if "error" in size_result:
-            return size_result
-
-        chosen = size_result["size"]   # content-aware (layout fixes the aspect)
-        width_mm = chosen["width_mm"]
-        height_mm = chosen["height_mm"]
-        edge_of = size_result.get("edge_of", {})        # per-terminal edge → hints
-        antenna_side = size_result.get("antenna_side")  # for the frame-mismatch guard
-        auto_sized = True
-
-    # Create the PCB file
-    script = """
-import pcbnew, json, sys
-
-params = json.loads(open(sys.argv[1]).read())
-
-board = pcbnew.CreateEmptyBoard()
-board.Save(params["pcb_path"])
-print(json.dumps({"status": "ok"}))
-"""
-    result = run_pcbnew_script(script, params={"pcb_path": pcb_path})
-    if "error" in result:
-        return result
-
-    # Add board outline
-    script = """
+# The Edge.Cuts removal+redraw sub-script — SINGLE SOURCE. Used by pass 1
+# (_step_create_pcb_and_outline, after CreateEmptyBoard) AND by re-fit pass 2
+# (_step_redraw_outline, via LoadBoard with NO CreateEmptyBoard, so the placed
+# footprints + nets survive). It only touches Edge.Cuts drawings — footprint
+# positions and pad nets are untouched. Keeping it in one constant means the two
+# call sites can never drift (Rule 3: one source of truth for the outline geometry).
+_OUTLINE_REDRAW_SCRIPT = """
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
@@ -270,7 +212,78 @@ for i in range(4):
 board.Save(params["pcb_path"])
 print(json.dumps({"status": "ok"}))
 """
-    result = run_pcbnew_script(script, params={
+
+
+def _step_create_pcb_and_outline(
+    pcb_path: str,
+    width_mm: float,
+    height_mm: float,
+    components: Dict[str, Dict],
+    holes: Optional[Dict[str, Any]] = None,
+    terminal_distribution: str = "single_edge",
+) -> Dict[str, Any]:
+    """Step 2: Create PCB file and add board outline.
+
+    If width/height are 0, auto-estimates from component footprints. When
+    ``holes`` requests corner mounting holes, the estimate reserves a
+    per-side inset so the holes don't crowd the content (spec §3 / Phase 5).
+    ``terminal_distribution`` ("single_edge"/"multi_edge") chooses whether the
+    auto-size spreads field terminals across the side edges; the resulting
+    per-terminal ``edge_of`` is returned for the caller to feed to placement.
+    """
+    # Build footprint list for size estimation if needed
+    auto_sized = False
+    edge_of: Dict[str, str] = {}
+    antenna_side: Optional[str] = None
+    measured_comps: List[Dict[str, Any]] = []   # re-fit pass 2 reuses these (§4)
+    if width_mm <= 0 or height_mm <= 0:
+        fp_specs = []
+        for ref, info in components.items():
+            fp_str = info["footprint"]
+            lib, name = fp_str.split(":", 1)
+            fp_specs.append({"library": lib, "footprint_name": name, "ref": ref})
+
+        if not fp_specs:
+            return {"error": "No footprints to estimate board size from"}
+
+        # Axis-aware corner reservation (RFE #1): the FULL corner clearance along
+        # the terminal edge (so terminals laid out past the corner holes still
+        # fit), but only the hole-CENTER inset on the perpendicular depth axis
+        # (the holes sit in the empty corner columns there) — full clearance on
+        # both axes made the board taller than its content.
+        size_result = _estimate_board_size(
+            fp_specs, corner_inset_mm=_hole_corner_clear(holes),
+            corner_center_inset_mm=_hole_center_inset(holes),
+            terminal_distribution=terminal_distribution)
+        if "error" in size_result:
+            return size_result
+
+        chosen = size_result["size"]   # content-aware (layout fixes the aspect)
+        width_mm = chosen["width_mm"]
+        height_mm = chosen["height_mm"]
+        edge_of = size_result.get("edge_of", {})        # per-terminal edge → hints
+        antenna_side = size_result.get("antenna_side")  # for the frame-mismatch guard
+        measured_comps = size_result.get("comps", [])   # cached body w/h for pass 2
+        auto_sized = True
+
+    # Create the PCB file
+    script = """
+import pcbnew, json, sys
+
+params = json.loads(open(sys.argv[1]).read())
+
+board = pcbnew.CreateEmptyBoard()
+board.Save(params["pcb_path"])
+print(json.dumps({"status": "ok"}))
+"""
+    result = run_pcbnew_script(script, params={"pcb_path": pcb_path})
+    if "error" in result:
+        return result
+
+    # Add board outline (Edge.Cuts redraw — SINGLE SOURCE, shared with pass-2
+    # re-fit via _OUTLINE_REDRAW_SCRIPT). Safe here: the board was just created
+    # empty, so there is nothing to preserve.
+    result = run_pcbnew_script(_OUTLINE_REDRAW_SCRIPT, params={
         "pcb_path": pcb_path,
         "width_mm": width_mm,
         "height_mm": height_mm,
@@ -285,6 +298,7 @@ print(json.dumps({"status": "ok"}))
         "auto_sized": auto_sized,
         "edge_of": edge_of,          # {} unless auto-sized; multi_edge → spans 2-3 edges
         "antenna_side": antenna_side,
+        "comps": measured_comps,     # [] unless auto-sized; re-fit pass 2 reuses these
     }
 
 
@@ -301,6 +315,20 @@ _EDGE_DESIGNATOR_CLASSES = ("J", "SW", "USB")
 # Corner mounting-hole defaults (board.yaml `mounting_holes:` overrides these;
 # see sidecar._validate_mounting_holes). count=0 disables holes entirely.
 _HOLE_DEFAULTS = {"count": 4, "drill_mm": 3.2, "inset_mm": 3.5, "keepout_mm": 1.5}
+
+# Board re-fit routing slack (SPEC_Post_Placement_Board_Refit §4 / R1). The measured
+# interior-cluster bbox already reflects the spacing the placer used, so pass 2
+# inflates it by only this modest margin PER SIDE (not the 2.5× area factor) to leave
+# routing channels at the cluster boundary. Empirical — tuned against the golden
+# routing counts at the eyeball/integration gate; bump it (less shrink) if routing
+# starves, never loosen the unrouted bound.
+_CLUSTER_ROUTING_MARGIN_MM = 3.0
+
+
+class _RefitDecline(Exception):
+    """Re-fit declined BEFORE any board mutation (empty cluster / not meaningfully
+    smaller). No backup was taken, so there is nothing to restore — distinct from a
+    post-commit fallback (which restores the .pass1 backup)."""
 
 
 def _resolve_mounting_holes(mh_source: Optional[Dict[str, Any]]) -> Dict[str, Any]:
@@ -416,6 +444,137 @@ print(json.dumps({"status": "ok", "holes_added": len(positions),
     }, timeout=60.0)
 
 
+# ---------------------------------------------------------------------------
+# Board re-fit pass-2 steps (SPEC_Post_Placement_Board_Refit §3, §6).
+# These run ONLY when board_refit is on, after a measured-smaller second size.
+# ---------------------------------------------------------------------------
+
+def _step_redraw_outline(pcb_path: str, width_mm: float, height_mm: float) -> Dict[str, Any]:
+    """Re-draw the Edge.Cuts rectangle to a NEW size on an EXISTING board (re-fit
+    pass 2, §3 step 4 / §9-A1).
+
+    Runs the shared :data:`_OUTLINE_REDRAW_SCRIPT` via ``LoadBoard`` — it NEVER
+    calls ``CreateEmptyBoard`` (which would wipe the placed footprints + nets), so
+    the cluster placed in pass 1 survives and only the board outline changes. The
+    subsequent placement pass re-anchors edge terminals + holes to this new outline
+    via ``GetBoardEdgesBoundingBox()``."""
+    return run_pcbnew_script(_OUTLINE_REDRAW_SCRIPT, params={
+        "pcb_path": pcb_path,
+        "width_mm": width_mm,
+        "height_mm": height_mm,
+    })
+
+
+def _step_measure_cluster(
+    pcb_path: str, edge_placed_refs: List[str]
+) -> Dict[str, Any]:
+    """Measure the placed INTERIOR-cluster rectangle (re-fit §3 step 2).
+
+    Unions the body bboxes (antenna keepout EXCLUDED, same ``body_bbox`` the sizer
+    uses) of every footprint that is NEITHER an edge-placed terminal NOR a mounting
+    hole — the rectangle the tighter board must hug. The cluster is defined by
+    EXCLUSION, not by ``is_terminal`` (§2 blocker):
+
+    - ``edge_placed_refs`` — refs the pass-1 placer anchored to an edge (from its
+      ``rotation_chosen`` decisions). These march along the edges, so they are NOT
+      part of the interior cluster.
+    - ``_ref_class(ref) == "H"`` — corner mounting holes. H is NOT an edge-designator
+      class, so an ``is_terminal`` filter would KEEP them and inflate the bbox to the
+      full board → the no-op guard fires → the feature silently does nothing.
+
+    Everything else IS cluster — crucially INCLUDING interior module headers (J6 the
+    OLED, ``edge:"none"``, spiral-placed inside the cluster): they are ``is_terminal``
+    for sizing but physically sit in the cluster, so the measure must count them or
+    it under-sizes. Returns ``{cluster_w, cluster_h, counted:[refs]}`` in mm; an
+    empty cluster yields ``0×0`` (the caller's no-op guard then declines)."""
+    script = """
+import pcbnew, json, sys
+
+params = json.loads(open(sys.argv[1]).read())
+""" + BODY_EXTENT_HELPER + """
+board = pcbnew.LoadBoard(params["pcb_path"])
+edge_refs = set(params["edge_placed_refs"])
+
+def _ref_class(ref):
+    for i, c in enumerate(ref):
+        if c.isdigit():
+            return ref[:i]
+    return ref
+
+bx0 = by0 = float("inf")
+bx1 = by1 = float("-inf")
+counted = []
+for fp in board.GetFootprints():
+    ref = fp.GetReference()
+    if ref in edge_refs:
+        continue                  # edge-placed terminal — anchors to the edge band
+    if _ref_class(ref) == "H":
+        continue                  # corner hole — would inflate the bbox to full board
+    has_keepout = any(z.GetIsRuleArea() for z in fp.Zones()) if hasattr(fp, 'Zones') else False
+    fx0, fy0, fx1, fy1 = body_bbox(fp, has_keepout)
+    bx0 = min(bx0, fx0); by0 = min(by0, fy0)
+    bx1 = max(bx1, fx1); by1 = max(by1, fy1)
+    counted.append(ref)
+
+if bx0 == float("inf"):
+    print(json.dumps({"status": "ok", "cluster_w": 0.0, "cluster_h": 0.0, "counted": []}))
+else:
+    print(json.dumps({"status": "ok",
+                      "cluster_w": round(bx1 - bx0, 3),
+                      "cluster_h": round(by1 - by0, 3),
+                      "counted": counted}))
+"""
+    return run_pcbnew_script(script, params={
+        "pcb_path": pcb_path,
+        "edge_placed_refs": list(edge_placed_refs),
+    })
+
+
+def _step_remove_mounting_holes(pcb_path: str) -> Dict[str, Any]:
+    """Delete every ``H*`` mounting-hole footprint AND its keepout zone, so re-fit
+    pass 2 can re-add them at the NEW corners via ``_step_add_mounting_holes``
+    without duplicating (H5–H8) or leaving stale keepouts (re-fit §6).
+
+    The hole keepouts are ANONYMOUS board-level rule-area ZONEs (no ref linkage to
+    their H* footprint, §6 blocker), so they are identified by type: every
+    board-level zone with ``GetIsRuleArea()``. This is safe because the only other
+    rule-area keepout — the MCU antenna — lives as a FOOTPRINT child zone
+    (``fp.Zones()``), not a board-level zone; and GND copper pours are NOT rule
+    areas and are added only AFTER autoroute, so none exist at pass-2 time. The
+    script asserts that invariant by reporting the removed zone count."""
+    script = """
+import pcbnew, json, sys
+
+params = json.loads(open(sys.argv[1]).read())
+board = pcbnew.LoadBoard(params["pcb_path"])
+
+def _ref_class(ref):
+    for i, c in enumerate(ref):
+        if c.isdigit():
+            return ref[:i]
+    return ref
+
+removed_fps = []
+for fp in list(board.GetFootprints()):
+    if _ref_class(fp.GetReference()) == "H":
+        removed_fps.append(fp.GetReference())
+        board.Remove(fp)
+
+# Anonymous board-level rule-area keepouts (the hole keepouts). The antenna keepout
+# is a FOOTPRINT child zone, not board-level, so it is untouched here.
+removed_zones = 0
+for z in list(board.Zones()):
+    if z.GetIsRuleArea():
+        board.Remove(z)
+        removed_zones += 1
+
+board.Save(params["pcb_path"])
+print(json.dumps({"status": "ok", "removed_footprints": removed_fps,
+                  "removed_zones": removed_zones}))
+"""
+    return run_pcbnew_script(script, params={"pcb_path": pcb_path}, timeout=60.0)
+
+
 def _content_aware_size(
     components: List[Dict[str, Any]],
     terminal_edge_horizontal: bool = True,
@@ -467,11 +626,20 @@ def _estimate_board_size(
     fp_specs: List[Dict[str, str]], corner_inset_mm: float = 0.0,
     corner_center_inset_mm: float = 0.0, terminal_distribution: str = "single_edge",
     side_silk_gap_mm: float = 2.5,
+    cluster_wh: Optional[Tuple[float, float]] = None,
+    comps: Optional[List[Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     """Estimate board dimensions from footprint specs. The bridge script only
     MEASURES (body w/h + whether the ref is an edge terminal); the content-aware
     math lives in the pure :func:`_content_aware_size` so it is testable and
-    shared. ``fp_specs`` entries carry ``ref`` for the terminal classification."""
+    shared. ``fp_specs`` entries carry ``ref`` for the terminal classification.
+
+    Board re-fit (SPEC_Post_Placement_Board_Refit §4): when ``comps`` (the measured
+    footprint list returned by a prior call) is supplied, the bridge measurement
+    script is SKIPPED and those cached comps reused — pass 2 must not re-measure.
+    ``cluster_wh`` overrides the square-cluster interior estimate with a measured
+    ``(w, h)`` rectangle. The result ALWAYS includes ``comps`` so the caller can
+    hand them to a second pass."""
     script = """
 import pcbnew, json, os, sys
 
@@ -535,13 +703,20 @@ for spec in fp_specs:
 
 print(json.dumps({"components": components, "errors": errors}))
 """
-    result = run_pcbnew_script(script, params={
-        "fp_specs": fp_specs, "edge_classes": list(_EDGE_DESIGNATOR_CLASSES)})
-    if "error" in result:
-        return result
-    comps = result.get("components", [])
+    # Pass 1 measures via the bridge script; pass 2 (re-fit) supplies cached
+    # ``comps`` and SKIPS the measurement entirely — the measured body w/h +
+    # keepout_side are reused verbatim (only ``cluster_wh`` changes the math).
+    if comps is None:
+        result = run_pcbnew_script(script, params={
+            "fp_specs": fp_specs, "edge_classes": list(_EDGE_DESIGNATOR_CLASSES)})
+        if "error" in result:
+            return result
+        comps = result.get("components", [])
+        measure_errors = result.get("errors", [])
+    else:
+        measure_errors = []
     if not comps:
-        return {"error": "No valid footprints found", "details": result.get("errors", [])}
+        return {"error": "No valid footprints found", "details": measure_errors}
     # Distribute terminals across edge(s) — the SINGLE source for BOTH the board
     # size and the per-terminal edge assignment (single_edge collapses to today's
     # _content_aware_size; the regression-lock test pins this). The returned
@@ -552,15 +727,17 @@ print(json.dumps({"components": components, "errors": errors}))
         comps, antenna_side, mode=terminal_distribution,
         corner_inset_mm=corner_inset_mm,
         corner_center_inset_mm=corner_center_inset_mm,
-        side_silk_gap_mm=side_silk_gap_mm)
+        side_silk_gap_mm=side_silk_gap_mm,
+        cluster_wh=cluster_wh)
     return {
         "status": "ok",
         "size": dist["size"],
         "edge_of": dist["edge_of"],
         "primary_edge": dist["primary_edge"],
         "antenna_side": antenna_side,
-        "errors": result.get("errors", []),
-        "error_count": len(result.get("errors", [])),
+        "comps": comps,
+        "errors": measure_errors,
+        "error_count": len(measure_errors),
     }
 
 
@@ -2048,12 +2225,17 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
         # auto-size spreads field terminals across the side edges.
         _term_dist = "single_edge"
         _term_anchor = "start"
+        _refit = False
         if design_intent is not None:
             _term_dist = design_intent.source.get("terminal_distribution", "single_edge")
             # terminal_centering (board.yaml, default off) centres each edge's
             # terminal group instead of packing it at one end (layout balance only).
             _term_anchor = ("center" if design_intent.source.get("terminal_centering")
                             else "start")
+            # board_refit (board.yaml, default off) re-fits an AUTO-SIZED board to its
+            # measured cluster after placement (SPEC_Post_Placement_Board_Refit). The
+            # auto_sized gate (D2) is applied below — never re-fit user-dimensioned boards.
+            _refit = bool(design_intent.source.get("board_refit"))
         step = _step_create_pcb_and_outline(
             pcb_path, eff_width_mm, eff_height_mm, components, holes=holes,
             terminal_distribution=_term_dist,
@@ -2067,6 +2249,10 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
         # Passed to placement as the LOWEST-priority {"edge": E} hints below.
         terminal_edge_of = step.get("edge_of") or {}
         antenna_side_est = step.get("antenna_side")
+        # Captured for re-fit (D2 gate + pass-2 reuse): whether the board was
+        # auto-sized, and the measured footprint bodies (so pass 2 skips re-measuring).
+        auto_sized = bool(step.get("auto_sized"))
+        measured_comps = step.get("comps") or []
         pipeline_result["board_width_mm"] = actual_width
         pipeline_result["board_height_mm"] = actual_height
         if step.get("auto_sized"):
@@ -2103,26 +2289,27 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
         pipeline_result["pads_assigned"] = step.get("pads_assigned", 0)
 
         # Merge placement hints, lowest → highest priority:
-        #   auto terminal distribution  <  intent-carried  <  explicit param.
-        # The distributor's {ref: edge} is the BASE so an explicit user/intent hint
-        # on a terminal still wins; terminals with no hint fall to the script's
-        # antenna-opposite rule (single_edge boards pass NO distribution hints, so
-        # they stay byte-identical). normalize_hint validates every directive.
-        _dist_hints = {ref: {"edge": e} for ref, e in terminal_edge_of.items()}
-        _base_hints = dict(_dist_hints)
-        if design_intent is not None and design_intent.placement_hints:
-            _base_hints.update(design_intent.placement_hints)
-        clean_hints, hint_warnings = _merge_placement_hints(
-            _base_hints,
-            placement_hints,
-        )
-        # Mounting holes are physical fixtures we already placed — pin them at the
-        # corners at HIGHEST priority (else the placer, which no longer edge-places
-        # "H", would shove them into the interior). Normalized via the same path.
-        if hole_hints:
-            norm_holes, hole_ws = _merge_placement_hints(None, hole_hints)
-            clean_hints.update(norm_holes)
-            hint_warnings.extend(hole_ws)
+        #   auto terminal distribution  <  intent-carried  <  explicit param  <
+        #   mounting-hole fixtures (pinned at the corners). SINGLE SOURCE so pass 1
+        # AND a re-fit pass 2 compose hints identically. The distributor's {ref:edge}
+        # is the BASE so an explicit user/intent hint on a terminal still wins;
+        # terminals with no hint fall to the script's antenna-opposite rule.
+        # normalize_hint validates every directive.
+        def _compose_hints(edge_of, hole_hints_):
+            base = {ref: {"edge": e} for ref, e in edge_of.items()}
+            if design_intent is not None and design_intent.placement_hints:
+                base.update(design_intent.placement_hints)
+            clean, warns = _merge_placement_hints(base, placement_hints)
+            # Mounting holes are physical fixtures we already placed — pin them at the
+            # corners at HIGHEST priority (else the placer, which no longer edge-places
+            # "H", would shove them into the interior). Normalized via the same path.
+            if hole_hints_:
+                norm_holes, hole_ws = _merge_placement_hints(None, hole_hints_)
+                clean.update(norm_holes)
+                warns.extend(hole_ws)
+            return clean, warns
+
+        clean_hints, hint_warnings = _compose_hints(terminal_edge_of, hole_hints)
 
         # Step 5: Smart placement (tiered, connectivity-aware). corner_clear keeps
         # edge terminals clear of the corner mounting holes (single source with
@@ -2133,6 +2320,114 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
             terminal_anchor=_term_anchor)
         _record("smart_placement", step)
         # Non-fatal — continue even if placement is imperfect
+
+        # ── Board re-fit pass 2 (SPEC_Post_Placement_Board_Refit §3) ───────────
+        # Measure the placed interior cluster; if the board can hug it more tightly,
+        # redraw a smaller outline and re-place onto it. Opt-in (board_refit) and
+        # ONLY for auto-sized boards (D1/D2) — the size lever that recovers the
+        # sizing over-estimate. ANY decline/failure/soft-regression keeps pass 1; a
+        # committed attempt that fails restores the .pass1 backup so the on-disk
+        # board always matches the in-memory `step`.
+        if _refit and auto_sized and measured_comps:
+            _backup = pcb_path + ".pass1"
+            _old_w, _old_h = actual_width, actual_height
+            try:
+                # Cluster = everything NOT edge-placed and NOT a mounting hole (§2:
+                # includes interior J6, excludes H* + the edge-anchored terminals).
+                _edge_placed = [
+                    d["ref"] for d in (step.get("placement_decisions") or [])
+                    if d.get("event") == "rotation_chosen" and d.get("edge")
+                ]
+                _meas = _step_measure_cluster(pcb_path, _edge_placed)
+                _cw, _ch = _meas.get("cluster_w", 0.0), _meas.get("cluster_h", 0.0)
+                if "error" in _meas or _cw <= 0 or _ch <= 0:
+                    raise _RefitDecline("cluster measure empty or failed")
+                # Inflate by the routing-slack margin per side (tunable, §4/R1).
+                _m = _CLUSTER_ROUTING_MARGIN_MM
+                _resize = _estimate_board_size(
+                    [], corner_inset_mm=_hole_corner_clear(holes),
+                    corner_center_inset_mm=_hole_center_inset(holes),
+                    terminal_distribution=_term_dist,
+                    cluster_wh=(_cw + 2 * _m, _ch + 2 * _m), comps=measured_comps)
+                if "error" in _resize:
+                    raise _RefitDecline("re-estimate failed: %s" % _resize.get("error"))
+                _new_w = _resize["size"]["width_mm"]
+                _new_h = _resize["size"]["height_mm"]
+                # No-op guard: meaningfully smaller on ≥1 axis, growing on neither.
+                _TOL = 1.0
+                _dw, _dh = _old_w - _new_w, _old_h - _new_h
+                if not ((_dw > _TOL or _dh > _TOL) and _dw >= -_TOL and _dh >= -_TOL):
+                    raise _RefitDecline(
+                        "not meaningfully smaller (%sx%s → %sx%s)"
+                        % (_old_w, _old_h, _new_w, _new_h))
+
+                # Commit: backup, redraw outline (footprints/nets survive), re-fixture
+                # the corner holes on the new outline, re-place. Any sub-step error
+                # below is a generic exception → the fallback handler restores .pass1.
+                shutil.copy2(pcb_path, _backup)
+                if "error" in _step_redraw_outline(pcb_path, _new_w, _new_h):
+                    raise RuntimeError("redraw_outline failed")
+                if "error" in _step_remove_mounting_holes(pcb_path):
+                    raise RuntimeError("remove_mounting_holes failed")
+                _hole_positions2: List[Dict[str, Any]] = []
+                _hole_hints2: Dict[str, Dict[str, Any]] = {}
+                if holes.get("count", 0) > 0:
+                    _ah = _step_add_mounting_holes(pcb_path, holes)
+                    if "error" in _ah:
+                        raise RuntimeError("add_mounting_holes failed")
+                    _hole_positions2 = _ah.get("positions") or []
+                    _hole_hints2 = {
+                        r["ref"]: {"fixed": [r["x_mm"], r["y_mm"]], "rotation": 0}
+                        for r in _hole_positions2
+                    }
+                _clean2, _warns2 = _compose_hints(_resize.get("edge_of") or {}, _hole_hints2)
+                _step2 = _step_smart_placement(
+                    pcb_path, nets, placement_hints=_clean2,
+                    corner_clear_mm=_hole_corner_clear(holes),
+                    terminal_anchor=_term_anchor)
+                if "error" in _step2:
+                    raise RuntimeError("pass-2 placement failed")
+                # Fit-fallback (§3 step 5): a hard miss OR a soft regression
+                # (terminal crowded / MCU dropped to interior so the antenna no longer
+                # overhangs) means the tighter board doesn't seat — restore pass 1.
+                _soft = {d.get("event") for d in (_step2.get("placement_decisions") or [])} & {
+                    "terminal_edge_crowded", "keepout_fallback_interior"}
+                if _step2.get("failed_placements") or _soft:
+                    raise RuntimeError(
+                        "fit regression (failed=%s soft=%s)"
+                        % (_step2.get("failed_placements"), sorted(_soft)))
+
+                # Pass 2 won — adopt its board, dims, holes, placement, hints.
+                step = _step2
+                actual_width, actual_height = _new_w, _new_h
+                hole_positions = _hole_positions2
+                clean_hints, hint_warnings = _clean2, _warns2
+                pipeline_result["board_width_mm"] = _new_w
+                pipeline_result["board_height_mm"] = _new_h
+                pipeline_result.setdefault("warnings", []).append(
+                    "Board re-fit %sx%s → %sx%smm (measured cluster %.1fx%.1f)"
+                    % (_old_w, _old_h, _new_w, _new_h, _cw, _ch))
+                _record("board_refit", {
+                    "status": "ok", "width_mm": _new_w, "height_mm": _new_h,
+                    "from_width_mm": _old_w, "from_height_mm": _old_h,
+                    "cluster_w": _cw, "cluster_h": _ch})
+                try:
+                    os.remove(_backup)
+                except OSError:
+                    pass
+            except _RefitDecline as _decl:
+                _record("board_refit", {"status": "declined", "reason": str(_decl)})
+            except Exception as _f:  # noqa: BLE001 — re-fit is an optimization, never fatal
+                # Restore the pass-1 board if we had committed, so disk matches `step`.
+                try:
+                    if os.path.exists(_backup):
+                        shutil.copy2(_backup, pcb_path)
+                        os.remove(_backup)
+                except OSError:
+                    pass
+                _record("board_refit", {"status": "fallback", "reason": str(_f)})
+                pipeline_result.setdefault("warnings", []).append(
+                    "Board re-fit fell back to pass 1: %s" % _f)
 
         # Which edge each terminal was placed on (from the rotation decisions) —
         # used by the silk-legend step to offset labels inboard, away from that

--- a/src/kicad_mcp/tools/pcb_pipeline.py
+++ b/src/kicad_mcp/tools/pcb_pipeline.py
@@ -1582,15 +1582,35 @@ silk = board.GetLayerID("F.SilkS")
 by_ref = {fp.GetReference(): fp for fp in board.GetFootprints()}
 # For an EDGE terminal the legend goes on the INBOARD side of each pad (away from
 # the terminal's edge), clear of the body that extends OUTBOARD toward the
-# wire-entry face (spec §6: readable beside the block, never under it). Interior
-# module headers (no edge assignment) keep the default above-pad offset — they
-# have no consistent body direction and "inboard" would point into the cluster.
+# wire-entry face (spec §6: readable beside the block, never under it). An interior
+# module header (no edge assignment) has no inboard normal, so its labels go to the
+# SIDE of the pad column — past the body, toward the nearer board edge — never
+# "above the pad", which lands ON the pad above it for a VERTICAL header.
 terminal_edges = params.get("terminal_edges") or {}
 # edge -> inboard (inward-normal) unit step. (0,0) marks "no edge" (interior).
 _INBOARD = {"top": (0, 1), "bottom": (0, -1), "left": (1, 0), "right": (-1, 0)}
+# Every pad bbox on the board (ref, x0, y0, x1, y1). An interior module header has
+# no inboard normal and is packed into the cluster, so we pick the SIDE whose label
+# band is CLEAR of all OTHER pads — and skip the header's silk if no side is clear,
+# rather than draw a label on a neighbour's pad.
+_all_pads = []
+for f in board.GetFootprints():
+    for pd in f.Pads():
+        pb = pd.GetBoundingBox()
+        _all_pads.append((f.GetReference(), pb.GetLeft(), pb.GetTop(),
+                          pb.GetRight(), pb.GetBottom()))
+
+def _band_clear(own, x0, y0, x1, y1):
+    for ref, px0, py0, px1, py1 in _all_pads:
+        if ref == own:
+            continue
+        if not (px1 < x0 or px0 > x1 or py1 < y0 or py0 > y1):
+            return False
+    return True
 
 labels_added = 0
 missing = []
+legends_unplaced = []   # interior headers boxed into the cluster (no clear side)
 for leg in params["legends"]:
     fp = by_ref.get(leg["ref"])
     if fp is None:
@@ -1604,6 +1624,30 @@ for leg in params["legends"]:
     # label merely past the pad edge sits UNDER the block. Offset past the body
     # edge so the label lands on exposed board, beyond the block, in the open gap.
     fbb = fp.GetBoundingBox(False, False)
+
+    # Interior module header (no edge normal): choose the side whose label band is
+    # clear of every other pad. A VERTICAL pad column -> labels go left/right (each
+    # beside its own pad); a HORIZONTAL row -> up/down. "Above the pad" (the old
+    # default) lands ON the pad above for a vertical header. If neither valid side
+    # is clear (the header is boxed into the cluster) the per-pad silk is SKIPPED,
+    # not drawn over a neighbour — the pinout still lives in the connector legend
+    # data; rendering it would need a placement-level silk clearance.
+    side = None
+    if (ix, iy) == (0, 0):
+        maxw = max((len(positions[i]) for i in range(len(positions)) if positions[i]),
+                   default=1) * size
+        d = margin + maxw + size // 2      # band depth (+ a glyph of safety)
+        if (fbb.GetBottom() - fbb.GetTop()) >= (fbb.GetRight() - fbb.GetLeft()):
+            cands = [("R", fbb.GetRight() + margin, fbb.GetTop(), fbb.GetRight() + d, fbb.GetBottom()),
+                     ("L", fbb.GetLeft() - d, fbb.GetTop(), fbb.GetLeft() - margin, fbb.GetBottom())]
+        else:
+            cands = [("U", fbb.GetLeft(), fbb.GetTop() - d, fbb.GetRight(), fbb.GetTop() - margin),
+                     ("D", fbb.GetLeft(), fbb.GetBottom() + margin, fbb.GetRight(), fbb.GetBottom() + d)]
+        side = next((s for s, a, b, c, e in cands if _band_clear(leg["ref"], a, b, c, e)), None)
+        if side is None:
+            legends_unplaced.append(leg["ref"])
+            continue
+
     for pad in fp.Pads():
         num = pad.GetNumber()
         if not num.isdigit():
@@ -1612,10 +1656,13 @@ for leg in params["legends"]:
         if idx < 0 or idx >= len(positions) or not positions[idx]:
             continue
         p = pad.GetPosition()
-        bb = pad.GetBoundingBox()
-        # Cross-axis = the pad's own position (label stays over its pad); the
-        # inboard axis clears the BODY envelope (fbb) + half the glyph.
-        if ix > 0:        # inboard right (terminal on the left edge)
+        lw = len(positions[idx]) * size    # this label's width (centre-justified)
+        # Cross-axis = the pad's own position (label stays over its pad); the offset
+        # axis clears the BODY envelope (fbb). Edge terminals push the centre out by
+        # half a glyph (their body already extends past the pads); interior headers
+        # push by half the LABEL width so the whole centre-justified glyph clears the
+        # thin header body.
+        if ix > 0:        # edge terminal, inboard right (terminal on the left edge)
             tx, ty = fbb.GetRight() + margin + size // 2, p.y
         elif ix < 0:      # inboard left (right edge)
             tx, ty = fbb.GetLeft() - margin - size // 2, p.y
@@ -1623,8 +1670,14 @@ for leg in params["legends"]:
             tx, ty = p.x, fbb.GetBottom() + margin + size // 2
         elif iy < 0:      # inboard up (bottom edge)
             tx, ty = p.x, fbb.GetTop() - margin - size // 2
-        else:             # interior module header: keep the simple above-pad offset
-            tx, ty = p.x, bb.GetTop() - margin - size // 2
+        elif side == "R":
+            tx, ty = fbb.GetRight() + margin + lw // 2, p.y
+        elif side == "L":
+            tx, ty = fbb.GetLeft() - margin - lw // 2, p.y
+        elif side == "U":
+            tx, ty = p.x, fbb.GetTop() - margin - size // 2
+        else:             # "D"
+            tx, ty = p.x, fbb.GetBottom() + margin + size // 2
         txt = pcbnew.PCB_TEXT(board)
         txt.SetText(positions[idx])
         txt.SetPosition(pcbnew.VECTOR2I(int(tx), int(ty)))
@@ -1656,7 +1709,8 @@ for leg in params["legends"]:
 
 board.Save(params["pcb_path"])
 print(json.dumps({"status": "ok", "labels_added": labels_added,
-                  "missing_refs": missing}))
+                  "missing_refs": missing,
+                  "legends_unplaced": legends_unplaced}))
 """
     res = run_pcbnew_script(script, params={
         "pcb_path": pcb_path, "legends": legends, "margin_mm": margin_mm,

--- a/src/kicad_mcp/tools/pcb_pipeline.py
+++ b/src/kicad_mcp/tools/pcb_pipeline.py
@@ -793,6 +793,7 @@ def _step_smart_placement(
     spacing_mm: float = 1.0,
     placement_hints: Optional[Dict[str, Dict[str, Any]]] = None,
     corner_clear_mm: float = 0.0,
+    terminal_anchor: str = "start",
 ) -> Dict[str, Any]:
     """Step 5: Smart tiered placement based on connectivity and component type.
 
@@ -823,6 +824,7 @@ params = json.loads(open(sys.argv[1]).read())
 board = pcbnew.LoadBoard(params["pcb_path"])
 spacing = params["spacing_mm"]
 corner_clear = params.get("corner_clear_mm", 0.0)  # corner space the mounting holes occupy
+terminal_anchor = params.get("anchor", "start")    # "start" | "center" along each edge
 outline = get_board_outline(board)
 
 if not outline:
@@ -1295,7 +1297,7 @@ for edge in ("top", "bottom", "left", "right"):
     else:
         lay_box = (board_xmin, board_ymin + corner_clear,
                    board_xmax, board_ymax - corner_clear)
-    laid = layout_along_edge(items, edge, lay_box, margin, spacing)
+    laid = layout_along_edge(items, edge, lay_box, margin, spacing, anchor=terminal_anchor)
     for (ref, x, y, fits) in laid:
         ang, rext, rpad = rot_by_ref[ref]
         el, er, et, eb = rext
@@ -1445,6 +1447,7 @@ print(json.dumps({
         "pcb_path": pcb_path,
         "spacing_mm": spacing_mm,
         "corner_clear_mm": corner_clear_mm,
+        "anchor": terminal_anchor,
         "net_members": dict(net_members),
         "placement_hints": dict(placement_hints or {}),
         "edge_classes": list(_EDGE_DESIGNATOR_CLASSES),
@@ -2044,8 +2047,13 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
         # terminal_distribution (board.yaml, default single_edge) decides whether the
         # auto-size spreads field terminals across the side edges.
         _term_dist = "single_edge"
+        _term_anchor = "start"
         if design_intent is not None:
             _term_dist = design_intent.source.get("terminal_distribution", "single_edge")
+            # terminal_centering (board.yaml, default off) centres each edge's
+            # terminal group instead of packing it at one end (layout balance only).
+            _term_anchor = ("center" if design_intent.source.get("terminal_centering")
+                            else "start")
         step = _step_create_pcb_and_outline(
             pcb_path, eff_width_mm, eff_height_mm, components, holes=holes,
             terminal_distribution=_term_dist,
@@ -2121,7 +2129,8 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
         # the board-size reservation above, so the cleared span actually fits).
         step = _step_smart_placement(
             pcb_path, nets, placement_hints=clean_hints,
-            corner_clear_mm=_hole_corner_clear(holes))
+            corner_clear_mm=_hole_corner_clear(holes),
+            terminal_anchor=_term_anchor)
         _record("smart_placement", step)
         # Non-fatal — continue even if placement is imperfect
 

--- a/src/kicad_mcp/utils/firmware/knowledge.py
+++ b/src/kicad_mcp/utils/firmware/knowledge.py
@@ -104,12 +104,8 @@ SPH0645 = {
     "ws": "WS", "bclk": "BCLK", "data": "DATA", "sel": "SEL",
     "vdd": "VDD", "gnd": "GND",
 }
-# Generic module headers (lib_id, footprint). Pin numbers are "1".."N".
-# (1x02 speaker headers are now synthesized via connectors.synthesize_connector.)
-HDR_1X4 = ("Connector_Generic:Conn_01x04",
-           "Connector_PinHeader_2.54mm:PinHeader_1x04_P2.54mm_Vertical")
-HDR_1X5 = ("Connector_Generic:Conn_01x05",
-           "Connector_PinHeader_2.54mm:PinHeader_1x05_P2.54mm_Vertical")
+# (Module headers — 1x02 speaker / 1x04 I2C+UART — are now synthesized via
+# connectors.synthesize_connector, which owns symbol+footprint selection.)
 
 # --- verified footprints (speed-cal v5 BOM) for template-placed passives ---
 LIB_C = "Device:C"

--- a/src/kicad_mcp/utils/firmware/sidecar.py
+++ b/src/kicad_mcp/utils/firmware/sidecar.py
@@ -111,6 +111,9 @@ class BoardSidecar:
     # terminals on the antenna-opposite edge) or "multi_edge" (spill onto the side
     # edges to square the board). See SPEC_Multi_Edge_Terminal_Distribution.md.
     terminal_distribution: Optional[str] = None
+    # centre each edge's field-terminal group within its edge (vs the default
+    # pack-from-one-end). Layout balance only — does not change board size.
+    terminal_centering: Optional[bool] = None
 
 
 # Top-level board.yaml keys. An unknown key is a loud error (catches a typo like
@@ -120,7 +123,7 @@ class BoardSidecar:
 _KNOWN_SIDECAR_KEYS = frozenset({
     "power_source", "board_size_mm", "extra_connectors",
     "placement", "placement_hints", "mounting_holes", "bus_part_overrides",
-    "terminal_distribution",
+    "terminal_distribution", "terminal_centering",
 })
 
 _TERMINAL_DISTRIBUTIONS = frozenset({"single_edge", "multi_edge"})
@@ -232,6 +235,9 @@ def _validate(d: dict[str, Any]) -> list[str]:
     if td is not None and td not in _TERMINAL_DISTRIBUTIONS:
         errs.append(f"terminal_distribution {td!r} not in "
                     f"{sorted(_TERMINAL_DISTRIBUTIONS)}")
+    tc = d.get("terminal_centering")
+    if tc is not None and not isinstance(tc, bool):
+        errs.append(f"terminal_centering must be true/false, got {tc!r}")
     for i, c in enumerate(d.get("extra_connectors", []) or []):
         where = f"extra_connectors[{i}]"
         if not isinstance(c, dict):
@@ -309,6 +315,7 @@ def load_sidecar(path: str) -> BoardSidecar:
                         if data.get("mounting_holes") is not None else None),
         bus_part_overrides=dict(data.get("bus_part_overrides", {}) or {}),
         terminal_distribution=data.get("terminal_distribution"),
+        terminal_centering=data.get("terminal_centering"),
     )
 
 
@@ -345,6 +352,8 @@ def apply_sidecar(
         intent.source["mounting_holes"] = dict(sidecar.mounting_holes)
     if sidecar.terminal_distribution is not None:
         intent.source["terminal_distribution"] = sidecar.terminal_distribution
+    if sidecar.terminal_centering is not None:
+        intent.source["terminal_centering"] = sidecar.terminal_centering
 
     nets_by_name = {n.name: n for n in intent.nets}
     existing_refs = {p.ref for p in intent.peripherals}

--- a/src/kicad_mcp/utils/firmware/sidecar.py
+++ b/src/kicad_mcp/utils/firmware/sidecar.py
@@ -107,6 +107,10 @@ class BoardSidecar:
     # DECLARES the bus's part {part: "INMP441"} when firmware doesn't name it (or
     # to correct an assumption/ambiguity). Provenance "user" — wins over corpus.
     bus_part_overrides: dict[str, dict[str, Any]] = field(default_factory=dict)
+    # terminal distribution across board edges: "single_edge" (default — all field
+    # terminals on the antenna-opposite edge) or "multi_edge" (spill onto the side
+    # edges to square the board). See SPEC_Multi_Edge_Terminal_Distribution.md.
+    terminal_distribution: Optional[str] = None
 
 
 # Top-level board.yaml keys. An unknown key is a loud error (catches a typo like
@@ -116,7 +120,10 @@ class BoardSidecar:
 _KNOWN_SIDECAR_KEYS = frozenset({
     "power_source", "board_size_mm", "extra_connectors",
     "placement", "placement_hints", "mounting_holes", "bus_part_overrides",
+    "terminal_distribution",
 })
+
+_TERMINAL_DISTRIBUTIONS = frozenset({"single_edge", "multi_edge"})
 
 _KNOWN_BUS_OVERRIDE_KEYS = frozenset({"part", "footprint"})
 
@@ -221,6 +228,10 @@ def _validate(d: dict[str, Any]) -> list[str]:
     if bs is not None and not (isinstance(bs, list) and len(bs) == 2
                                and all(isinstance(x, (int, float)) for x in bs)):
         errs.append("board_size_mm must be [width, height] numbers")
+    td = d.get("terminal_distribution")
+    if td is not None and td not in _TERMINAL_DISTRIBUTIONS:
+        errs.append(f"terminal_distribution {td!r} not in "
+                    f"{sorted(_TERMINAL_DISTRIBUTIONS)}")
     for i, c in enumerate(d.get("extra_connectors", []) or []):
         where = f"extra_connectors[{i}]"
         if not isinstance(c, dict):
@@ -297,6 +308,7 @@ def load_sidecar(path: str) -> BoardSidecar:
         mounting_holes=(dict(data["mounting_holes"])
                         if data.get("mounting_holes") is not None else None),
         bus_part_overrides=dict(data.get("bus_part_overrides", {}) or {}),
+        terminal_distribution=data.get("terminal_distribution"),
     )
 
 
@@ -331,6 +343,8 @@ def apply_sidecar(
         intent.source["board_size_mm"] = list(sidecar.board_size_mm)
     if sidecar.mounting_holes is not None:
         intent.source["mounting_holes"] = dict(sidecar.mounting_holes)
+    if sidecar.terminal_distribution is not None:
+        intent.source["terminal_distribution"] = sidecar.terminal_distribution
 
     nets_by_name = {n.name: n for n in intent.nets}
     existing_refs = {p.ref for p in intent.peripherals}

--- a/src/kicad_mcp/utils/firmware/sidecar.py
+++ b/src/kicad_mcp/utils/firmware/sidecar.py
@@ -114,6 +114,10 @@ class BoardSidecar:
     # centre each edge's field-terminal group within its edge (vs the default
     # pack-from-one-end). Layout balance only — does not change board size.
     terminal_centering: Optional[bool] = None
+    # re-fit the auto-sized board to the MEASURED interior cluster after placement
+    # (a tighter second pass). Size lever — only applies to auto-sized boards. See
+    # SPEC_Post_Placement_Board_Refit.md.
+    board_refit: Optional[bool] = None
 
 
 # Top-level board.yaml keys. An unknown key is a loud error (catches a typo like
@@ -123,7 +127,7 @@ class BoardSidecar:
 _KNOWN_SIDECAR_KEYS = frozenset({
     "power_source", "board_size_mm", "extra_connectors",
     "placement", "placement_hints", "mounting_holes", "bus_part_overrides",
-    "terminal_distribution", "terminal_centering",
+    "terminal_distribution", "terminal_centering", "board_refit",
 })
 
 _TERMINAL_DISTRIBUTIONS = frozenset({"single_edge", "multi_edge"})
@@ -238,6 +242,9 @@ def _validate(d: dict[str, Any]) -> list[str]:
     tc = d.get("terminal_centering")
     if tc is not None and not isinstance(tc, bool):
         errs.append(f"terminal_centering must be true/false, got {tc!r}")
+    br = d.get("board_refit")
+    if br is not None and not isinstance(br, bool):
+        errs.append(f"board_refit must be true/false, got {br!r}")
     for i, c in enumerate(d.get("extra_connectors", []) or []):
         where = f"extra_connectors[{i}]"
         if not isinstance(c, dict):
@@ -316,6 +323,7 @@ def load_sidecar(path: str) -> BoardSidecar:
         bus_part_overrides=dict(data.get("bus_part_overrides", {}) or {}),
         terminal_distribution=data.get("terminal_distribution"),
         terminal_centering=data.get("terminal_centering"),
+        board_refit=data.get("board_refit"),
     )
 
 
@@ -354,6 +362,8 @@ def apply_sidecar(
         intent.source["terminal_distribution"] = sidecar.terminal_distribution
     if sidecar.terminal_centering is not None:
         intent.source["terminal_centering"] = sidecar.terminal_centering
+    if sidecar.board_refit is not None:
+        intent.source["board_refit"] = sidecar.board_refit
 
     nets_by_name = {n.name: n for n in intent.nets}
     existing_refs = {p.ref for p in intent.peripherals}

--- a/src/kicad_mcp/utils/firmware/templates.py
+++ b/src/kicad_mcp/utils/firmware/templates.py
@@ -377,11 +377,6 @@ def usb_programming(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
     return ex
 
 
-def _header(alloc: RefAllocator, hdr: tuple[str, str], value: str) -> Peripheral:
-    return Peripheral(ref=alloc.next("J"), type="HDR", lib_id=hdr[0], value=value,
-                      footprint=hdr[1], origin="template")
-
-
 def _decide_part(bus: Bus, template_part: str, ex: Expansion) -> tuple[bool, str]:
     """Part-resolution decision (C6) for a bus whose on-board template builds
     ``template_part``. Returns ``(place, origin)`` and stamps the bus + emits the
@@ -569,8 +564,10 @@ def _emit_remote_mic(
 
 def i2c_device_header(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
     """Each I2C bus with no recognized IC -> a 4-pin module header
-    (GND/VCC/SCL/SDA) + 4.7k pull-ups. Covers the OLED and any unknown I2C
-    module."""
+    (GND/+3V3/SCL/SDA) + 4.7k pull-ups. Covers the OLED and any unknown I2C
+    module. Routed through the §4 ``_emit_connector`` helper so the header carries
+    a per-pad silk legend like every other synthesized connector — the module
+    header was the last connector class still bypassing the legend path."""
     ex = Expansion()
     if intent.mcu is None:
         return ex
@@ -582,22 +579,29 @@ def i2c_device_header(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
         sda_g, scl_g = bus.signals.get("SDA"), bus.signals.get("SCL")
         if sda_g is None or scl_g is None:
             continue
-        j = _header(alloc, K.HDR_1X4, f"I2C{n}")
-        r_sda, r_scl = _res(alloc, "4.7k", K.FP_R_0603), _res(alloc, "4.7k", K.FP_R_0603)
-        ex.components += [j, r_sda, r_scl]
-        # OLED / I2C breakout module header → keep interior near its bus, not
-        # forced to a board edge by the connector heuristic.
-        ex.placement_hints[j.ref] = {"edge": "none"}
-        ex.power += [("GND", Endpoint(ref=j.ref, pin="1")),
-                     ("+3V3", Endpoint(ref=j.ref, pin="2")),
-                     ("+3V3", Endpoint(ref=r_sda.ref, pin="2")),
-                     ("+3V3", Endpoint(ref=r_scl.ref, pin="2"))]
         scl_net, sda_net = f"I2C{n}_SCL", f"I2C{n}_SDA"
+        # Positions in pad order 1..4 (GND, +3V3, SCL, SDA) — same pinout the bare
+        # header used. The rails route to ``ex.power`` as taps; the signal pads come
+        # back in ``sig`` for the passive nets below. ``_emit_connector`` also adds
+        # the connector to ``ex.components``, stamps the interior ``edge:none`` hint,
+        # and appends the silk legend. OLED / I2C breakout → interior, near its bus.
+        positions = [
+            ConnectorPosition("GND", "GND"),
+            ConnectorPosition("+3V3", "+3V3"),
+            ConnectorPosition(scl_net, "SCL"),
+            ConnectorPosition(sda_net, "SDA"),
+        ]
+        j, sig = _emit_connector(ex, alloc, positions, device=f"I2C{n}",
+                                 connector_type="pin_header")
+        r_sda, r_scl = _res(alloc, "4.7k", K.FP_R_0603), _res(alloc, "4.7k", K.FP_R_0603)
+        ex.components += [r_sda, r_scl]
+        ex.power += [("+3V3", Endpoint(ref=r_sda.ref, pin="2")),
+                     ("+3V3", Endpoint(ref=r_scl.ref, pin="2"))]
         ex.new_nets += [
             _passive_net(scl_net, Endpoint(ref=mcu, gpio=scl_g),
-                         Endpoint(ref=j.ref, pin="3"), Endpoint(ref=r_scl.ref, pin="1")),
+                         sig[scl_net], Endpoint(ref=r_scl.ref, pin="1")),
             _passive_net(sda_net, Endpoint(ref=mcu, gpio=sda_g),
-                         Endpoint(ref=j.ref, pin="4"), Endpoint(ref=r_sda.ref, pin="1")),
+                         sig[sda_net], Endpoint(ref=r_sda.ref, pin="1")),
         ]
         n += 1
     return ex
@@ -625,19 +629,26 @@ def uart_device_header(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
             _emit_remote_uart(ex, alloc, mcu, n, rx_g, tx_g, pl)
             n += 1
             continue
-        j = _header(alloc, K.HDR_1X4, f"UART{n}")
+        rx_net, tx_net = f"UART{n}_RX", f"UART{n}_TX"
+        # Positions in pad order 1..4 (GND, +3V3, RX, TX) — same pinout the bare
+        # header used. ``_emit_connector`` adds the connector, taps the rails to
+        # power, stamps the interior ``edge:none`` hint, and emits the silk legend
+        # (matches i2c_device_header and _emit_remote_uart's RX/TX labels).
+        positions = [
+            ConnectorPosition("GND", "GND"),
+            ConnectorPosition("+3V3", "+3V3"),
+            ConnectorPosition(rx_net, "RX"),
+            ConnectorPosition(tx_net, "TX"),
+        ]
+        j, sig = _emit_connector(ex, alloc, positions, device=f"UART{n}",
+                                 connector_type="pin_header")
         c = _cap(alloc, "100nF", K.FP_C_BYPASS)
-        ex.components += [j, c]
-        # UART breakout module header → keep interior near its IC, not forced to a
-        # board edge by the connector heuristic (matches i2c_device_header).
-        ex.placement_hints[j.ref] = {"edge": "none"}
-        ex.power += [("GND", Endpoint(ref=j.ref, pin="1")),
-                     ("+3V3", Endpoint(ref=j.ref, pin="2")),
-                     ("+3V3", Endpoint(ref=c.ref, pin="1")),
+        ex.components += [c]
+        ex.power += [("+3V3", Endpoint(ref=c.ref, pin="1")),
                      ("GND", Endpoint(ref=c.ref, pin="2"))]
         ex.new_nets += [
-            _passive_net(f"UART{n}_RX", Endpoint(ref=mcu, gpio=rx_g), Endpoint(ref=j.ref, pin="3")),
-            _passive_net(f"UART{n}_TX", Endpoint(ref=mcu, gpio=tx_g), Endpoint(ref=j.ref, pin="4")),
+            _passive_net(rx_net, Endpoint(ref=mcu, gpio=rx_g), sig[rx_net]),
+            _passive_net(tx_net, Endpoint(ref=mcu, gpio=tx_g), sig[tx_net]),
         ]
         n += 1
     return ex

--- a/src/kicad_mcp/utils/placement/edge_terminal.py
+++ b/src/kicad_mcp/utils/placement/edge_terminal.py
@@ -222,6 +222,7 @@ def layout_along_edge(
     margin: float,
     spacing: float,
     clearance: Optional[float] = None,
+    anchor: str = "start",
 ) -> list:
     """Lay connectors out in given order along ``edge``.
 
@@ -233,13 +234,25 @@ def layout_along_edge(
     Cross-axis anchoring: an ``overhang`` terminal anchors its PAD box at
     ``clearance`` inside the edge (courtyard may cross the edge outward, pads
     stay on-board); otherwise the full courtyard sits ``margin`` inside.  Along
-    the edge, connectors advance by their courtyard width plus ``spacing``."""
+    the edge, connectors advance by their courtyard width plus ``spacing``.
+
+    ``anchor``: ``"start"`` (default) packs the group from the edge start (the
+    historical behaviour); ``"center"`` centres the whole group within the usable
+    span ``[edge_start+margin, edge_end-margin]`` — equal slack at both ends — so
+    a group shorter than its edge sits balanced rather than packed at one end. A
+    group that fills (or over-fills) the edge falls back to ``start`` (the
+    ``max(0, …)`` clamp), and the per-item ``fits`` check is unchanged. The corner
+    keepout the caller bakes into ``board_box`` is respected either way."""
     if clearance is None:
         clearance = margin
     xmin, ymin, xmax, ymax = board_box
     out = []
     if edge in ("top", "bottom"):
-        cursor = xmin + margin
+        edge_lo = xmin + margin
+        total = (sum(it[1][0] + it[1][1] for it in items)
+                 + spacing * max(0, len(items) - 1))
+        cursor = edge_lo + (max(0.0, ((xmax - margin) - edge_lo - total) / 2.0)
+                            if anchor == "center" else 0.0)
         for (ref, ext, pad_ext, overhang) in items:
             L, R, T, B = ext
             pL, pR, pT, pB = pad_ext
@@ -252,7 +265,11 @@ def layout_along_edge(
             out.append((ref, x, y, fits))
             cursor = x + R + spacing
     else:
-        cursor = ymin + margin
+        edge_lo = ymin + margin
+        total = (sum(it[1][2] + it[1][3] for it in items)
+                 + spacing * max(0, len(items) - 1))
+        cursor = edge_lo + (max(0.0, ((ymax - margin) - edge_lo - total) / 2.0)
+                            if anchor == "center" else 0.0)
         for (ref, ext, pad_ext, overhang) in items:
             L, R, T, B = ext
             pL, pR, pT, pB = pad_ext
@@ -546,13 +563,17 @@ def nearest_edge(target, board_box):
             best_edge = edge
     return best_edge
 
-def layout_along_edge(items, edge, board_box, margin, spacing, clearance=None):
+def layout_along_edge(items, edge, board_box, margin, spacing, clearance=None, anchor="start"):
     if clearance is None:
         clearance = margin
     xmin, ymin, xmax, ymax = board_box
     out = []
     if edge in ("top", "bottom"):
-        cursor = xmin + margin
+        edge_lo = xmin + margin
+        total = (sum(it[1][0] + it[1][1] for it in items)
+                 + spacing * max(0, len(items) - 1))
+        cursor = edge_lo + (max(0.0, ((xmax - margin) - edge_lo - total) / 2.0)
+                            if anchor == "center" else 0.0)
         for (ref, ext, pad_ext, overhang) in items:
             L, R, T, B = ext
             pL, pR, pT, pB = pad_ext
@@ -565,7 +586,11 @@ def layout_along_edge(items, edge, board_box, margin, spacing, clearance=None):
             out.append((ref, x, y, fits))
             cursor = x + R + spacing
     else:
-        cursor = ymin + margin
+        edge_lo = ymin + margin
+        total = (sum(it[1][2] + it[1][3] for it in items)
+                 + spacing * max(0, len(items) - 1))
+        cursor = edge_lo + (max(0.0, ((ymax - margin) - edge_lo - total) / 2.0)
+                            if anchor == "center" else 0.0)
         for (ref, ext, pad_ext, overhang) in items:
             L, R, T, B = ext
             pL, pR, pT, pB = pad_ext

--- a/src/kicad_mcp/utils/placement/edge_terminal.py
+++ b/src/kicad_mcp/utils/placement/edge_terminal.py
@@ -312,8 +312,128 @@ def normalize_hint(raw: object) -> Tuple[dict, list]:
 
 
 # ---------------------------------------------------------------------------
-# Injectable source string for embedded pcbnew scripts
+# Terminal distribution (SPEC_Multi_Edge_Terminal_Distribution.md §3-§5)
+# Pure, parent-side: the SINGLE source for BOTH the board size and the per-ref
+# edge assignment (passed to placement as {"edge": E} hints). Runs in the parent
+# only — NOT injected into the pcbnew script — so it does not appear in
+# EDGE_TERMINAL_HELPER and must not import tools.pcb_pipeline (no cycle).
 # ---------------------------------------------------------------------------
+
+_OPP_EDGE = {"top": "bottom", "bottom": "top", "left": "right", "right": "left"}
+
+
+def _size_from_assignment(
+    interior, terminals, edge_of, primary, side_a, side_b, horizontal,
+    routing_factor, padding, spacing, corner_inset_mm, corner_center_inset_mm,
+    side_silk_gap_mm,
+):
+    """Board ``{width_mm,height_mm}`` for a given edge assignment (SPEC §4,
+    generalized). Canonical frame: ``primary`` terminals run along the ALONG axis;
+    the two side edges run along the CROSS axis. Reduces EXACTLY to
+    ``_content_aware_size`` when every terminal is on ``primary`` (the regression
+    lock) — verified by ``test_terminal_distribution``."""
+    interior_area = sum(c["w"] * c["h"] for c in interior)
+    max_interior = max((max(c["w"], c["h"]) for c in interior), default=0.0)
+    cluster = math.sqrt(interior_area * routing_factor) if interior_area > 0 else 0.0
+    cluster = max(cluster, max_interior)
+
+    def _on(edge):
+        return [t for t in terminals if edge_of.get(t["ref"]) == edge]
+
+    def _along(ts):
+        return sum(max(t["w"], t["h"]) + spacing for t in ts)
+
+    def _depth(ts):
+        return max((min(t["w"], t["h"]) for t in ts), default=0.0)
+
+    p_ts, a_ts, b_ts = _on(primary), _on(side_a), _on(side_b)
+    sides_used = bool(a_ts) or bool(b_ts)
+    # Side bands eat the ALONG axis (depth inward) + reserve an inboard silk gap so
+    # side-edge legends clear the cluster. The primary band eats the CROSS axis.
+    d_a = _depth(a_ts) + (side_silk_gap_mm if a_ts else 0.0)
+    d_b = _depth(b_ts) + (side_silk_gap_mm if b_ts else 0.0)
+    d_p = _depth(p_ts)
+    # ALONG: the primary run / cluster sits BETWEEN the two side bands (so the
+    # primary terminals never extend into a side band — §4.1 body-overlap guard).
+    along_dim = max(cluster, _along(p_ts)) + d_a + d_b + 2 * padding + 2 * corner_inset_mm
+    # CROSS: cluster / side runs sit ABOVE the primary band. Corner reserve is FULL
+    # on this axis only when a terminal edge (a side) runs along it (RFE #1).
+    cross_corner = corner_inset_mm if sides_used else corner_center_inset_mm
+    cross_dim = (max(cluster, _along(a_ts), _along(b_ts)) + d_p
+                 + 2 * padding + 2 * cross_corner)
+    w, h = (along_dim, cross_dim) if horizontal else (cross_dim, along_dim)
+    return {"width_mm": math.ceil(w), "height_mm": math.ceil(h)}
+
+
+def distribute_terminals(
+    components,
+    antenna_side: Optional[str] = None,
+    *,
+    mode: str = "single_edge",
+    routing_factor: float = 2.5,
+    padding: float = 2.0,
+    spacing: float = 1.0,
+    corner_inset_mm: float = 0.0,
+    corner_center_inset_mm: float = 0.0,
+    side_silk_gap_mm: float = 2.5,
+    near_square_thresh: float = 1.35,
+) -> dict:
+    """Decide each field-wiring terminal's board edge AND the board size — the
+    single source for sizing + placement (SPEC §3-§5).
+
+    ``components``: ``[{"ref","w","h","is_terminal"}, …]``. ``antenna_side``: the
+    edge the MCU antenna overhangs ("top"/…/None); terminals go OPPOSITE it
+    (``primary``), spilling only to the perpendicular SIDE edges, never the antenna
+    edge. ``mode="single_edge"`` keeps today's all-on-one-edge behaviour;
+    ``"multi_edge"`` peels terminals onto the side edges to square the board.
+
+    Returns ``{"edge_of": {ref: edge}, "size": {"width_mm","height_mm"},
+    "primary_edge": edge}``."""
+    interior = [c for c in components if not c.get("is_terminal")]
+    terminals = sorted((c for c in components if c.get("is_terminal")),
+                       key=lambda t: natural_ref_key(t.get("ref", "")))
+    horizontal = (antenna_side in ("top", "bottom")) if antenna_side else True
+    primary = _OPP_EDGE.get(antenna_side or "", "bottom")
+    side_a, side_b = ("left", "right") if horizontal else ("top", "bottom")
+
+    def _size(edge_of):
+        return _size_from_assignment(
+            interior, terminals, edge_of, primary, side_a, side_b, horizontal,
+            routing_factor, padding, spacing, corner_inset_mm,
+            corner_center_inset_mm, side_silk_gap_mm)
+
+    all_primary = {t["ref"]: primary for t in terminals}
+    base_size = _size(all_primary)
+    base = {"edge_of": all_primary, "size": base_size, "primary_edge": primary}
+
+    # single_edge, or too few terminals to split → today's behaviour.
+    if mode != "multi_edge" or len(terminals) < 2:
+        return base
+
+    # Step 2: already near-square (aspect-ratio cutoff, axis-independent) → no-op.
+    bw, bh = base_size["width_mm"], base_size["height_mm"]
+    lo, hi = min(bw, bh), max(bw, bh)
+    if lo > 0 and hi <= lo * near_square_thresh:
+        return base
+
+    # Step 3: peel a suffix (natural-ref order) off primary; first ceil(k/2) of the
+    # peeled refs → side_a, the rest → side_b (each side stays in natural order).
+    # Score (max-dimension, area); argmin, ties → smaller k (and single-edge wins
+    # over any multi-edge tie, since the loop only replaces on a STRICT improvement).
+    n = len(terminals)
+    best_edge_of, best_size = all_primary, base_size
+    best_score = (hi, bw * bh)
+    for k in range(1, n):
+        edge_of = dict(all_primary)
+        peeled = terminals[n - k:]
+        half = (k + 1) // 2
+        for i, t in enumerate(peeled):
+            edge_of[t["ref"]] = side_a if i < half else side_b
+        sz = _size(edge_of)
+        score = (max(sz["width_mm"], sz["height_mm"]), sz["width_mm"] * sz["height_mm"])
+        if score < best_score:
+            best_score, best_edge_of, best_size = score, edge_of, sz
+    return {"edge_of": best_edge_of, "size": best_size, "primary_edge": primary}
 # Concatenated into the _step_smart_placement script.  The definitions below
 # MUST stay behaviourally identical to the Python-side functions above (type
 # annotations stripped — the embedded script has no `from __future__ import

--- a/src/kicad_mcp/utils/placement/edge_terminal.py
+++ b/src/kicad_mcp/utils/placement/edge_terminal.py
@@ -342,17 +342,34 @@ _OPP_EDGE = {"top": "bottom", "bottom": "top", "left": "right", "right": "left"}
 def _size_from_assignment(
     interior, terminals, edge_of, primary, side_a, side_b, horizontal,
     routing_factor, padding, spacing, corner_inset_mm, corner_center_inset_mm,
-    side_silk_gap_mm,
+    side_silk_gap_mm, cluster_wh: Optional[tuple] = None,
 ):
     """Board ``{width_mm,height_mm}`` for a given edge assignment (SPEC §4,
     generalized). Canonical frame: ``primary`` terminals run along the ALONG axis;
     the two side edges run along the CROSS axis. Reduces EXACTLY to
     ``_content_aware_size`` when every terminal is on ``primary`` (the regression
-    lock) — verified by ``test_terminal_distribution``."""
+    lock) — verified by ``test_terminal_distribution``.
+
+    ``cluster_wh``: optional measured ``(cluster_w, cluster_h)`` rectangle (board
+    frame) from a placement pass — replaces the square-``C`` interior estimate with
+    axis-specific values (SPEC_Post_Placement_Board_Refit.md §4). ``None`` ⇒ the
+    square-``C`` path, byte-identical to today (the re-fit regression lock)."""
     interior_area = sum(c["w"] * c["h"] for c in interior)
     max_interior = max((max(c["w"], c["h"]) for c in interior), default=0.0)
-    cluster = math.sqrt(interior_area * routing_factor) if interior_area > 0 else 0.0
-    cluster = max(cluster, max_interior)
+    if cluster_wh is None:
+        cluster = math.sqrt(interior_area * routing_factor) if interior_area > 0 else 0.0
+        cluster = max(cluster, max_interior)
+        along_cluster = cross_cluster = cluster
+    else:
+        # Measured rectangle → axis-specific. ALONG is the primary-run axis: board
+        # WIDTH when horizontal (antenna top/bottom), HEIGHT otherwise. Keep the
+        # per-axis ``max_interior`` floor so a single oversized body still fits.
+        cluster_w, cluster_h = cluster_wh
+        along_cluster, cross_cluster = (
+            (cluster_w, cluster_h) if horizontal else (cluster_h, cluster_w)
+        )
+        along_cluster = max(along_cluster, max_interior)
+        cross_cluster = max(cross_cluster, max_interior)
 
     def _on(edge):
         return [t for t in terminals if edge_of.get(t["ref"]) == edge]
@@ -372,11 +389,11 @@ def _size_from_assignment(
     d_p = _depth(p_ts)
     # ALONG: the primary run / cluster sits BETWEEN the two side bands (so the
     # primary terminals never extend into a side band — §4.1 body-overlap guard).
-    along_dim = max(cluster, _along(p_ts)) + d_a + d_b + 2 * padding + 2 * corner_inset_mm
+    along_dim = max(along_cluster, _along(p_ts)) + d_a + d_b + 2 * padding + 2 * corner_inset_mm
     # CROSS: cluster / side runs sit ABOVE the primary band. Corner reserve is FULL
     # on this axis only when a terminal edge (a side) runs along it (RFE #1).
     cross_corner = corner_inset_mm if sides_used else corner_center_inset_mm
-    cross_dim = (max(cluster, _along(a_ts), _along(b_ts)) + d_p
+    cross_dim = (max(cross_cluster, _along(a_ts), _along(b_ts)) + d_p
                  + 2 * padding + 2 * cross_corner)
     w, h = (along_dim, cross_dim) if horizontal else (cross_dim, along_dim)
     return {"width_mm": math.ceil(w), "height_mm": math.ceil(h)}
@@ -394,6 +411,7 @@ def distribute_terminals(
     corner_center_inset_mm: float = 0.0,
     side_silk_gap_mm: float = 2.5,
     near_square_thresh: float = 1.35,
+    cluster_wh: Optional[tuple] = None,
 ) -> dict:
     """Decide each field-wiring terminal's board edge AND the board size — the
     single source for sizing + placement (SPEC §3-§5).
@@ -417,7 +435,7 @@ def distribute_terminals(
         return _size_from_assignment(
             interior, terminals, edge_of, primary, side_a, side_b, horizontal,
             routing_factor, padding, spacing, corner_inset_mm,
-            corner_center_inset_mm, side_silk_gap_mm)
+            corner_center_inset_mm, side_silk_gap_mm, cluster_wh)
 
     all_primary = {t["ref"]: primary for t in terminals}
     base_size = _size(all_primary)

--- a/tests/integration/test_firmware_pcb_pipeline.py
+++ b/tests/integration/test_firmware_pcb_pipeline.py
@@ -593,6 +593,92 @@ def test_audio_remote_to_routed_pcb(mcp_server, tmp_path):
         f"beyond the block on the inboard side)")
 
 
+def test_audio_remote_multi_edge_distribution(mcp_server, tmp_path):
+    """board.yaml ``terminal_distribution: multi_edge`` spreads the field terminals
+    across the antenna-opposite edge AND the two side edges (vs the single-edge
+    default the test above guards) → a squarer, smaller board. Pins the real-board
+    invariants: terminals on ≤3 edges (never the antenna), oriented wire-entry
+    OUTWARD on the side edges too, side-edge legends clear of pads, still routes,
+    and no antenna_frame_mismatch. See SPEC_Multi_Edge_Terminal_Distribution.md."""
+    import shutil
+
+    from kicad_mcp.utils.firmware.intent import load_intent
+    from kicad_mcp.utils.placement.edge_terminal import (
+        natural_ref_key, outward_normal, rotation_to_face)
+    from kicad_mcp.utils.placement.wire_entry import WIRE_ENTRY
+    from kicad_mcp.tools.pcb_silkscreen import _op_check_silkscreen_overlaps
+
+    design = _tool(mcp_server, "design")
+    build = _tool(mcp_server, "build_pcb_from_schematic")
+
+    fw = tmp_path / "fw"
+    fw.mkdir()
+    shutil.copy(AUDIO_CONFIG_H, fw / "config.h")
+    shutil.copy(AUDIO_CONFIG_H.parent / "platformio.ini", fw / "platformio.ini")
+    (fw / "board.yaml").write_text(
+        "terminal_distribution: multi_edge\n"
+        "placement:\n"
+        "  CMCA_MIC: {locus: remote, device: INMP441}\n"
+        "  CMCA_PRESENCE: {locus: remote, device: LD2410}\n"
+        "  CMCA_I2S: {locus: on_board_with_remote_io, device: MAX98357A, external_io: [outp, outn]}\n"
+        "  CMCA_I2S2: {locus: on_board_with_remote_io, device: MAX98357A, external_io: [outp, outn]}\n"
+    )
+    intent = tmp_path / "intent.yaml"
+    sch = tmp_path / "ar.kicad_sch"
+    pro = tmp_path / "ar.kicad_pro"
+
+    assert design(operation="import_firmware", firmware_path=str(fw / "config.h"),
+                  out_path=str(intent))["status"] == "ok"
+    assert design(operation="expand_templates", intent_path=str(intent))["status"] == "ok"
+    r3 = design(operation="generate_schematic", intent_path=str(intent),
+                schematic_path=str(sch))
+    assert r3["status"] == "ok" and not r3["unresolved_endpoints"]
+
+    pro.write_text(json.dumps(_MINIMAL_PRO))
+    r4 = build(project_path=str(pro), board_width_mm=0, board_height_mm=0,
+               autoroute_passes=4, export_gerbers=False, intent_path=str(intent))
+    assert r4["status"] == "ok"
+    _assert_mostly_routed(r4, max_unrouted=4)
+
+    bw, bh = r4["board_width_mm"], r4["board_height_mm"]
+    # Squarer than the single-edge letterbox the sibling test pins (~129x65, AR≈2.0).
+    assert max(bw, bh) / min(bw, bh) < 1.6, f"multi-edge board not squarer: {bw}x{bh}"
+    assert bw * bh < 129 * 65, f"multi-edge area {bw*bh} not smaller than single-edge"
+
+    rot = [d for d in r4["steps"]["smart_placement"]["placement_decisions"]
+           if d["event"] == "rotation_chosen"]
+    edges = {d["edge"] for d in rot}
+    # Spread across opposite + side edges; NEVER the antenna edge (top here).
+    assert edges <= {"bottom", "left", "right"} and "top" not in edges
+    assert len(edges) >= 2, f"multi_edge did not spread terminals: {edges}"
+    # Per-edge natural ref order still holds (the layout gate).
+    by_edge: dict = {}
+    for d in rot:
+        by_edge.setdefault(d["edge"], []).append(d["ref"])
+    for e, refs in by_edge.items():
+        assert refs == sorted(refs, key=natural_ref_key), f"{e} out of order: {refs}"
+    # Wire-entry faces OUTWARD on EVERY used edge — incl. the new side edges
+    # (the A2 assumption: rotation_to_face works for left/right, not just top/bottom).
+    mkds = WIRE_ENTRY["TerminalBlock_Phoenix_MKDS-1,5-N-5.08_1xN_P5.08mm_Horizontal"]
+    for d in (x for x in rot if x.get("source") == "wire_entry"):
+        assert d["angle"] == rotation_to_face(mkds, outward_normal(d["edge"])), \
+            f"{d['ref']} on {d['edge']}: wire-entry not aimed outward"
+    # No copper pad off the board (rotation-sign guard on the side edges too).
+    assert not _refs_with_pads_off_board(r4["pcb_path"]), "pads off the board outline"
+
+    # Side-edge legends render clear of every pad (A1 — the crowding that drove the
+    # original single-edge decision; the side_silk_gap must actually clear them).
+    legend_labels = {p for L in load_intent(str(intent)).connector_legends
+                     for p in L.positions if p}
+    ov = _op_check_silkscreen_overlaps(str(pro).replace(".kicad_pro", ".kicad_pcb"))
+    pad_hits = {o.get("silk_text") for o in ov.get("overlaps", [])}
+    assert not (pad_hits & legend_labels), \
+        f"legend label(s) overlap a pad: {sorted(pad_hits & legend_labels)}"
+
+    # The frame guard stayed silent (parent/script antenna edge agree, A4).
+    assert not any("antenna_frame_mismatch" in w for w in (r4.get("warnings") or []))
+
+
 def test_approval_gate_audio_remote(mcp_server, tmp_path):
     """Phase 7 approval gate: build with approved=False returns a proposal of the
     PLACED (unrouted) board — real terminal edges, holes, a tweakable board.yaml,

--- a/tests/integration/test_firmware_pcb_pipeline.py
+++ b/tests/integration/test_firmware_pcb_pipeline.py
@@ -779,6 +779,90 @@ def test_audio_remote_terminal_centering(mcp_server, tmp_path):
     assert not {o.get("silk_text") for o in ov.get("overlaps", [])} & {"SCL", "SDA", "BCLK"}
 
 
+def test_audio_remote_board_refit(mcp_server, tmp_path, monkeypatch):
+    """board.yaml ``board_refit: true`` runs the post-placement re-fit pass
+    (SPEC_Post_Placement_Board_Refit Part A). On audio-remote the board is already
+    minimal for its terminals (the square-cluster over-estimate is ~4mm and the
+    terminals need it), so re-fit is a VERIFIED NO-OP — it must NEVER ship a worse
+    board. This test FORCES the full pass-2 path (margin→0 makes the no-op guard
+    pass so the second placement actually runs) and pins the safety contract:
+
+    - every pass-2 bridge step (redraw outline, remove+re-add holes, re-place) runs
+      CLEAN on real KiCad — the re-fit declines only on the *placement-fit* check,
+      not a bridge error (this is the regression guard for the SWIG ``Zones()``
+      crash + the CreateEmptyBoard-wipe blocker);
+    - the board that SHIPS is the valid pass-1 board, restored byte-for-dims from
+      the .pass1 backup — routes, seats, pads on-board, holes at the 88x72 corners.
+
+    With the default margin the re-fit declines at the no-op guard instead; that
+    cheaper path is covered by the pure no-op-guard tests."""
+    import shutil
+
+    from kicad_mcp.tools import pcb_pipeline
+
+    # Force the pass-2 path: a 0 routing margin lets the recomputed board pass the
+    # no-op guard, so the second placement runs (then trips the terminal-crowding
+    # fallback — exactly the path that exercises every bridge step).
+    monkeypatch.setattr(pcb_pipeline, "_CLUSTER_ROUTING_MARGIN_MM", 0.0)
+
+    design = _tool(mcp_server, "design")
+    build = _tool(mcp_server, "build_pcb_from_schematic")
+
+    fw = tmp_path / "fw"
+    fw.mkdir()
+    shutil.copy(AUDIO_CONFIG_H, fw / "config.h")
+    shutil.copy(AUDIO_CONFIG_H.parent / "platformio.ini", fw / "platformio.ini")
+    (fw / "board.yaml").write_text(
+        "terminal_distribution: multi_edge\n"
+        "board_refit: true\n"
+        "placement:\n"
+        "  CMCA_MIC: {locus: remote, device: INMP441}\n"
+        "  CMCA_PRESENCE: {locus: remote, device: LD2410}\n"
+        "  CMCA_I2S: {locus: on_board_with_remote_io, device: MAX98357A, external_io: [outp, outn]}\n"
+        "  CMCA_I2S2: {locus: on_board_with_remote_io, device: MAX98357A, external_io: [outp, outn]}\n"
+    )
+    intent = tmp_path / "intent.yaml"
+    sch = tmp_path / "ar.kicad_sch"
+    pro = tmp_path / "ar.kicad_pro"
+
+    assert design(operation="import_firmware", firmware_path=str(fw / "config.h"),
+                  out_path=str(intent))["status"] == "ok"
+    assert design(operation="expand_templates", intent_path=str(intent))["status"] == "ok"
+    r3 = design(operation="generate_schematic", intent_path=str(intent),
+                schematic_path=str(sch))
+    assert r3["status"] == "ok" and not r3["unresolved_endpoints"]
+
+    pro.write_text(json.dumps(_MINIMAL_PRO))
+    r4 = build(project_path=str(pro), board_width_mm=0, board_height_mm=0,
+               autoroute_passes=4, export_gerbers=False, intent_path=str(intent))
+    assert r4["status"] == "ok"
+
+    refit = r4["steps"].get("board_refit")
+    assert refit is not None, "board_refit step did not run with the flag on"
+    # The pass-2 bridge steps must have run CLEAN — a decline here would mean either
+    # the no-op guard didn't pass (margin patch ineffective) or a bridge step crashed.
+    assert refit["status"] in {"fallback", "ok"}, f"unexpected re-fit status: {refit}"
+    if refit["status"] == "fallback":
+        # Reverted on the PLACEMENT-fit check, NOT a bridge error → every bridge step
+        # (redraw / remove+re-add holes / re-place) completed on real KiCad.
+        assert "fit regression" in refit["reason"], \
+            f"re-fit fell back on a bridge error, not a fit check: {refit['reason']}"
+
+    # Whatever re-fit decided, the SHIPPED board is valid + minimal-or-smaller.
+    _assert_mostly_routed(r4, max_unrouted=4)
+    assert not _refs_with_pads_off_board(r4["pcb_path"]), "pads off the board outline"
+    assert not r4["steps"]["smart_placement"].get("failed_placements"), \
+        "shipped board has failed placements — re-fit broke the fallback contract"
+    bw, bh = r4["board_width_mm"], r4["board_height_mm"]
+    if refit["status"] == "fallback":
+        assert (bw, bh) == (88, 72), f"fallback did not restore the pass-1 board: {bw}x{bh}"
+    else:  # committed (a future board where the cluster genuinely over-estimates)
+        assert bw * bh <= 88 * 72, f"committed re-fit grew the board: {bw}x{bh}"
+
+    # The .pass1 backup must be cleaned up on both paths (no litter next to the board).
+    assert not list(tmp_path.rglob("*.pass1")), "leftover .pass1 backup not cleaned up"
+
+
 def test_approval_gate_audio_remote(mcp_server, tmp_path):
     """Phase 7 approval gate: build with approved=False returns a proposal of the
     PLACED (unrouted) board — real terminal edges, holes, a tweakable board.yaml,

--- a/tests/integration/test_firmware_pcb_pipeline.py
+++ b/tests/integration/test_firmware_pcb_pipeline.py
@@ -97,6 +97,28 @@ def _terminal_hole_overlaps(pcb_path):
     return run_pcbnew_script(script, params={"pcb": pcb_path}, timeout=60.0)["overlaps"]
 
 
+def _terminal_centers(pcb_path):
+    """Each field-terminal J*'s courtyard centre (mm) AND the board centre — for the
+    terminal-centering gate (a centred edge group's mid-point sits near the board
+    mid-point on that edge's along-axis)."""
+    from kicad_mcp.utils.pcbnew_bridge import run_pcbnew_script
+    script = (
+        "import pcbnew, json, sys\n"
+        "b = pcbnew.LoadBoard(json.loads(open(sys.argv[1]).read())['pcb'])\n"
+        "be = b.GetBoardEdgesBoundingBox()\n"
+        "out = {'board': [pcbnew.ToMM((be.GetLeft()+be.GetRight())//2),\n"
+        "                 pcbnew.ToMM((be.GetTop()+be.GetBottom())//2)], 'J': {}}\n"
+        "for f in b.GetFootprints():\n"
+        "    r = f.GetReference()\n"
+        "    if r.startswith('J'):\n"
+        "        bb = f.GetBoundingBox(False, False)\n"
+        "        out['J'][r] = [pcbnew.ToMM((bb.GetLeft()+bb.GetRight())//2),\n"
+        "                       pcbnew.ToMM((bb.GetTop()+bb.GetBottom())//2)]\n"
+        "print(json.dumps(out))\n"
+    )
+    return run_pcbnew_script(script, params={"pcb": pcb_path}, timeout=60.0)
+
+
 def _assert_mostly_routed(r4, max_unrouted):
     """Assert the board routed essentially completely, within ``max_unrouted``.
 
@@ -677,6 +699,84 @@ def test_audio_remote_multi_edge_distribution(mcp_server, tmp_path):
 
     # The frame guard stayed silent (parent/script antenna edge agree, A4).
     assert not any("antenna_frame_mismatch" in w for w in (r4.get("warnings") or []))
+
+
+def test_audio_remote_terminal_centering(mcp_server, tmp_path):
+    """board.yaml ``terminal_centering: true`` centres each edge's field-terminal
+    group within its edge instead of packing it at one end (Part B of
+    SPEC_Post_Placement_Board_Refit.md). Layout balance only — the board size is
+    unchanged. Combined here with multi_edge so all three used edges are exercised.
+    Pins: each used edge's terminal group is centred (group mid ≈ board mid on that
+    edge's axis), and the placement is still valid (on-edge, ordered, oriented,
+    pads on-board, silk clear, routes)."""
+    import shutil
+
+    from kicad_mcp.utils.placement.edge_terminal import natural_ref_key
+    from kicad_mcp.tools.pcb_silkscreen import _op_check_silkscreen_overlaps
+
+    design = _tool(mcp_server, "design")
+    build = _tool(mcp_server, "build_pcb_from_schematic")
+
+    fw = tmp_path / "fw"
+    fw.mkdir()
+    shutil.copy(AUDIO_CONFIG_H, fw / "config.h")
+    shutil.copy(AUDIO_CONFIG_H.parent / "platformio.ini", fw / "platformio.ini")
+    (fw / "board.yaml").write_text(
+        "terminal_distribution: multi_edge\n"
+        "terminal_centering: true\n"
+        "placement:\n"
+        "  CMCA_MIC: {locus: remote, device: INMP441}\n"
+        "  CMCA_PRESENCE: {locus: remote, device: LD2410}\n"
+        "  CMCA_I2S: {locus: on_board_with_remote_io, device: MAX98357A, external_io: [outp, outn]}\n"
+        "  CMCA_I2S2: {locus: on_board_with_remote_io, device: MAX98357A, external_io: [outp, outn]}\n"
+    )
+    intent = tmp_path / "intent.yaml"
+    sch = tmp_path / "ar.kicad_sch"
+    pro = tmp_path / "ar.kicad_pro"
+
+    assert design(operation="import_firmware", firmware_path=str(fw / "config.h"),
+                  out_path=str(intent))["status"] == "ok"
+    assert design(operation="expand_templates", intent_path=str(intent))["status"] == "ok"
+    r3 = design(operation="generate_schematic", intent_path=str(intent),
+                schematic_path=str(sch))
+    assert r3["status"] == "ok" and not r3["unresolved_endpoints"]
+
+    pro.write_text(json.dumps(_MINIMAL_PRO))
+    r4 = build(project_path=str(pro), board_width_mm=0, board_height_mm=0,
+               autoroute_passes=4, export_gerbers=False, intent_path=str(intent))
+    assert r4["status"] == "ok"
+    _assert_mostly_routed(r4, max_unrouted=4)
+
+    rot = [d for d in r4["steps"]["smart_placement"]["placement_decisions"]
+           if d["event"] == "rotation_chosen"]
+    edge_of = {d["ref"]: d["edge"] for d in rot}
+    assert set(edge_of.values()) <= {"bottom", "left", "right"}
+
+    # Each used edge's terminal group is CENTRED: the midpoint of the group's
+    # span (along that edge's axis) sits near the board midpoint. A start-packed
+    # group would sit well off-centre toward one end.
+    cen = _terminal_centers(r4["pcb_path"])
+    bcx, bcy = cen["board"]
+    by_edge: dict = {}
+    for ref, edge in edge_of.items():
+        by_edge.setdefault(edge, []).append(ref)
+    for edge, refs in by_edge.items():
+        horiz = edge in ("top", "bottom")
+        coords = sorted(cen["J"][r][0 if horiz else 1] for r in refs)
+        group_mid = (coords[0] + coords[-1]) / 2.0
+        board_mid = bcx if horiz else bcy
+        assert abs(group_mid - board_mid) < 6.0, \
+            f"{edge} group not centred: mid {group_mid:.1f} vs board {board_mid:.1f}"
+        # order still ascending along the edge
+        ordered = sorted(refs, key=natural_ref_key)
+        assert [cen["J"][r][0 if horiz else 1] for r in ordered] == \
+            sorted(cen["J"][r][0 if horiz else 1] for r in ordered)
+
+    # Still a valid placement: pads on-board, silk clear, no failed placements.
+    assert not _refs_with_pads_off_board(r4["pcb_path"])
+    assert not r4["steps"]["smart_placement"].get("failed_placements")
+    ov = _op_check_silkscreen_overlaps(str(pro).replace(".kicad_pro", ".kicad_pcb"))
+    assert not {o.get("silk_text") for o in ov.get("overlaps", [])} & {"SCL", "SDA", "BCLK"}
 
 
 def test_approval_gate_audio_remote(mcp_server, tmp_path):

--- a/tests/test_board_sizing.py
+++ b/tests/test_board_sizing.py
@@ -9,7 +9,11 @@ vertical axis swap, and the keepout-exclusion contract.
 """
 import math
 
-from kicad_mcp.tools.pcb_pipeline import _content_aware_size
+from kicad_mcp.tools.pcb_pipeline import (
+    _content_aware_size,
+    _hole_center_inset,
+    _hole_corner_clear,
+)
 
 
 def _wh(size):
@@ -86,15 +90,62 @@ def test_returns_single_size_not_a_list():
 # --- corner mounting-hole inset (Phase 5) ------------------------------------
 
 def test_corner_inset_zero_is_noop():
-    # inset=0 must equal the no-inset baseline — this is what keeps every other
-    # sizing test valid (the param defaults to 0.0).
+    # Both corner params default to 0.0 — that baseline must equal the no-inset
+    # case, which is what keeps every other sizing test valid.
     comp = [{"w": 10.0, "h": 10.0, "is_terminal": False}]
     assert _content_aware_size(comp, padding=2.0) == \
-        _content_aware_size(comp, padding=2.0, corner_inset_mm=0.0)
+        _content_aware_size(comp, padding=2.0, corner_inset_mm=0.0,
+                            corner_center_inset_mm=0.0)
 
 
-def test_corner_inset_grows_both_dims_by_2x():
+def test_corner_full_clearance_grows_only_the_terminal_edge_axis():
+    # RFE #1: corner_inset_mm (full keepout clearance) is reserved ALONG the
+    # terminal edge only. terminal_edge_horizontal=True -> along = WIDTH, so width
+    # grows by 2*3.5 and height is untouched. (2*3.5 is integral, so it survives
+    # the ceil() exactly.)
     comp = [{"w": 10.0, "h": 10.0, "is_terminal": False}]
     w0, h0 = _wh(_content_aware_size(comp, padding=2.0))
     w1, h1 = _wh(_content_aware_size(comp, padding=2.0, corner_inset_mm=3.5))
-    assert (w1, h1) == (w0 + 7, h0 + 7)   # 2 * 3.5 on each axis
+    assert (w1, h1) == (w0 + 7, h0)
+
+
+def test_corner_center_inset_grows_only_the_depth_axis():
+    # RFE #1: corner_center_inset_mm (hole-center inset) is reserved on the
+    # PERPENDICULAR depth axis only. horizontal -> depth = HEIGHT.
+    comp = [{"w": 10.0, "h": 10.0, "is_terminal": False}]
+    w0, h0 = _wh(_content_aware_size(comp, padding=2.0))
+    w1, h1 = _wh(_content_aware_size(comp, padding=2.0, corner_center_inset_mm=3.5))
+    assert (w1, h1) == (w0, h0 + 7)
+
+
+def test_corner_reservation_follows_the_terminal_edge_axis_on_swap():
+    # The seam that matters: full-clearance tracks the terminal edge, center-inset
+    # tracks the perpendicular — so on a VERTICAL terminal edge they swap onto the
+    # other dimensions (full -> HEIGHT, center -> WIDTH). Pins the axis mapping so
+    # a future edit can't silently transpose the two reservations.
+    comp = [{"w": 10.0, "h": 10.0, "is_terminal": False}]
+    w0, h0 = _wh(_content_aware_size(comp, padding=2.0,
+                                     terminal_edge_horizontal=False))
+    w1, h1 = _wh(_content_aware_size(comp, padding=2.0,
+                                     terminal_edge_horizontal=False,
+                                     corner_inset_mm=3.5, corner_center_inset_mm=1.5))
+    assert (w1, h1) == (w0 + 3, h0 + 7)   # center 2*1.5 -> width, full 2*3.5 -> height
+
+
+def test_hole_reserves_vanish_together_when_holes_off():
+    # Both reserves are 0 when there are no holes, so a no-holes board sizes
+    # exactly as if the params were never passed (mirrors each other's guard).
+    assert _hole_corner_clear(None) == 0.0
+    assert _hole_center_inset(None) == 0.0
+    off = {"count": 0, "inset_mm": 3.5, "drill_mm": 3.2, "keepout_mm": 1.5}
+    assert _hole_corner_clear(off) == 0.0
+    assert _hole_center_inset(off) == 0.0
+
+
+def test_center_inset_is_strictly_less_than_full_corner_clear():
+    # The whole point of RFE #1: the depth reserve (center inset) is smaller than
+    # the along reserve (full keepout clearance) — that gap is the height saved.
+    holes = {"count": 4, "inset_mm": 3.5, "drill_mm": 3.2, "keepout_mm": 1.5}
+    assert _hole_center_inset(holes) == 3.5
+    assert _hole_corner_clear(holes) == 3.5 + 1.6 + 1.5      # 6.6
+    assert _hole_center_inset(holes) < _hole_corner_clear(holes)

--- a/tests/test_edge_terminal_placement.py
+++ b/tests/test_edge_terminal_placement.py
@@ -243,6 +243,51 @@ class TestLayoutAlongEdge:
         res = layout_along_edge(self._items(30), "top", self.BOARD, 1.0, 1.0)
         assert any(not fits for (_, _, _, fits) in res)
 
+    # --- anchor="center" (Part B: terminal centering) ------------------------
+
+    def test_anchor_start_is_default_and_unchanged(self):
+        # The regression lock: anchor="start" must be byte-identical to the
+        # historical no-anchor call on every edge.
+        items = self._items(3)
+        for edge in ("top", "bottom", "left", "right"):
+            assert (layout_along_edge(items, edge, self.BOARD, 1.0, 1.0)
+                    == layout_along_edge(items, edge, self.BOARD, 1.0, 1.0, anchor="start"))
+
+    def test_center_balances_a_short_group_on_top_edge(self):
+        # 3 items, each 4mm wide (+1 spacing) → total span 4*3 + 1*2 = 14mm.
+        # usable = 100 - 2*margin(1) = 98 → slack 84 → 42 each side.
+        items = self._items(3)
+        res = layout_along_edge(items, "top", self.BOARD, 1.0, 1.0, anchor="center")
+        xs = [x for (_, x, _, _) in res]
+        left_gap = xs[0] - 2.0 - (self.BOARD[0] + 1.0)        # first courtyard-left to edge_lo
+        right_gap = (self.BOARD[2] - 1.0) - (xs[-1] + 2.0)    # edge_hi to last courtyard-right
+        assert abs(left_gap - right_gap) < EPS                # symmetric
+        assert left_gap > 0                                   # actually moved inboard
+        # order + spacing preserved
+        assert xs == sorted(xs)
+
+    def test_center_on_left_edge_balances_vertically(self):
+        items = self._items(2)
+        res = layout_along_edge(items, "left", self.BOARD, 1.0, 1.0, anchor="center")
+        ys = [y for (_, _, y, _) in res]
+        top_gap = ys[0] - 3.0 - (self.BOARD[1] + 1.0)
+        bot_gap = (self.BOARD[3] - 1.0) - (ys[-1] + 3.0)
+        assert abs(top_gap - bot_gap) < EPS
+
+    def test_center_group_filling_edge_falls_back_to_start(self):
+        # A group as long as the edge → no slack → center clamps to start (no
+        # negative offset, identical to start anchoring).
+        items = self._items(30)   # overflows the 100mm edge
+        start = layout_along_edge(items, "top", self.BOARD, 1.0, 1.0, anchor="start")
+        center = layout_along_edge(items, "top", self.BOARD, 1.0, 1.0, anchor="center")
+        assert center == start
+
+    def test_center_single_item_is_edge_centre(self):
+        res = layout_along_edge(self._items(1), "top", self.BOARD, 1.0, 1.0, anchor="center")
+        _, x, _, _ = res[0]
+        # courtyard centre lands at the board centre x
+        assert abs(x - (self.BOARD[0] + self.BOARD[2]) / 2.0) < EPS
+
 
 # ---------------------------------------------------------------------------
 # normalize_hint — explicit ambiguous-input pinning (the validation seam)
@@ -370,7 +415,9 @@ class TestEdgeTerminalHelperSource:
         # non-overhang branch anchors the full courtyard, not the pad box).
         items = [(f"J{i+1}", (2.0, 2.0, 3.0, 3.0), (1.0, 1.0, 1.5, 1.5), i % 2 == 0)
                  for i in range(4)]
+        # Compare BOTH anchors — a "center" bug present in only one copy would slip
+        # past a default-only ("start") comparison (the param defaults to "start").
         for edge in ["top", "bottom", "left", "right"]:
-            assert ns["layout_along_edge"](items, edge, board, 1.0, 1.0) == layout_along_edge(
-                items, edge, board, 1.0, 1.0
-            )
+            for anchor in ("start", "center"):
+                assert ns["layout_along_edge"](items, edge, board, 1.0, 1.0, anchor=anchor) \
+                    == layout_along_edge(items, edge, board, 1.0, 1.0, anchor=anchor)

--- a/tests/test_firmware_sidecar.py
+++ b/tests/test_firmware_sidecar.py
@@ -216,6 +216,9 @@ def test_known_keys_all_accepted(tmp_path):
         placement_hints: {}
         mounting_holes: {count: 4}
         bus_part_overrides: {}
+        terminal_distribution: multi_edge
+        terminal_centering: true
+        board_refit: true
     """))
     assert sc.power_source == "usb_c"
     assert sc.board_size_mm == [90, 75]
@@ -224,6 +227,30 @@ def test_known_keys_all_accepted(tmp_path):
     assert sc.placement_hints == {}
     assert sc.mounting_holes == {"count": 4}
     assert sc.bus_part_overrides == {}
+    assert sc.terminal_distribution == "multi_edge"
+    assert sc.terminal_centering is True
+    assert sc.board_refit is True
+
+
+# --- layout flags: terminal_centering / board_refit (bool) --------------------
+
+@pytest.mark.parametrize("key", ["terminal_centering", "board_refit"])
+@pytest.mark.parametrize("bad", ["1", "[]", "abc"])   # NB: YAML 'yes'/'on' ARE bools
+def test_layout_bool_flag_rejects_non_bool(tmp_path, key, bad):
+    with pytest.raises(SidecarError) as e:
+        load_sidecar(_write(tmp_path, f"{key}: {bad}\n"))
+    assert f"{key} must be true/false" in str(e.value)
+
+
+def test_board_refit_threads_into_intent_source():
+    # The orchestration reads design_intent.source["board_refit"]; apply_sidecar must
+    # populate it (and only when explicitly set, mirroring terminal_centering).
+    i = _intent()
+    apply_sidecar(i, BoardSidecar(board_refit=True))
+    assert i.source.get("board_refit") is True
+    j = _intent()
+    apply_sidecar(j, BoardSidecar())   # unset → absent (default off)
+    assert "board_refit" not in j.source
 
 
 # --- bus_part_overrides (C7) --------------------------------------------------

--- a/tests/test_firmware_templates.py
+++ b/tests/test_firmware_templates.py
@@ -11,6 +11,7 @@ import pytest
 
 from kicad_mcp.utils.firmware import knowledge as K
 from kicad_mcp.utils.firmware.intent import (
+    Endpoint,
     build_intent,
     from_dict,
     to_dict,
@@ -284,14 +285,39 @@ def test_i2s_mic_instantiated():
 def test_i2c_device_header_with_pullups():
     i = _audio()
     ex = i2c_device_header(i, RefAllocator(i))
-    assert any(c.value.startswith("I2C") for c in ex.components)   # the header
+    hdr = next(c for c in ex.components if c.value.startswith("I2C"))   # the header
     assert len([c for c in ex.components if c.value == "4.7k"]) == 2
+    # Pad→net mapping is unchanged by the §4-helper rewrite (GND/+3V3 are taps on
+    # pads 1/2; SCL/SDA land on pads 3/4) — the identity property the rewrite must
+    # preserve so any built board / fixture stays valid.
+    assert ("GND", Endpoint(ref=hdr.ref, pin="1")) in ex.power
+    assert ("+3V3", Endpoint(ref=hdr.ref, pin="2")) in ex.power
+    scl = next(n for n in ex.new_nets if n.name == "I2C0_SCL")
+    sda = next(n for n in ex.new_nets if n.name == "I2C0_SDA")
+    assert Endpoint(ref=hdr.ref, pin="3") in scl.endpoints
+    assert Endpoint(ref=hdr.ref, pin="4") in sda.endpoints
+    # Item #4: module header now carries a per-pad silk legend (was the last
+    # connector class bypassing the legend path). positions[i] labels pad i+1.
+    legend = next(lg for lg in ex.legends if lg.ref == hdr.ref)
+    assert legend.positions == ["GND", "+3V3", "SCL", "SDA"]
+    assert legend.device == "I2C0"
 
 def test_uart_device_header():
     i = _audio()
     ex = uart_device_header(i, RefAllocator(i))
-    assert any(c.value.startswith("UART") for c in ex.components)
+    hdr = next(c for c in ex.components if c.value.startswith("UART"))
     assert {n.name for n in ex.new_nets} == {"UART0_RX", "UART0_TX"}
+    # Same pad→net identity check as the I2C header (pads 1/2 = GND/+3V3 taps,
+    # 3/4 = RX/TX).
+    assert ("GND", Endpoint(ref=hdr.ref, pin="1")) in ex.power
+    assert ("+3V3", Endpoint(ref=hdr.ref, pin="2")) in ex.power
+    rx = next(n for n in ex.new_nets if n.name == "UART0_RX")
+    tx = next(n for n in ex.new_nets if n.name == "UART0_TX")
+    assert Endpoint(ref=hdr.ref, pin="3") in rx.endpoints
+    assert Endpoint(ref=hdr.ref, pin="4") in tx.endpoints
+    legend = next(lg for lg in ex.legends if lg.ref == hdr.ref)
+    assert legend.positions == ["GND", "+3V3", "RX", "TX"]
+    assert legend.device == "UART0"
 
 def test_usb_programming_skipped_for_native_usb():
     # ESP32-S3 has native USB -> no CP2102 bridge.

--- a/tests/test_new_tools.py
+++ b/tests/test_new_tools.py
@@ -739,6 +739,7 @@ class TestBuildPcbFromSchematic:
             str(tmp_path / "test.kicad_pcb"), 22, 69,
             mock_netlist.return_value["components"],
             holes={"count": 4, "drill_mm": 3.2, "inset_mm": 3.5, "keepout_mm": 1.5},
+            terminal_distribution="single_edge",
         )
 
     @patch("kicad_mcp.tools.pcb_pipeline._step_add_mounting_holes")

--- a/tests/test_terminal_distribution.py
+++ b/tests/test_terminal_distribution.py
@@ -127,3 +127,100 @@ def test_vertical_antenna_transposes_axes():
     horiz = distribute_terminals(comps, "top", mode="single_edge")["size"]
     vert = distribute_terminals(comps, "left", mode="single_edge")["size"]
     assert (horiz["width_mm"], horiz["height_mm"]) == (vert["height_mm"], vert["width_mm"])
+
+
+# --- cluster_wh override (SPEC_Post_Placement_Board_Refit §4, §8.1) -------------
+#
+# A controlled roster where the terminal run dominates the ALONG axis (so width is
+# pinned by terminals, not the cluster) and the cluster sets the CROSS axis. Lets
+# us hand-compute the cross shrink and assert width is untouched.
+import math as _math
+
+_RF_INT = [{"ref": "U1", "w": 8.0, "h": 8.0, "is_terminal": False}]
+_RF_TERMS = [{"ref": f"J{i}", "w": 10.0, "h": 12.0, "is_terminal": True}
+             for i in range(1, 5)]
+# square-C for _RF_INT: sqrt(64 * 2.5) = 12.649… (> max_interior 8)
+_RF_SQUARE_C = _math.sqrt(64.0 * 2.5)
+
+
+@pytest.mark.parametrize("antenna,mode", [
+    ("top", "single_edge"), ("left", "single_edge"),
+    ("top", "multi_edge"), ("left", "multi_edge"), (None, "single_edge"),
+])
+@pytest.mark.parametrize("ci,cc", [(0.0, 0.0), (6.6, 3.5)])
+def test_cluster_wh_none_is_regression_lock(antenna, mode, ci, cc):
+    # Passing cluster_wh=None must be byte-identical to not passing it at all —
+    # the square-C path is preserved (the re-fit regression lock, SPEC §4/§8.1).
+    comps = _INT + _TERMS
+    default = distribute_terminals(comps, antenna, mode=mode,
+                                   corner_inset_mm=ci, corner_center_inset_mm=cc)
+    explicit_none = distribute_terminals(comps, antenna, mode=mode,
+                                         corner_inset_mm=ci, corner_center_inset_mm=cc,
+                                         cluster_wh=None)
+    assert default == explicit_none
+
+
+def test_cluster_wh_equal_to_square_is_noop():
+    # cluster_wh = (C, C) where C is the square-C reproduces the square path
+    # exactly — the pure-level no-op identity the orchestration guard relies on.
+    comps = _RF_INT + _RF_TERMS
+    base = distribute_terminals(comps, "top", mode="single_edge")["size"]
+    same = distribute_terminals(comps, "top", mode="single_edge",
+                                cluster_wh=(_RF_SQUARE_C, _RF_SQUARE_C))["size"]
+    assert same == base
+
+
+def test_cluster_wh_rectangle_shrinks_cross_dim_exact():
+    # ALONG (width, horizontal): 4 terminals → _along = 4·(12+1) = 52 dominates the
+    # cluster (10) → width = 52 + 2·padding(2) = 56, UNCHANGED by the measure.
+    # CROSS (height): cross_cluster = max(10, max_interior 8) = 10; depth(p)=min(10,12)=10
+    #   → height = 10 + 10 + 2·padding = 24.  Square path: 12.649 + 10 + 4 = 26.6 → 27.
+    comps = _RF_INT + _RF_TERMS
+    sq = distribute_terminals(comps, "top", mode="single_edge")["size"]
+    got = distribute_terminals(comps, "top", mode="single_edge",
+                               cluster_wh=(10.0, 10.0))["size"]
+    assert got == {"width_mm": 56, "height_mm": 24}
+    assert got["width_mm"] == sq["width_mm"], "width is terminal-bound, must not move"
+    assert got["height_mm"] < sq["height_mm"], "measured cluster must shrink the cross dim"
+
+
+def test_cluster_wh_transposes_with_vertical_antenna():
+    # ALONG is the primary-run axis: width when horizontal (top), height when
+    # vertical (left). So the same measured rectangle maps to transposed boards.
+    comps = _RF_INT + _RF_TERMS
+    horiz = distribute_terminals(comps, "top", mode="single_edge",
+                                 cluster_wh=(10.0, 14.0))["size"]
+    vert = distribute_terminals(comps, "left", mode="single_edge",
+                                cluster_wh=(14.0, 10.0))["size"]
+    # left board with (14,10) must transpose the top board with (10,14)
+    assert (horiz["width_mm"], horiz["height_mm"]) == (vert["height_mm"], vert["width_mm"])
+
+
+def test_cluster_wh_reduction_property_audio_remote_shape():
+    # The audio-remote-shaped roster: a measured cluster smaller than the square-C
+    # estimate must drive the board strictly smaller (the whole point of re-fit).
+    comps = _INT + _TERMS
+    sq = distribute_terminals(comps, "top", mode="single_edge")["size"]
+    # _INT square-C ≈ sqrt((18·18 + 6·5)·2.5) ≈ 30.2; measure it materially smaller.
+    refit = distribute_terminals(comps, "top", mode="single_edge",
+                                 cluster_wh=(20.0, 20.0))["size"]
+    assert refit["height_mm"] < sq["height_mm"]
+    assert refit["width_mm"] * refit["height_mm"] < sq["width_mm"] * sq["height_mm"]
+
+
+def test_cluster_wh_feeds_multi_edge_and_stays_valid():
+    # multi_edge must consume cluster_wh too: the peel re-runs against the measured
+    # cluster. The optimizer minimizes (max_dim, area) lexicographically, so the
+    # sound invariant is on the PRIMARY objective — for any fixed peel a smaller
+    # cluster gives a board ≤ on both axes, hence the refit's best max-dim ≤ the
+    # None best. Every terminal stays assigned to a non-antenna edge.
+    comps = _INT + _TERMS
+    multi_none = distribute_terminals(comps, "top", mode="multi_edge",
+                                      corner_inset_mm=6.6, corner_center_inset_mm=3.5)
+    multi_refit = distribute_terminals(comps, "top", mode="multi_edge",
+                                       corner_inset_mm=6.6, corner_center_inset_mm=3.5,
+                                       cluster_wh=(20.0, 20.0))
+    mn = multi_none["size"]; mr = multi_refit["size"]
+    assert max(mr["width_mm"], mr["height_mm"]) <= max(mn["width_mm"], mn["height_mm"])
+    assert set(multi_refit["edge_of"]) == {t["ref"] for t in _TERMS}
+    assert "top" not in set(multi_refit["edge_of"].values())

--- a/tests/test_terminal_distribution.py
+++ b/tests/test_terminal_distribution.py
@@ -1,0 +1,129 @@
+"""Pure tests for ``distribute_terminals`` (SPEC_Multi_Edge_Terminal_Distribution
+§8.1). Boundary-focused per CLAUDE.md: the regression lock (single_edge ≡ today's
+``_content_aware_size``), the 4-antenna-sides axis mapping, the spill heuristic,
+and the degenerate counts (0, 1, near-square)."""
+from __future__ import annotations
+
+import pytest
+
+from kicad_mcp.tools.pcb_pipeline import _content_aware_size
+from kicad_mcp.utils.placement.edge_terminal import distribute_terminals
+
+# A reusable cluster + a wide terminal roster (the audio-remote shape: many
+# terminals → a wide letterbox in single-edge mode).
+_INT = [{"ref": "U1", "w": 18.0, "h": 18.0, "is_terminal": False},
+        {"ref": "U2", "w": 6.0, "h": 5.0, "is_terminal": False}]
+_TERMS = [{"ref": f"J{i}", "w": 10.0, "h": 12.0, "is_terminal": True} for i in range(1, 7)]
+
+
+def _wh(size):
+    return size["width_mm"], size["height_mm"]
+
+
+# --- THE regression lock: single_edge must equal _content_aware_size exactly ----
+
+@pytest.mark.parametrize("antenna,horiz", [
+    ("top", True), ("bottom", True), ("left", False), ("right", False), (None, True),
+])
+@pytest.mark.parametrize("ci,cc", [(0.0, 0.0), (6.6, 3.5), (3.0, 3.0)])
+def test_single_edge_equals_content_aware_size(antenna, horiz, ci, cc):
+    comps = _INT + _TERMS
+    got = distribute_terminals(comps, antenna, mode="single_edge",
+                               corner_inset_mm=ci, corner_center_inset_mm=cc)["size"]
+    want = _content_aware_size(comps, terminal_edge_horizontal=horiz,
+                               corner_inset_mm=ci, corner_center_inset_mm=cc)
+    assert got == want
+
+
+def test_single_edge_no_terminals_matches_baseline():
+    got = distribute_terminals(_INT, "top", mode="single_edge")
+    assert got["edge_of"] == {}
+    assert got["size"] == _content_aware_size(_INT, terminal_edge_horizontal=True)
+
+
+# --- edge assignment: opposite the antenna, never the antenna edge --------------
+
+@pytest.mark.parametrize("antenna,primary", [
+    ("top", "bottom"), ("bottom", "top"), ("left", "right"), ("right", "left"),
+])
+def test_primary_is_opposite_antenna(antenna, primary):
+    got = distribute_terminals(_INT + _TERMS, antenna, mode="single_edge")
+    assert got["primary_edge"] == primary
+    assert set(got["edge_of"].values()) == {primary}
+
+
+@pytest.mark.parametrize("antenna", ["top", "bottom", "left", "right"])
+def test_multi_edge_never_uses_antenna_edge(antenna):
+    got = distribute_terminals(_INT + _TERMS, antenna, mode="multi_edge",
+                               corner_inset_mm=6.6, corner_center_inset_mm=3.5)
+    assert antenna not in set(got["edge_of"].values())
+    # only the opposite + the two perpendicular sides are ever used
+    sides = {"top", "bottom", "left", "right"} - {antenna}
+    assert set(got["edge_of"].values()) <= sides
+
+
+# --- the heuristic: spill only when it helps ------------------------------------
+
+def test_multi_edge_spills_a_wide_letterbox_and_squares_it():
+    comps = _INT + _TERMS
+    single = distribute_terminals(comps, "top", mode="single_edge",
+                                  corner_inset_mm=6.6, corner_center_inset_mm=3.5)
+    multi = distribute_terminals(comps, "top", mode="multi_edge",
+                                 corner_inset_mm=6.6, corner_center_inset_mm=3.5)
+    sw, sh = _wh(single["size"]); mw, mh = _wh(multi["size"])
+    assert len(set(multi["edge_of"].values())) >= 2, "expected a spill to side edges"
+    assert abs(mw - mh) < abs(sw - sh), "multi-edge should be squarer"
+    assert mw * mh <= sw * sh, "multi-edge area must not be worse"
+
+
+def test_multi_edge_noops_when_already_near_square():
+    # A roster that single-edges to a near-square board: spilling must NOT happen.
+    comps = _INT + [{"ref": "J1", "w": 10.0, "h": 12.0, "is_terminal": True}]
+    single = distribute_terminals(comps, "top", mode="single_edge")
+    multi = distribute_terminals(comps, "top", mode="multi_edge")
+    assert multi["edge_of"] == single["edge_of"]
+    assert multi["size"] == single["size"]
+
+
+def test_one_terminal_is_never_split():
+    comps = _INT + [{"ref": "J1", "w": 10.0, "h": 12.0, "is_terminal": True}]
+    got = distribute_terminals(comps, "top", mode="multi_edge")
+    assert set(got["edge_of"].values()) == {"bottom"}
+
+
+def test_zero_terminals_multi_edge():
+    got = distribute_terminals(_INT, "top", mode="multi_edge")
+    assert got["edge_of"] == {}
+
+
+# --- ordering preserved per side (the layout gate requires it) ------------------
+
+def test_peeled_sides_keep_natural_ref_order():
+    from kicad_mcp.utils.placement.edge_terminal import natural_ref_key
+    got = distribute_terminals(_INT + _TERMS, "top", mode="multi_edge",
+                               corner_inset_mm=6.6, corner_center_inset_mm=3.5)
+    by_edge: dict = {}
+    for ref, edge in got["edge_of"].items():
+        by_edge.setdefault(edge, []).append(ref)
+    # edge_of is built by iterating terminals in natural order, so each edge's refs
+    # come out already sorted — exactly what the integration layout gate asserts.
+    for edge, refs in by_edge.items():
+        assert refs == sorted(refs, key=natural_ref_key), \
+            f"{edge} refs out of natural order: {refs}"
+
+
+def test_deterministic():
+    a = distribute_terminals(_INT + _TERMS, "top", mode="multi_edge",
+                             corner_inset_mm=6.6, corner_center_inset_mm=3.5)
+    b = distribute_terminals(_INT + _TERMS, "top", mode="multi_edge",
+                             corner_inset_mm=6.6, corner_center_inset_mm=3.5)
+    assert a == b
+
+
+def test_vertical_antenna_transposes_axes():
+    # Same roster, antenna on top (horizontal terminals) vs left (vertical): the
+    # single-edge sizes are transposes of each other.
+    comps = _INT + _TERMS
+    horiz = distribute_terminals(comps, "top", mode="single_edge")["size"]
+    vert = distribute_terminals(comps, "left", mode="single_edge")["size"]
+    assert (horiz["width_mm"], horiz["height_mm"]) == (vert["height_mm"], vert["width_mm"])


### PR DESCRIPTION
Autoplacer **board-compaction** arc for the firmware PCB pipeline — three independent, opt-in levers that stop auto-sized boards from being wasteful letterboxes, plus two silk/reserve fixes. Every behavioral change is behind a default-off `board.yaml` flag, so the other golden boards stay byte-identical.

## What's in here

| Lever | `board.yaml` flag | Effect | Status |
|---|---|---|---|
| **Multi-edge distribution** | `terminal_distribution: multi_edge` | spreads field terminals across the antenna-opposite + side edges | **the real win — audio-remote 129×65 → 88×72, −24% area** |
| **Terminal centering** (Part B) | `terminal_centering: true` | centers each edge's terminal group instead of packing one end | balance/look only, no size change |
| **Board re-fit** (Part A) | `board_refit: true` | two-pass: measure the placed cluster, redraw a tighter outline, re-place | correct + safe, but a **verified no-op on the goldens** (see below) |

Plus: per-pad silk legends on I2C/UART module headers (clearance-aware), and axis-aware corner mounting-hole reservation (RFE #1).

## ⚠️ Honest note on board re-fit (Part A)

Part A is fully implemented, tested, and safe — but the real-KiCad eyeball gate showed the **spec's motivating measurement was wrong**, so it yields no size win on audio-remote:

- square-cluster estimate `C` = √(area·2.5) is **~42mm, not the ~50 the spec assumed**; the measured cluster is 37.9mm → recoverable over-estimate is **~4mm, not ~11mm**.
- And that ~4mm isn't free — the bottom terminal band needs it. Every shrink trips `terminal_edge_crowded` and the fit-fallback reverts; every safe margin makes the recomputed board ≥ the original, so the no-op guard declines.

It's **kept** as a sound mechanism that would help a *denser-interior / lighter-terminal* board where `C` genuinely over-estimates. On the current goldens it declines and ships a byte-identical board. The integration test forces the pass-2 path and pins the **safety contract** (every bridge step runs clean; fallback restores a valid routed board), not a shrink. `SPEC_Post_Placement_Board_Refit.md` §0 records the measured reality.

A real bug was found + fixed en route: `_step_remove_mounting_holes` crashed on `list(board.Zones())` (SWIG yields raw pointers) — fixed to the collect-then-remove pattern `pcb_autoroute._export_dsn` uses, now guarded by the integration test.

## Design notes

- **Single sources of truth:** `distribute_terminals` is the one place that decides board size + per-terminal edge; `_OUTLINE_REDRAW_SCRIPT` and `_compose_hints` are shared between pass 1 and pass 2 so the two can't drift.
- **`cluster_wh=None` is byte-identical to today** (regression-locked) — re-fit only changes behavior when the flag is on AND the board is auto-sized.
- Every spec was cold-reviewed by clean-context subagents before implementation (caught mechanism-breaking blockers each time).

## Verification

- **2106 unit tests** + mypy clean
- **9/9 firmware integration tests** on KiCad 10 (8 goldens unperturbed + the new `test_audio_remote_board_refit`)

## Still open (minor, not blocking)

- §4.1 adjacent-edge band layout inset (deferred; only bites a denser side group)
- interior-silk-clearance RFE (J6 legend can get boxed-in)
- A6 explicit "rule-area zones survive DSN export" test (transitively covered today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)