### PR TITLE
Release 0.11.0 prep: cold code+test review, deferred fixes, board-regen gate

### DIFF
--- a/AGENT-INSTALL.md
+++ b/AGENT-INSTALL.md
@@ -142,17 +142,17 @@ All are optional. The server auto-detects sensible defaults for each platform.
 
 ## How to Use the Tools
 
-### Read CLAUDE.md First
+### Read AGENT-INSTRUCTIONS.md First
 
-The file `CLAUDE.md` in the repo root is your primary reference for **using** the tools. It contains:
+The file `AGENT-INSTRUCTIONS.md` in the repo root is your primary reference for **using** the tools, written for any agent (Claude, Gemini, Cursor, …). It contains:
 
 - **Mandatory rules** — three things you must never do (manual routing, guessing library names, parallel PCB writes)
-- **Complete workflow** — the 8-step process from schematic to verified board
+- **Complete workflow** — the step-by-step process from schematic to verified board
 - **Tool selection table** — which tool to use for each task
 - **Placement guidelines** — component grouping, spacing, pin numbering
 - **DRC interpretation** — which violations matter and which are cosmetic
 
-If you are registered as an MCP server for a project that does KiCad work, the project's claude configuration should include kicad-mcp's `CLAUDE.md` so you always have it in context.
+The critical rules are also delivered automatically to every MCP client through the server's `instructions` (no file-reading required), so you see them before opening any doc. (Claude Code users: the repo's local, git-ignored `CLAUDE.md` `@`-imports `AGENT-INSTRUCTIONS.md` and adds Claude-specific notes.)
 
 ### Client Compatibility
 
@@ -258,9 +258,9 @@ When filing an issue, include:
 ### Pull Requests
 
 - PRs for bug fixes, new platform support, and new tools are welcome
-- New operations fold into an existing router (schematic, pcb, audit, drc, autoroute, library, project, analyze, export) or add a new standalone tool if they don't fit any router's domain
+- New operations fold into an existing router (schematic, pcb, audit, drc, autoroute, library, project, analyze, export, lcsc, schematic_layout, design) or add a new standalone tool if they don't fit any router's domain
 - PCB tools use the subprocess bridge (`run_pcbnew_script`); schematic tools use kicad-sch-api in-process
-- Run `pytest` before submitting — all tests should pass (currently 1134 tests)
+- Run `pytest` before submitting — all tests should pass (2,000+ tests)
 - Tools return `{"status": "ok", ...}` on success or `{"error": "..."}` on failure — follow this convention
 
 ### Adding a New Operation to an Existing Router

--- a/AGENT-INSTRUCTIONS.md
+++ b/AGENT-INSTRUCTIONS.md
@@ -1,0 +1,199 @@
+# kicad-mcp — Operating Instructions for AI Agents
+
+How to use this MCP server to design circuits and lay out PCBs. These
+instructions are agent-agnostic — they apply whether you are Claude, Gemini,
+Cursor, or any other MCP-capable agent. (Contributor/development conventions for
+hacking on this repo live in `AGENTS.md` and `CONTRIBUTING.md`, not here.)
+
+You have access to <!-- tool-count -->17<!-- /tool-count --> MCP tools. Most are **routers** that dispatch on an `operation=` argument (e.g. `pcb(operation="place_footprint", ...)`, `drc(operation="autofix", ...)`, `library(operation="search", ...)`); the rest are standalone tools (`build_pcb_from_schematic`, `estimate_board_size`, `suggest_placement`, `panelize_pcb`, `analyze_placement_telemetry`). See [TOOLS.md](TOOLS.md) for the full router/operation reference.
+
+## Mandatory Rules
+
+### NEVER manually route traces
+
+Do not route with `pcb(operation="add_trace")` or `pcb(operation="add_via")`. LLMs cannot compute spatial clearances reliably — manual routing produces track crossings, shorts, and clearance violations. Always use `autoroute(operation="run")` instead. It wraps FreeRouter and solves routing in seconds with zero violations.
+
+The only acceptable use of `add_trace`/`add_via` is minor touch-ups after autorouting, if specifically requested.
+
+### NEVER guess library or footprint names
+
+KiCad library names change between versions. Always search first via the `library` router:
+
+```
+library(operation="search", query="op amp", type="symbol")   → lib_id for schematic add_component
+library(operation="search", query="0603 resistor")            → library + name for pcb place_footprint (type="footprint" is default)
+```
+
+### NEVER modify the same PCB file in parallel
+
+PCB tools run as subprocesses that load, modify, and save the file. Two concurrent writes will corrupt it. Always serialize PCB operations — never issue two mutating PCB calls against the same file at once.
+
+### Delegate read-only work to keep your context lean
+
+KiCad sessions accumulate large tool results that fill an agent's context window. **If your agent supports sub-tasks or sub-agents, delegate read-only work to them** and keep only the conclusions in your main context. If it doesn't, just be mindful of how much state you pull in.
+
+**Safe to delegate / parallelize (read-only):**
+- `library(operation="search")` — symbol/footprint lookup
+- `schematic(operation="info"|"list_components")`, `analyze(operation="connections"|"netlist")` — read-only analysis
+- `pcb(operation="get_pad_positions"|"list_nets"|"list_footprints")` — PCB state queries
+- `drc(operation="run")`, `audit(operation="all"|"placement"|"pad_clearances"|"check_silkscreen_overlaps")` — verification passes
+- `estimate_board_size`, `suggest_placement` — planning queries
+
+**Serialize in your main flow (state-mutating — never run two at once):**
+- Mutating router operations: `pcb(operation="place_footprint"|"move_footprint"|"add_net"|"bulk_assign_pad_nets"|"add_zone"|"fill_zones"|...)`, `schematic(operation="create"|"add_component"|"save"|...)`, `autoroute(operation="run")`, `drc(operation="autofix")`, `audit(operation="auto_fix_placement")`
+- Standalone mutators: `build_pcb_from_schematic`, `panelize_pcb`
+
+## Workflow
+
+Follow this order for a complete board design:
+
+### 1. Schematic
+
+```
+schematic(operation="create", name="project")
+library(operation="search", query="...", type="symbol")           # Find symbol lib_id
+schematic(operation="add_component", lib_id=..., reference=..., value=..., position=[x, y])
+schematic(operation="connect_pins_with_labels", comp1_ref=..., pin1=..., comp2_ref=..., pin2=..., net_name=...)
+schematic(operation="add_label_to_pin", reference=..., pin_number=..., text="GND")  # Power/ground
+schematic(operation="save")
+schematic(operation="validate")
+```
+
+### 2. Board Size Planning
+
+```
+estimate_board_size(footprints=[                    # Get dimensions BEFORE creating PCB
+    {"library": "...", "footprint_name": "..."},
+    ...
+])
+```
+
+### 3. PCB Setup
+
+```
+pcb(operation="create", pcb_path="project.kicad_pcb")
+pcb(operation="set_outline", pcb_path=..., x_mm=100, y_mm=100, width_mm=50, height_mm=30)
+pcb(operation="set_design_rules", pcb_path=..., min_track_width_mm=0.25, min_clearance_mm=0.2)
+```
+
+### 4. Footprint Placement
+
+```
+library(operation="search", query="...")     # Find footprint library + name (type="footprint" default)
+pcb(operation="place_footprint", pcb_path=..., library=..., footprint_name=..., reference=..., value=..., x_mm=..., y_mm=...)
+```
+
+Or after placing footprints anywhere and assigning nets:
+```
+suggest_placement(pcb_path=...)             # Get optimized positions based on connectivity
+# Then apply with pcb(operation="move_footprint", ...) for each suggestion
+```
+
+After placing all footprints:
+```
+audit(operation="all", pcb_path=...)        # Overlaps + keepouts + silkscreen in one call
+```
+
+### 5. Net Assignment
+
+For a schematic-driven board, the whole PCB (placement + nets + routing) is built in one step by the pipeline — see `build_pcb_from_schematic(project_path="project.kicad_pro")`.
+
+To assign nets manually on an existing PCB:
+```
+pcb(operation="add_net", pcb_path=..., net_name="VCC")
+pcb(operation="bulk_assign_pad_nets", pcb_path=..., assignments=[
+    {"reference": "U1", "pad": "1", "net": "VCC"},
+    ...
+])
+```
+
+Verify: `pcb(operation="get_pad_positions", pcb_path=..., reference="U1")` — every pad should show its net name.
+
+### 6. Autoroute
+
+```
+autoroute(operation="run", pcb_path=..., passes=2)
+```
+
+FreeRouter is non-deterministic. Use `passes=2` or `passes=3` for complex boards — the tool keeps the best result. Requires Java 17+. (Long routes can run async via `autoroute(operation="start"|"poll")`.)
+
+### 7. Panelization (optional)
+
+```
+panelize_pcb(pcb_path=..., rows=2, cols=5, cut_type="vcuts", framing="railstb")
+```
+
+Creates a manufacturing panel with V-scores or mousebites. Supports framing rails, tooling holes, and fiducials. Output defaults to `{name}-panel.kicad_pcb`.
+
+### 8. Copper Zones and Finish
+
+```
+pcb(operation="add_zone", pcb_path=..., net_name="GND", layer="B.Cu",
+    corners=[[x1,y1], [x2,y1], [x2,y2], [x1,y2]])
+pcb(operation="fill_zones", pcb_path=...)
+drc(operation="run", project_path="project.kicad_pro")
+pcb(operation="check_silkscreen_overlaps", pcb_path=...)
+```
+
+Zone corners should match or exceed the board outline. Common pattern: GND pour on B.Cu covering the full board.
+
+### 9. DRC Auto-Fix (optional)
+
+If DRC reveals violations, auto-fix them in one shot:
+
+```
+drc(operation="autofix", pcb_path=..., project_path="project.kicad_pro", autoroute_passes=2)
+```
+
+Fixes courtyard overlaps (nudges footprints), routing violations (clears + re-autoroutes), and silkscreen overlaps in order. Returns before/after DRC comparison.
+
+For targeted fixes:
+```
+audit(operation="auto_fix_placement", pcb_path=..., spacing_mm=0.5)   # Courtyard overlaps only
+pcb(operation="auto_fix_silkscreen", pcb_path=...)                     # Silkscreen overlaps only
+```
+
+## Tool Selection
+
+| I need to... | Use this | Not this |
+|---|---|---|
+| Choose board size | `estimate_board_size` | Guessing dimensions |
+| Initial placement | `suggest_placement` | Manual coordinate math |
+| Route traces | `autoroute(operation="run")` | `pcb(operation="add_trace"/"add_via")` |
+| Find a symbol name | `library(operation="search", type="symbol")` | Guessing from training data |
+| Find a footprint name | `library(operation="search")` (footprint default) | Guessing from training data |
+| Build a PCB from a schematic | `build_pcb_from_schematic` | Manual `add_net` + `bulk_assign_pad_nets` |
+| Check all placement issues | `audit(operation="all")` | Three separate audit calls |
+| Fix silkscreen overlaps | `pcb(operation="auto_fix_silkscreen")` | Manual `pcb(operation="update_silkscreen")` |
+| Fix courtyard overlaps | `audit(operation="auto_fix_placement")` | Manual `pcb(operation="move_footprint")` guesswork |
+| Fix all DRC violations | `drc(operation="autofix")` | Manual fix-by-fix iteration |
+| Run DRC | `drc(operation="run")` | Skipping verification |
+
+## Placement Guidelines
+
+- Group related components: IC + decoupling cap + pull-ups should be adjacent
+- Leave 2-3mm between component groups for trace routing
+- Horizontal screw terminals (Phoenix MKDS) are designed to overhang the board edge — this is normal and expected
+- SOIC pin numbering: pins 1-4 left side top-to-bottom, pins 5-8 right side bottom-to-top
+- Use `audit(operation="validate_one")` to check a specific position before placing, `audit(operation="placement")` to check all placements after
+
+## DRC Interpretation
+
+**Acceptable on prototype boards:**
+- `courtyards_overlap` — OK if hand-solderable
+- `starved_thermal` — fewer thermal relief spokes, still connected
+- `silk_overlap`, `silk_over_copper` — cosmetic only
+
+**Must fix:**
+- `tracks_crossing` — same-layer traces from different nets crossing
+- `shorting_items` — different nets shorted
+- `clearance` — copper-to-copper too close
+- `unconnected_items` — missing connections
+
+## Technical Notes
+
+- PCB tools run via KiCad's bundled Python as subprocesses (`utils/pcbnew_bridge.py`). Each call loads the board, modifies it, saves, and returns JSON.
+- Schematic tools use `kicad-sch-api` in-process. One schematic loaded at a time — call `schematic(operation="load")` or `schematic(operation="create")` before other schematic operations.
+- Library search indexes are at `~/.cache/kicad-mcp/library_index.db`. They auto-rebuild when KiCad libraries change; force one with `library(operation="rebuild_index")`.
+- `autoroute(operation="run")` auto-detects the FreeRouter JAR in common locations. Set `FREEROUTER_JAR` env var to override.
+- All tools return `{"status": "ok", ...}` on success or `{"error": "..."}` on failure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,87 @@
 
 All notable changes to kicad-mcp are documented here.
 
-## [Unreleased] — 0.11.0.dev0
+## [0.11.0] — 2026-06-03
+
+A large release: the tool-surface consolidation (below), an entire firmware
+front end, a human-rational autoplacer, component intelligence, autoroute
+hardening, and a release-readiness review pass. Net tool count is **17** — the
+13 consolidated core routers/standalones plus the firmware/LCSC/placement domain
+tools added this release.
+
+### Added — Firmware front end (`design` router)
+
+Turn an ESP32-style `config.h` pin map into a partial, routed board:
+`import_firmware → expand_templates → generate_schematic`, consumed by
+`build_pcb_from_schematic`. MCU auto-detected from `platformio.ini`. Everything
+firmware can't know (power tree, decoupling, pull-ups, address straps,
+connectors, parts) is emitted as an explicit **gap manifest** — never invented.
+
+- **Part resolution (C1–C9):** binds each bus to the SPECIFIC part the firmware
+  names (corpus + sibling source/docs), never silently substitutes. An ambiguous
+  bus (>1 candidate) is disclosed and held unrealized; a `board.yaml`
+  `bus_part_overrides` entry lets the user declare the part.
+- **Placement locus (L1–L8):** `board.yaml` `placement:` declares per-bus locus
+  (`remote` → field-wired screw terminal, `on_board_with_remote_io`, …) with
+  per-pad silk legends so terminals are wireable by hand.
+- `board.yaml` sidecar for firmware-blind facts (connectors, power source, board
+  size, mounting holes); refuses silent part substitution (INMP441 EOL case).
+
+### Added — Human-rational autoplacer
+
+Topology-aware placement that lays out a board the way a person would, verified
+by eyeballing real boards (`suggest_placement` / `schematic_layout` / the build
+pipeline):
+
+- Antenna-keepout overhang (module RF keepout hangs off the board edge, copper
+  stays on-board); content-aware board sizing; WIRE_ENTRY-oriented terminals.
+- Corner M3 mounting holes + per-hole no-copper keepouts; an approval gate
+  (`build(approved=False)` returns a placement proposal + render before routing).
+- Opt-in board re-fit, terminal centering, and **multi-edge terminal
+  distribution** (spreads field terminals across 2–3 edges; ~−24% area on the
+  audio-remote board).
+
+### Added — Component intelligence (`lcsc` router)
+
+LCSC/JLCPCB part search + footprint resolution backed by a local indexed DB,
+with assembly-tier awareness.
+
+### Changed — Autoroute hardening
+
+- Rank passes by KiCad's measured ratsnest, not FreeRouter's log; report the
+  measured unconnected count so the routing gate is honest.
+- Run FreeRouter as a macOS background app (no Dock/focus steal); disable its
+  analytics phone-home (air-gap).
+
+### Fixed — Release-readiness pass (cold code + test review, board-regen gate)
+
+- **Critical:** `schematic move_component` used `filter(reference=…)`, which
+  silently returns ALL components → moved the wrong one and reported `ok`.
+- **High:** touching-courtyard detection in keepout auto-fix; pre-route pad-gap
+  drift → single-source `PAD_GAP_HELPER`; `set_design_rules` now actually writes
+  through-hole/edge-clearance and stops clobbering the copper layer count;
+  footprint-load failure made fatal (was silently building incomplete boards);
+  zones/gerber failures can't discard a routed board; `drc autofix` checks
+  FreeRouter availability BEFORE clearing routing; async autoroute runs the
+  shared preflight; I2S mic net-name collision on a 2nd bus; netlist
+  incompleteness forwarding; lcsc tier-attribute guards.
+- **Medium:** oscillator double-classification; silk-vs-routing keyword order;
+  fiducials validation; premature keepout event; mutable default; event-context
+  early return; `from_dict` null coercion (+ top-level null-list TypeError);
+  label unescaping; sqlite connection leaks; `suggest_cards` skipped list;
+  config.h ambiguity warning; connector-edge cascade.
+- **#7 LM2596** misclassified as a linear LDO (prefix-shadow: loose `LM\d{3}`
+  matched inside `LM2596`) → anchored the pattern.
+- **Board-regen gate (verified on real boards, KiCad 9 + 10):** mounting-hole
+  keepout self-flagged its own NPTH pad and never kept the copper pour off the
+  screw annulus → fixed; module thermal vias (0.2mm) tripped the default 0.3mm
+  min-hole → create step now sets a 0.2mm min through-hole. All five golden
+  boards regenerate, route fully (DRC `unconnected=0`), and carry zero must-fix
+  DRC violations.
+- Cross-agent operating instructions (`AGENT-INSTRUCTIONS.md` + server
+  `instructions`) so non-Claude agents get the operating guide; corrected stale
+  tool references/counts. Unit suite grown to **2143** with regression coverage
+  pinning every fix above.
 
 ### Breaking — Tool Surface Consolidation (97 → 13 tools)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ A useful bug report includes:
 
 - **What you tried to do.** The agent prompt or tool call, if applicable.
 - **What happened instead.** The error message or unexpected output, verbatim.
-- **DRC output, if relevant.** `run_drc_check` results are gold for layout bugs.
+- **DRC output, if relevant.** `drc(operation="run")` results are gold for layout bugs.
 - **The schematic or PCB file.** A minimal `.kicad_sch` or `.kicad_pcb` that reproduces the issue is the fastest path to a fix. Strip out anything proprietary.
 - **Versions:** KiCad (`kicad-cli --version`), kicad-sch-api (`pip show kicad-sch-api`), OS, agent (Claude Code, Cursor, etc.).
 
@@ -23,7 +23,7 @@ Welcome, but a couple of preflight things:
 1. **Open an issue first** if it's a non-trivial change. Saves both of us from wasted effort if I disagree on direction.
 2. **Run the tests** before pushing:
    ```bash
-   pytest   # 479+ tests, ~9 seconds, no KiCad install required
+   pytest   # 2,000+ tests, ~30 seconds, no KiCad install required
    ```
 3. **Match the commit style.** `git log --oneline` shows it. Lowercase prefix (`fix:`, `feat:`, `test:`, `docs:`), short imperative summary, body explains the *why*.
 4. **One concern per PR.** Bug fix and unrelated cleanup go in separate PRs.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The agent knows the full workflow — schematic → board sizing → component p
 
 I built this because I need it. I'm not an electrical engineer — I build things for my model railroad that need custom PCBs, and I can't design circuits without this tool and Claude. This is how I actually get boards made: I describe what I need, Claude drives KiCad through this server, and I send the Gerbers to fab. It's not a demo or a hackathon project.
 
-That means reliability matters. The test suite (1134 tests) exists because I depend on this working correctly when I sit down to design a board. Bugs in PCB layout tools turn into real problems — wrong footprints, shorted traces, boards that don't work when they arrive from the manufacturer.
+That means reliability matters. The test suite (2,000+ tests) exists because I depend on this working correctly when I sit down to design a board. Bugs in PCB layout tools turn into real problems — wrong footprints, shorted traces, boards that don't work when they arrive from the manufacturer.
 
 I use Claude Code on a Mac. Other platforms *should* work — the code handles macOS, Windows, and Linux — but are untested. PRs for other agents and platforms will be considered.
 
@@ -42,7 +42,7 @@ If you hit a bug, [open an issue](https://github.com/blwfish/kicad-mcp/issues/ne
 
 ### What's Under the Hood
 
-The server provides <!-- tool-count -->17<!-- /tool-count --> tools — 11 domain routers and 5 standalones:
+The server provides <!-- tool-count -->17<!-- /tool-count --> tools — 12 domain routers and 5 standalones:
 
 - **`schematic`** — create and edit circuit schematics, place components, wire connections, labels, sheets
 - **`pcb`** — board layout, footprint placement, nets, routing, copper zones, silkscreen management
@@ -55,6 +55,7 @@ The server provides <!-- tool-count -->17<!-- /tool-count --> tools — 11 domai
 - **`export`** — manufacturing output: Gerbers, BOM CSV, PCB thumbnail
 - **`lcsc`** — LCSC/JLCPCB component search, footprint resolution, and part selection
 - **`schematic_layout`** — topology-aware schematic placement (see [docs/SPEC_Schematic_Placement.md](docs/SPEC_Schematic_Placement.md))
+- **`design`** — firmware-driven design: import firmware, expand templates, generate schematics, suggest device cards
 - **`build_pcb_from_schematic`** *(standalone)* — top-level schematic → board pipeline
 - **`panelize_pcb`** *(standalone)* — manufacturing panelization
 - **`estimate_board_size`** *(standalone)* — pre-PCB board size estimation
@@ -66,7 +67,7 @@ The server uses [FastMCP](https://github.com/jlowin/fastmcp) and delegates PCB o
 ### For Developers
 
 ```bash
-# 1134 tests, no KiCad installation required — runs in ~14 seconds
+# 2,000+ tests, no KiCad installation required — runs in ~30 seconds
 pytest
 
 # Lint

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1,6 +1,6 @@
 # Tool Summary
 
-This MCP server exposes <!-- tool-count -->17<!-- /tool-count --> MCP tools for KiCad EDA — 11 domain routers and 5 standalones.
+This MCP server exposes <!-- tool-count -->17<!-- /tool-count --> MCP tools for KiCad EDA — 12 domain routers and 5 standalones.
 
 Each router takes an `operation` parameter that selects the sub-operation.
 Unknown operations return an error listing valid choices.
@@ -17,8 +17,8 @@ Operations: `create`, `load`, `save`, `validate`, `info`, `clone`, `backup`,
 `add_wire`, `remove_wire`, `add_wire_between_pins`, `add_junction`,
 `add_label`, `remove_label`, `edit_label`, `add_label_to_pin`,
 `add_hierarchical_label`, `connect_pins_with_labels`,
-`add_text`, `add_text_box`, `edit_text`,
-`add_sheet`, `add_sheet_pin`, `add_net`
+`add_text`, `add_text_box`,
+`add_sheet`, `add_sheet_pin`
 
 ### `pcb` — PCB editing
 Operations: `create`, `load`, `finalize`,
@@ -35,7 +35,8 @@ Operations: `create`, `load`, `finalize`,
 
 ### `audit` — placement and clearance verification
 Operations: `all`, `placement`, `footprint_overlaps`, `pad_clearances`,
-`validate_one`, `auto_fix_placement`, `keepouts`, `pre_route_check`
+`validate_one`, `auto_fix_placement`, `keepouts`, `pre_route_check`,
+`constraints`, `check_silkscreen_overlaps`
 
 `all` accepts `detail="summary"` (default) or `detail="full"` for full bounding-box
 and gap data matching the standalone audit tools.
@@ -64,6 +65,11 @@ Operations: `search`, `resolve`, `assign`, `accept_tos`, `refresh_snapshot`
 ### `schematic_layout` — topology-aware schematic placement
 Operations: `suggest`, `apply`, `clear_cache`.
 See [docs/SPEC_Schematic_Placement.md](docs/SPEC_Schematic_Placement.md).
+
+### `design` — firmware-driven design + device cards
+Operations: `import_firmware`, `expand_templates`, `generate_schematic`,
+`show_intent`, `suggest_cards`.
+See [docs/SPEC_Firmware_Device_Cards.md](docs/SPEC_Firmware_Device_Cards.md).
 
 ## Standalone Tools
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kicad-mcp"
-version = "0.10.0"
+version = "0.11.0"
 description = "MCP server for KiCad electronic design automation — schematic, PCB layout, and analysis"
 readme = "README.md"
 license = { text = "MIT" }

--- a/scripts/sync_tool_count.py
+++ b/scripts/sync_tool_count.py
@@ -25,6 +25,7 @@ MARKDOWN_FILES = [
     ROOT / "README.md",
     ROOT / "TOOLS.md",
     ROOT / "AGENT-INSTALL.md",
+    ROOT / "AGENT-INSTRUCTIONS.md",
 ]
 TEST_FILE = ROOT / "tests" / "test_server.py"
 

--- a/src/kicad_mcp/server.py
+++ b/src/kicad_mcp/server.py
@@ -5,10 +5,32 @@ from fastmcp import FastMCP
 
 logger = logging.getLogger(__name__)
 
+# Delivered to EVERY MCP client over the protocol (Claude, Gemini, Cursor, …) —
+# the one cross-agent channel that needs no file-reading. Keep it short: the
+# few can't-miss rules plus pointers to the full docs. The complete operating
+# guide lives in AGENT-INSTRUCTIONS.md; the operation reference in TOOLS.md.
+SERVER_INSTRUCTIONS = """\
+KiCad EDA — design schematics and lay out PCBs. Most tools are routers that \
+dispatch on an `operation=` argument (e.g. pcb(operation="place_footprint"), \
+drc(operation="autofix"), library(operation="search")); the rest are standalone \
+(build_pcb_from_schematic, estimate_board_size, suggest_placement, panelize_pcb).
+
+Critical rules:
+- NEVER hand-route. Don't use pcb add_trace/add_via to route a board — use \
+autoroute(operation="run") (wraps FreeRouter). LLM-placed traces short and \
+violate clearances.
+- NEVER guess library/footprint names — they change between KiCad versions. \
+Search first with library(operation="search").
+- NEVER modify one PCB file with concurrent calls. PCB ops are \
+load/modify/save subprocesses; parallel writes corrupt the file. Serialize them.
+- Verify with drc(operation="run") and audit(operation="all") before finishing.
+
+See AGENT-INSTRUCTIONS.md for the full workflow, TOOLS.md for the operation reference."""
+
 
 def create_server() -> FastMCP:
     """Create and configure the KiCad MCP server."""
-    mcp = FastMCP("KiCad")
+    mcp = FastMCP("KiCad", instructions=SERVER_INSTRUCTIONS)
 
     # PCB domain router (phase 4: replaces 27 individual pcb_* tools)
     from kicad_mcp.tools.pcb import register_pcb_tools

--- a/src/kicad_mcp/tools/design.py
+++ b/src/kicad_mcp/tools/design.py
@@ -25,8 +25,11 @@ Operations:
 """
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
 
 import yaml
 from fastmcp import FastMCP
@@ -79,6 +82,16 @@ def _find_config_header(firmware_path: str) -> Optional[Path]:
         if prefer.exists():
             return prefer
         matches = sorted(p.rglob("config.h"))
+        if len(matches) > 1:
+            # Monorepo with several projects each carrying a config.h, and no
+            # include/config.h to disambiguate — we pick the alphabetically-first,
+            # which may be the wrong firmware. Warn so a silently-wrong import is
+            # diagnosable; the user can pass the specific config.h path to override.
+            logger.warning(
+                "Multiple config.h found under %r; using %s. Pass a specific "
+                "config.h path to disambiguate. Candidates: %s",
+                firmware_path, matches[0], ", ".join(str(m) for m in matches),
+            )
         return matches[0] if matches else None
     return None
 
@@ -314,6 +327,7 @@ def _op_suggest_cards(*, firmware_path: Optional[str]) -> dict:
     whoami = extract_whoami(intent.provenance)
 
     drafts: list[dict] = []
+    skipped: list[dict] = []
     for t, address in candidate_devices(parsed):
         if resolve_peripheral(t) is not None:
             continue  # already carded -> placed by import, nothing to draft
@@ -324,13 +338,23 @@ def _op_suggest_cards(*, firmware_path: Optional[str]) -> dict:
         if d is not None:
             drafts.append({"confidence": d.confidence, "reasons": d.reasons,
                            "card": d.card})
+        else:
+            # Auto-draft only handles I2C-addressable identity today. A non-I2C
+            # uncarded peripheral (HX711, bit-bang device, …) can't be drafted —
+            # record it so the caller knows it was considered and needs a card
+            # written by hand, rather than silently omitting it.
+            skipped.append({"type": t, "address": address,
+                            "reason": "no I2C address — auto-draft heuristics do not apply"})
     return {
         "status": "ok",
         "drafts": drafts,
         "count": len(drafts),
+        "skipped": skipped,
+        "skipped_count": len(skipped),
         "note": ("Drafts are proposals — review/confirm lib_id, footprint, roles, "
                  "supply/ground pins, then drop the card in a devices dir "
-                 "(KICAD_MCP_DEVICE_DIRS) and re-run import_firmware."),
+                 "(KICAD_MCP_DEVICE_DIRS) and re-run import_firmware. "
+                 "`skipped` peripherals need a device card written by hand."),
     }
 
 

--- a/src/kicad_mcp/tools/netlist.py
+++ b/src/kicad_mcp/tools/netlist.py
@@ -99,6 +99,13 @@ async def _op_extract_netlist(
             "nets": netlist_data["nets"],
             "analysis": analysis_results,
         }
+        # Forward incompleteness signals from the parser. The regex fallback
+        # (kicad-cli unavailable) cannot resolve hierarchical sub-schematics and
+        # returns empty pin lists; without these fields the caller sees a clean
+        # success and trusts data that is silently missing connectivity.
+        for _k in ("parser_path", "incomplete", "incomplete_reason"):
+            if _k in netlist_data:
+                result[_k] = netlist_data[_k]
         if project_path is not None:
             result["project_path"] = project_path
 
@@ -208,6 +215,13 @@ async def _op_analyze_schematic_connections(
             "schematic_path": schematic_path,
             "analysis": analysis,
         }
+        # Forward incompleteness signals. When parser_path == "regex" the pin
+        # lists are empty, so EVERY signal net reads as floating (pin_count <= 1)
+        # — the floating_net "potential_issues" above are then unreliable and the
+        # caller needs to know connectivity wasn't actually traced.
+        for _k in ("parser_path", "incomplete", "incomplete_reason"):
+            if _k in netlist_data:
+                result[_k] = netlist_data[_k]
 
         if ctx:
             await ctx.report_progress(100, 100)

--- a/src/kicad_mcp/tools/pcb_autoroute.py
+++ b/src/kicad_mcp/tools/pcb_autoroute.py
@@ -548,7 +548,13 @@ def _run_full_autoroute(
 def _autoroute_worker(job_id: str, **kwargs: Any) -> None:
     """Background thread worker for async autorouting."""
     try:
+        # Match the synchronous `run` path: pre-flight placement check +
+        # courtyard auto-fix before launching FreeRouter, so async routing
+        # doesn't skip a correction `run` would have applied.
+        preflight_info = _run_preflight(kwargs["pcb_path"])
         result = _run_full_autoroute(job_id=job_id, **kwargs)
+        if preflight_info:
+            result["preflight"] = preflight_info
         with _autoroute_lock:
             job = _autoroute_jobs.get(job_id)
             if job and job.get("status") != "cancelled":
@@ -695,6 +701,52 @@ print(json.dumps({
     })
 
 
+def _run_preflight(pcb_path: str) -> Dict[str, Any]:
+    """Pre-flight placement check + courtyard auto-fix before FreeRouter.
+
+    Shared by the synchronous `run` path AND the async `start`/worker path so
+    both apply the same placement correction before routing. Returns a
+    `preflight_info` dict (possibly empty) for the caller to attach to its
+    result.
+    """
+    preflight = _run_pre_route_check(pcb_path)
+    preflight_info: Dict[str, Any] = {}
+
+    if preflight.get("status") == "ok" and not preflight.get("route_ready", True):
+        overlaps = preflight.get("courtyard_overlaps", 0)
+
+        if overlaps > 0:
+            # Auto-fix courtyard overlaps by nudging footprints apart
+            logger.info("Pre-route: %d courtyard overlap(s), auto-fixing", overlaps)
+            fix_result = _run_auto_fix_placement(pcb_path)
+            preflight_info["auto_fix_applied"] = True
+            preflight_info["components_moved"] = fix_result.get("components_moved", 0)
+
+            # Re-check after fix
+            recheck = _run_pre_route_check(pcb_path)
+            if recheck.get("status") == "ok" and not recheck.get("route_ready", True):
+                # Still have issues (likely pad clearance, not just courtyards)
+                _errors_raw = recheck.get("errors", [])
+                preflight_info["errors_after_fix"] = _errors_raw[:10]
+                preflight_info["errors_after_fix_truncated"] = len(_errors_raw) > 10
+                preflight_info["route_ready_after_fix"] = False
+                # Continue anyway — FreeRouter may still produce a usable result
+                logger.warning("Pre-route: still %d error(s) after fix, routing anyway",
+                               recheck.get("error_count", 0))
+            else:
+                preflight_info["route_ready_after_fix"] = True
+        else:
+            # Pad clearance issues only — can't auto-fix, but warn and continue
+            preflight_info["pad_violations"] = preflight.get("pad_violations", 0)
+            _errors_raw = preflight.get("errors", [])
+            preflight_info["errors"] = _errors_raw[:10]
+            preflight_info["errors_truncated"] = len(_errors_raw) > 10
+            logger.warning("Pre-route: %d error(s) (no courtyard overlaps to fix)",
+                           preflight.get("error_count", 0))
+
+    return preflight_info
+
+
 def _op_run(
     pcb_path: str,
     freerouter_jar: str = "",
@@ -800,40 +852,7 @@ def _op_run(
             f.write("\n")
 
     # Pre-flight placement check — catch issues before spending time on FreeRouter
-    preflight = _run_pre_route_check(pcb_path)
-    preflight_info = {}
-
-    if preflight.get("status") == "ok" and not preflight.get("route_ready", True):
-        overlaps = preflight.get("courtyard_overlaps", 0)
-
-        if overlaps > 0:
-            # Auto-fix courtyard overlaps by nudging footprints apart
-            logger.info("Pre-route: %d courtyard overlap(s), auto-fixing", overlaps)
-            fix_result = _run_auto_fix_placement(pcb_path)
-            preflight_info["auto_fix_applied"] = True
-            preflight_info["components_moved"] = fix_result.get("components_moved", 0)
-
-            # Re-check after fix
-            recheck = _run_pre_route_check(pcb_path)
-            if recheck.get("status") == "ok" and not recheck.get("route_ready", True):
-                # Still have issues (likely pad clearance, not just courtyards)
-                _errors_raw = recheck.get("errors", [])
-                preflight_info["errors_after_fix"] = _errors_raw[:10]
-                preflight_info["errors_after_fix_truncated"] = len(_errors_raw) > 10
-                preflight_info["route_ready_after_fix"] = False
-                # Continue anyway — FreeRouter may still produce a usable result
-                logger.warning("Pre-route: still %d error(s) after fix, routing anyway",
-                               recheck.get("error_count", 0))
-            else:
-                preflight_info["route_ready_after_fix"] = True
-        else:
-            # Pad clearance issues only — can't auto-fix, but warn and continue
-            preflight_info["pad_violations"] = preflight.get("pad_violations", 0)
-            _errors_raw = preflight.get("errors", [])
-            preflight_info["errors"] = _errors_raw[:10]
-            preflight_info["errors_truncated"] = len(_errors_raw) > 10
-            logger.warning("Pre-route: %d error(s) (no courtyard overlaps to fix)",
-                           preflight.get("error_count", 0))
+    preflight_info = _run_preflight(pcb_path)
 
     result = _run_full_autoroute(
         pcb_path=pcb_path,

--- a/src/kicad_mcp/tools/pcb_board.py
+++ b/src/kicad_mcp/tools/pcb_board.py
@@ -166,9 +166,9 @@ pcb_path = params["pcb_path"]
 board = pcbnew.LoadBoard(pcb_path)
 ds = board.GetDesignSettings()
 
-# NOTE: do NOT set copper layer count here. Layer count is a board-structure
-# concern, not a design rule — an unconditional SetCopperLayerCount(2) silently
-# demoted 4-layer boards to 2 (dropping inner-layer routing from DRC's view).
+# NOTE: do NOT set the copper layer count here. Layer count is a
+# board-structure concern, not a design rule — forcing it to 2 silently
+# demoted 4-layer boards (dropping inner-layer routing from DRC's view).
 # Fresh boards already default to 2 copper layers (verified KiCad 9 + 10).
 ds.m_TrackMinWidth = pcbnew.FromMM(params["min_track_width_mm"])
 ds.m_MinClearance = pcbnew.FromMM(params["min_clearance_mm"])

--- a/src/kicad_mcp/tools/pcb_board.py
+++ b/src/kicad_mcp/tools/pcb_board.py
@@ -166,12 +166,20 @@ pcb_path = params["pcb_path"]
 board = pcbnew.LoadBoard(pcb_path)
 ds = board.GetDesignSettings()
 
-ds.SetCopperLayerCount(2)
+# NOTE: do NOT set copper layer count here. Layer count is a board-structure
+# concern, not a design rule — an unconditional SetCopperLayerCount(2) silently
+# demoted 4-layer boards to 2 (dropping inner-layer routing from DRC's view).
+# Fresh boards already default to 2 copper layers (verified KiCad 9 + 10).
 ds.m_TrackMinWidth = pcbnew.FromMM(params["min_track_width_mm"])
 ds.m_MinClearance = pcbnew.FromMM(params["min_clearance_mm"])
 ds.m_ViasMinSize = pcbnew.FromMM(params["min_via_diameter_mm"])
 ds.m_ViasMinDrill = pcbnew.FromMM(params["min_via_drill_mm"])
 ds.m_HoleToHoleMin = pcbnew.FromMM(params["min_hole_to_hole_mm"])
+# These two were reported in the return JSON but never applied to the board —
+# only to the .kicad_pro. A pcbnew-only DRC load (no project) used stale values.
+# Attribute names verified present + settable on KiCad 9 and 10.
+ds.m_MinThroughDrill = pcbnew.FromMM(params["min_through_hole_diameter_mm"])
+ds.m_CopperEdgeClearance = pcbnew.FromMM(params["min_copper_edge_clearance_mm"])
 
 board.Save(pcb_path)
 

--- a/src/kicad_mcp/tools/pcb_drc_fix.py
+++ b/src/kicad_mcp/tools/pcb_drc_fix.py
@@ -162,8 +162,27 @@ print(json.dumps({"status": "ok", "move_count": move_count}))
 
     # --- 2. Fix routing violations ---
     if fix_routing and groups["routing"]:
-        # Clear existing routing
-        clear_result = run_pcbnew_script("""
+        # FreeRouter/Java MUST be available BEFORE we touch anything. Clearing
+        # routing first and only then discovering we can't re-route would leave
+        # the board fully unrouted — strictly worse than the input — while still
+        # reporting status="ok". Check availability first; if it's missing, leave
+        # the existing routing untouched and record that the fix was skipped.
+        from kicad_mcp.tools.pcb_autoroute import (
+            _find_freerouter_jar,
+            _find_java,
+            _run_full_autoroute,
+        )
+
+        jar_path = _find_freerouter_jar(None)
+        java_path = _find_java()
+        if not (jar_path and java_path):
+            actions_taken.append(
+                "routing: skipped — FreeRouter/Java not available; left existing "
+                "routing intact (clearing it would leave the board unrouted)"
+            )
+        else:
+            # Clear existing routing, then re-autoroute.
+            clear_result = run_pcbnew_script("""
 import pcbnew, json, sys
 params = json.loads(open(sys.argv[1]).read())
 board = pcbnew.LoadBoard(params["pcb_path"])
@@ -177,23 +196,13 @@ for item in to_remove:
 board.Save(params["pcb_path"])
 print(json.dumps({"status": "ok", "removed": removed}))
 """, params={"pcb_path": pcb_path})
-        # Subprocess returned {"status": "ok", "removed": N} or {"error": ...}.
-        # Default-to-0 would silently re-autoroute an uncleared board, masking
-        # the failure with an optimistic action log entry.
-        if "error" in clear_result:
-            return {"error": f"Failed to clear existing routing: {clear_result['error']}"}
-        tracks_cleared = clear_result["removed"]
+            # Subprocess returned {"status": "ok", "removed": N} or {"error": ...}.
+            # Default-to-0 would silently re-autoroute an uncleared board, masking
+            # the failure with an optimistic action log entry.
+            if "error" in clear_result:
+                return {"error": f"Failed to clear existing routing: {clear_result['error']}"}
+            tracks_cleared = clear_result["removed"]
 
-        # Re-autoroute
-        from kicad_mcp.tools.pcb_autoroute import (
-            _find_freerouter_jar,
-            _find_java,
-            _run_full_autoroute,
-        )
-
-        jar_path = _find_freerouter_jar(None)
-        java_path = _find_java()
-        if jar_path and java_path:
             route_result = _run_full_autoroute(
                 pcb_path=pcb_path,
                 jar_path=jar_path,
@@ -205,11 +214,6 @@ print(json.dumps({"status": "ok", "removed": removed}))
             actions_taken.append(
                 f"routing: cleared {tracks_cleared} tracks/vias, "
                 f"re-autorouted ({autoroute_passes} passes, {incomplete} unconnected)"
-            )
-        else:
-            actions_taken.append(
-                f"routing: cleared {tracks_cleared} tracks/vias but "
-                "FreeRouter/Java not available for re-autoroute"
             )
 
     # --- 3. Fix silkscreen ---

--- a/src/kicad_mcp/tools/pcb_drc_fix.py
+++ b/src/kicad_mcp/tools/pcb_drc_fix.py
@@ -71,12 +71,17 @@ def _categorize_violations(categories: Dict[str, int]) -> Dict[str, list]:
             silkscreen.append(entry)
         elif msg in PLACEMENT_VIOLATIONS or msg_lower in {v.lower() for v in PLACEMENT_VIOLATIONS}:
             placement.append(entry)
-        elif any(kw in msg_lower for kw in _ROUTING_KEYWORDS):
-            routing.append(entry)
+        # Keyword fallback, most-specific first. "silk" must beat the routing
+        # keywords: a type like `silk_clearance` / `silk_mask_clearance` contains
+        # both "silk" AND "clearance", and a routing-first order would
+        # misclassify it as routing — triggering a full clear-and-reroute instead
+        # of the silkscreen fix. "courtyard" (placement) doesn't overlap routing.
         elif any(kw in msg_lower for kw in _SILKSCREEN_KEYWORDS):
             silkscreen.append(entry)
         elif any(kw in msg_lower for kw in _PLACEMENT_KEYWORDS):
             placement.append(entry)
+        elif any(kw in msg_lower for kw in _ROUTING_KEYWORDS):
+            routing.append(entry)
         else:
             other.append(entry)
 

--- a/src/kicad_mcp/tools/pcb_keepout.py
+++ b/src/kicad_mcp/tools/pcb_keepout.py
@@ -619,7 +619,7 @@ def _op_pre_route_check(
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
-""" + _KEEPOUT_HELPER + """
+""" + _KEEPOUT_HELPER + PAD_GAP_HELPER + """
 board = pcbnew.LoadBoard(params["pcb_path"])
 min_cl = params["min_clearance_mm"]
 
@@ -722,15 +722,9 @@ for i in range(n):
             continue
         if ax0 >= b["x1"] or ax1 <= b["x0"] or ay0 >= b["y1"] or ay1 <= b["y0"]:
             continue
-        # Signed gap — see check_pad_clearances above for the convention.
-        gap_x = max(a["x0"], b["x0"]) - min(a["x1"], b["x1"])
-        gap_y = max(a["y0"], b["y0"]) - min(a["y1"], b["y1"])
-        if gap_x >= 0 and gap_y >= 0:
-            gap = min(gap_x, gap_y)
-        elif gap_x >= 0 or gap_y >= 0:
-            gap = max(gap_x, gap_y)
-        else:
-            gap = max(gap_x, gap_y)
+        # Signed gap via the single source of truth (PAD_GAP_HELPER), shared
+        # with _op_pad_clearances so the two checks can never disagree.
+        gap = pad_signed_gap(a, b)
         if gap < min_cl:
             pad_violations.append({
                 "pad_a": f"{a['ref']}:{a['pad']}",
@@ -846,7 +840,11 @@ for pass_num in range(1, max_passes + 1):
         a = fp_data[i]; ab = a["bbox"]
         for j in range(i + 1, len(fp_data)):
             b = fp_data[j]; bb_ = b["bbox"]
-            if ab[0] < bb_[2] and ab[2] > bb_[0] and ab[1] < bb_[3] and ab[3] > bb_[1]:
+            # Non-strict AABB: touching courtyards (gap exactly 0) count as
+            # overlapping, matching rects_overlap / nudge_overlapping_footprints
+            # and KiCad DRC. A strict test here would leave touching courtyards
+            # that DRC still flags as courtyards_overlap.
+            if ab[0] <= bb_[2] and ab[2] >= bb_[0] and ab[1] <= bb_[3] and ab[3] >= bb_[1]:
                 pairs.append((a, b))
 
     if not pairs:
@@ -865,8 +863,9 @@ for pass_num in range(1, max_passes + 1):
         ox = min(mb[2], ab_[2]) - max(mb[0], ab_[0])  # x overlap
         oy = min(mb[3], ab_[3]) - max(mb[1], ab_[1])  # y overlap
 
-        if ox <= 0 or oy <= 0:
-            continue  # No longer overlapping (fixed by earlier nudge)
+        if ox < 0 or oy < 0:
+            continue  # A prior nudge this pass already separated them on an axis.
+            # (ox/oy == 0 means touching — still nudge apart by `spacing`.)
 
         mover_fp = mover["fp"]
         old_pos = mover_fp.GetPosition()

--- a/src/kicad_mcp/tools/pcb_panelize.py
+++ b/src/kicad_mcp/tools/pcb_panelize.py
@@ -95,12 +95,15 @@ def register_pcb_panelize_tools(mcp: FastMCP) -> None:
         VALID_CUT_TYPES = {"vcuts", "mousebites"}
         VALID_FRAMING = {"none", "railstb", "railslr", "frame"}
         VALID_TOOLING = {"none", "3hole", "4hole"}
+        VALID_FIDUCIALS = {"none", "3fid", "4fid"}
         if cut_type not in VALID_CUT_TYPES:
             return {"error": f"Invalid cut_type {cut_type!r}. Must be one of: {', '.join(sorted(VALID_CUT_TYPES))}"}
         if framing not in VALID_FRAMING:
             return {"error": f"Invalid framing {framing!r}. Must be one of: {', '.join(sorted(VALID_FRAMING))}"}
         if tooling not in VALID_TOOLING:
             return {"error": f"Invalid tooling {tooling!r}. Must be one of: {', '.join(sorted(VALID_TOOLING))}"}
+        if fiducials not in VALID_FIDUCIALS:
+            return {"error": f"Invalid fiducials {fiducials!r}. Must be one of: {', '.join(sorted(VALID_FIDUCIALS))}"}
 
         # Validate numeric ranges
         if not (1 <= rows <= 100):

--- a/src/kicad_mcp/tools/pcb_pipeline.py
+++ b/src/kicad_mcp/tools/pcb_pipeline.py
@@ -372,7 +372,8 @@ def _step_add_mounting_holes(pcb_path: str, holes: Dict[str, Any]) -> Dict[str, 
     Runs after the outline, before placement, so the placer (fed the holes as
     ``fixed`` hints by the caller) keeps clear of the corners. Holes are
     ``MountingHole_3.2mm_M3`` footprints (no net); each gets a square rule-area
-    keepout (no tracks/vias/pads) of half-extent ``drill/2 + keepout_mm`` on both
+    keepout (no tracks/vias/copper-pour — but pads ALLOWED, so the hole's own
+    NPTH pad doesn't self-flag) of half-extent ``drill/2 + keepout_mm`` on both
     copper layers. ``count`` 4 = all corners, 2 = TL+BR diagonal, 0 = skip.
 
     All pcbnew calls here were verified on KiCad 9.0.9 AND 10.0.3: the plain M3
@@ -412,12 +413,18 @@ for i, (cx, cy) in enumerate(corners):
     board.Add(fp)
     fp.SetReference("H%d" % (i + 1))
     fp.SetPosition(pcbnew.VECTOR2I(int(cx), int(cy)))
-    # No-copper keepout (square) so routing leaves the screw-head annulus clear.
+    # No-copper keepout (square) so routing leaves the screw-head annulus clear:
+    # disallow tracks, vias, and the copper POUR (zone fills). Do NOT disallow
+    # pads — the only pad in here is the mounting hole's OWN NPTH pad (a bare
+    # 3.2mm hole, no copper, no net), which would otherwise flag itself as an
+    # items_not_allowed DRC error. Disallowing zone fills (was missing) is what
+    # actually keeps the GND pour off the annulus — the stated intent.
     z = pcbnew.ZONE(board)
     z.SetIsRuleArea(True)
     z.SetDoNotAllowTracks(True)
     z.SetDoNotAllowVias(True)
-    z.SetDoNotAllowPads(True)
+    z.SetDoNotAllowPads(False)
+    z.SetDoNotAllowZoneFills(True)
     ls = pcbnew.LSET()
     ls.AddLayer(pcbnew.F_Cu)
     ls.AddLayer(pcbnew.B_Cu)

--- a/src/kicad_mcp/tools/pcb_pipeline.py
+++ b/src/kicad_mcp/tools/pcb_pipeline.py
@@ -432,7 +432,13 @@ for i, (cx, cy) in enumerate(corners):
     z.SetDoNotAllowTracks(True)
     z.SetDoNotAllowVias(True)
     z.SetDoNotAllowPads(False)
-    z.SetDoNotAllowZoneFills(True)
+    # KiCad 10 renamed SetDoNotAllowCopperPour -> SetDoNotAllowZoneFills; mirror
+    # the version-robust getter guard used in pcb_footprints/keepout_helpers so
+    # this works on both 9 and 10 (was 10-only, broke the 9.0 integration job).
+    if hasattr(z, "SetDoNotAllowZoneFills"):
+        z.SetDoNotAllowZoneFills(True)
+    else:
+        z.SetDoNotAllowCopperPour(True)
     ls = pcbnew.LSET()
     ls.AddLayer(pcbnew.F_Cu)
     ls.AddLayer(pcbnew.B_Cu)

--- a/src/kicad_mcp/tools/pcb_pipeline.py
+++ b/src/kicad_mcp/tools/pcb_pipeline.py
@@ -2286,6 +2286,23 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
         if not _record("load_footprints", step):
             return pipeline_result
 
+        # A footprint that fails to load is fatal: the board would silently be
+        # missing components, net assignment for them would no-op, and the final
+        # incomplete_nets count can read 0 (no ratsnest for absent pads) — fully
+        # masking the gap. Surface it as an error the caller must resolve (almost
+        # always a wrong/missing footprint mapping) rather than fabricating a
+        # board that doesn't match the schematic.
+        if step.get("error_count", 0) > 0:
+            _fp_errs = step.get("errors", [])
+            _more = len(_fp_errs) - 5
+            _tail = f" (and {_more} more)" if _more > 0 else ""
+            pipeline_result["error"] = (
+                f"{step['error_count']} footprint(s) failed to load — the board "
+                f"would be missing components: "
+                f"{'; '.join(_fp_errs[:5])}{_tail}"
+            )
+            return pipeline_result
+
         pipeline_result["footprints_placed"] = step.get("placed_count", 0)
 
         # Step 4: Inject nets + assign pads
@@ -2554,22 +2571,30 @@ def register_pipeline_tools(mcp: FastMCP) -> None:
                 f"autoroute step result missing expected counts (keys: {sorted(step.keys())})"
             )
 
-        # Step 7: Copper zones + fill
-        step = _step_add_zones_and_fill(pcb_path, ground_net)
-        _record("zones", step)
-        # Non-fatal
+        # Step 7: Copper zones + fill. Strictly NON-FATAL: the board is already
+        # routed and that result is valuable — a zone-fill timeout or pcbnew
+        # failure (run_pcbnew_script RAISES) must be recorded, not allowed to
+        # propagate and discard the routed board.
+        try:
+            _record("zones", _step_add_zones_and_fill(pcb_path, ground_net))
+        except Exception as e:  # noqa: BLE001 — finishing step, never fatal
+            _record("zones", {"error": f"zone fill failed (non-fatal): {e}"})
 
         # Step 7.5: Silk legends for synthesized terminals (firmware front end).
         # Field-wired terminals carry their wiring documentation on the silk.
         # (Single source: same _run_silk_legends used by the approval gate above.)
         _run_silk_legends()
 
-        # Step 8: Export gerbers (optional)
+        # Step 8: Export gerbers (optional). Non-fatal for the same reason as
+        # zones — never lose the routed board to an export failure.
         if export_gerbers:
-            step = _step_export_gerbers(pcb_path)
-            _record("export_gerbers", step)
-            if step.get("zip_path"):
-                pipeline_result["gerber_zip"] = step["zip_path"]
+            try:
+                step = _step_export_gerbers(pcb_path)
+                _record("export_gerbers", step)
+                if step.get("zip_path"):
+                    pipeline_result["gerber_zip"] = step["zip_path"]
+            except Exception as e:  # noqa: BLE001 — optional step, never fatal
+                _record("export_gerbers", {"error": f"gerber export failed (non-fatal): {e}"})
 
         pipeline_result["status"] = "ok"
         pipeline_result["pcb_path"] = pcb_path

--- a/src/kicad_mcp/tools/pcb_pipeline.py
+++ b/src/kicad_mcp/tools/pcb_pipeline.py
@@ -1319,12 +1319,16 @@ for ref in tier1:
             placed_t1 = True
             break
     if not placed_t1:
-        # No edge could seat the body — place interior at 0° (keepout still
-        # tracked via place_at) and FLAG it: the antenna does NOT overhang here.
-        placement_decisions.append({"event": "keepout_fallback_interior", "ref": ref})
+        # No edge could seat the body — try interior at 0° (keepout still tracked
+        # via place_at). The antenna does NOT overhang here. Only FLAG
+        # keepout_fallback_interior once the interior grid actually seats it; if
+        # the board is too full (fb is None) the component stays unplaced and is
+        # surfaced via failed_placements, not as a misleading "fallback" event for
+        # a part that never landed on the board.
         fb = fallback_grid(el0, er0, et0, eb0)
         if fb:
             place_at(ref, fb[0], fb[1])
+            placement_decisions.append({"event": "keepout_fallback_interior", "ref": ref})
 
 # --- Tier 2: Connectors → hint-aware, ordered, pad-inward edge placement ---
 # Three dispositions per connector (hint = validated {edge,rotation,fixed}):

--- a/src/kicad_mcp/tools/pcb_pipeline.py
+++ b/src/kicad_mcp/tools/pcb_pipeline.py
@@ -266,13 +266,21 @@ def _step_create_pcb_and_outline(
         measured_comps = size_result.get("comps", [])   # cached body w/h for pass 2
         auto_sized = True
 
-    # Create the PCB file
+    # Create the PCB file. Set the minimum through-hole drill to 0.2 mm: an empty
+    # board inherits KiCad's 0.3 mm default, but standard ESP32/MCU module
+    # footprints carry 0.2 mm thermal-pad vias, so every generated board would
+    # otherwise trip `drill_out_of_range` on those vias. 0.2 mm is JLCPCB's
+    # standard PTH minimum and the smallest hole these footprints use, so the
+    # rule stays meaningful (a smaller user hole is still flagged) while the
+    # board is DRC-clean out of the box.
     script = """
 import pcbnew, json, sys
 
 params = json.loads(open(sys.argv[1]).read())
 
 board = pcbnew.CreateEmptyBoard()
+ds = board.GetDesignSettings()
+ds.m_MinThroughDrill = pcbnew.FromMM(0.2)
 board.Save(params["pcb_path"])
 print(json.dumps({"status": "ok"}))
 """

--- a/src/kicad_mcp/tools/pcb_zones.py
+++ b/src/kicad_mcp/tools/pcb_zones.py
@@ -5,7 +5,7 @@ These are module-level _op_* helpers consumed by the pcb router (pcb.py).
 
 import logging
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from kicad_mcp.utils.pcbnew_bridge import run_pcbnew_script
 
@@ -16,15 +16,18 @@ def _op_add_zone(
     pcb_path: str,
     net_name: str,
     layer: str = "F.Cu",
-    corners: List[List[float]] = [],
+    corners: Optional[List[List[float]]] = None,
     clearance_mm: float = 0.3,
     min_width_mm: float = 0.2,
     connect_pads: str = "thermal",
     priority: int = 0,
 ) -> Dict[str, Any]:
-    """Add a copper zone (pour/fill) to the PCB."""
+    """Add a copper zone (pour/fill) to the PCB. An empty/None ``corners`` list
+    auto-derives the zone outline from the board edge."""
     if not os.path.exists(pcb_path):
         return {"error": f"PCB file not found: {pcb_path}"}
+    if corners is None:
+        corners = []
 
     script = """
 import pcbnew, json, sys

--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -447,10 +447,13 @@ def register_schematic_router(mcp: FastMCP) -> None:
             if len(position) != 2:
                 return {"error": "position must be [x, y]"}
             sch = _require_schematic()
-            matches = list(sch.components.filter(reference=reference))
-            if not matches:
+            # IMPORTANT: use components.get(ref), NOT components.filter(reference=ref).
+            # kicad-sch-api's filter() silently drops unrecognized kwargs (the valid
+            # key is reference_pattern, not reference) and returns ALL components —
+            # filter(reference=...)[0] would silently move the wrong component.
+            comp = sch.components.get(reference)
+            if comp is None:
                 return {"error": f"Component {reference!r} not found"}
-            comp = matches[0]
             old_pos = [comp.position.x, comp.position.y] if comp.position else None
             new_pos = list(_snap(position[0], position[1]))
             comp.position = tuple(new_pos)

--- a/src/kicad_mcp/tools/schematic_layout.py
+++ b/src/kicad_mcp/tools/schematic_layout.py
@@ -185,14 +185,17 @@ def _op_suggest(
     with event_context() as events:
         netlist = extract_netlist_via_cli(str(sch_path))
         if netlist is None:
-            return {
+            # Inside event_context — use _with_events so any accumulated
+            # warnings ride along instead of being silently dropped on this
+            # early-return path (the documented _with_events invariant).
+            return _with_events({
                 "status": "error",
                 "code": "netlist_extraction_failed",
                 "message": (
                     "kicad-cli netlist export failed. Verify kicad-cli is on PATH "
                     "and the schematic is parseable."
                 ),
-            }
+            }, events)
 
         state = placement_state.new_state(
             schematic_path=str(sch_path),

--- a/src/kicad_mcp/tools/schematic_layout.py
+++ b/src/kicad_mcp/tools/schematic_layout.py
@@ -530,6 +530,23 @@ def _op_apply(
                     is_fresh_state=False,
                 )
 
+        # If nothing was applied but components failed, the placement did NOT
+        # take effect (e.g. stale state — every ref missing from the current
+        # schematic). The save above succeeds trivially (no mutations), so
+        # returning status="ok" would let the caller trust a silent no-op and
+        # proceed to route/validate an unchanged schematic.
+        if applied_count == 0 and errors:
+            return _with_events({
+                "status": "error",
+                "code": "no_components_applied",
+                "message": (
+                    f"No components were moved; all {len(errors)} target(s) "
+                    "failed (stale state — re-run suggest?)."
+                ),
+                "applied": 0,
+                "errors": errors,
+            }, events)
+
         return _with_events({
             "status": "ok",
             "applied": applied_count,

--- a/src/kicad_mcp/utils/firmware/bus_part_resolver.py
+++ b/src/kicad_mcp/utils/firmware/bus_part_resolver.py
@@ -59,7 +59,12 @@ def resolve_bus_parts(
                                      candidates, "resolved"))
         else:
             # 0 → no evidence; >1 → ambiguous (NEVER pick one silently). Both leave
-            # the bus unresolved; >1 is gap-worthy so the caller can surface it.
+            # resolved_part None, but mark the AMBIGUOUS case on the bus so a later
+            # template (_decide_part) can tell it apart from no-evidence and hold
+            # the bus unrealized instead of assuming a default. (No-evidence keeps
+            # provenance None → assume-with-disclosure is correct there.)
+            if candidates:
+                bus.part_provenance = "ambiguous"
             out.append(BusResolution(bus.name, bus.type, None, candidates,
                                      "ambiguous" if candidates else "none"))
     return out

--- a/src/kicad_mcp/utils/firmware/intent.py
+++ b/src/kicad_mcp/utils/firmware/intent.py
@@ -453,24 +453,28 @@ def from_dict(d: dict[str, Any]) -> DesignIntent:
             "(fields may default-fill).", ver, SCHEMA_VERSION,
         )
     mcu_d = d.get("mcu")
+    # `d.get(k, [])` returns None when k is PRESENT with a null value (a
+    # hand-edited `buses: null`), and `[X(..) for x in None]` raises TypeError.
+    # Use `or []` like placements/placement_hints below so an explicit null
+    # degrades to empty rather than crashing load_intent.
     return DesignIntent(
         schema_version=d.get("schema_version", SCHEMA_VERSION),
         source=d.get("source", {}),
         mcu=Mcu(**_only_fields(Mcu, mcu_d)) if mcu_d else None,
-        peripherals=[Peripheral(**_only_fields(Peripheral, p)) for p in d.get("peripherals", [])],
-        buses=[Bus(**_only_fields(Bus, b)) for b in d.get("buses", [])],
+        peripherals=[Peripheral(**_only_fields(Peripheral, p)) for p in (d.get("peripherals") or [])],
+        buses=[Bus(**_only_fields(Bus, b)) for b in (d.get("buses") or [])],
         nets=[
             Net(
                 name=n["name"], kind=n["kind"], confidence=n["confidence"],
-                endpoints=[Endpoint(**_only_fields(Endpoint, e)) for e in n.get("endpoints", [])],
+                endpoints=[Endpoint(**_only_fields(Endpoint, e)) for e in (n.get("endpoints") or [])],
                 bus=n.get("bus"), origin=n.get("origin", "imported"),
             )
-            for n in d.get("nets", [])
+            for n in (d.get("nets") or [])
         ],
-        gaps=[Gap(**_only_fields(Gap, g)) for g in d.get("gaps", [])],
+        gaps=[Gap(**_only_fields(Gap, g)) for g in (d.get("gaps") or [])],
         connector_legends=[
             ConnectorLegend(**_only_fields(ConnectorLegend, c))
-            for c in d.get("connector_legends", [])
+            for c in (d.get("connector_legends") or [])
         ],
         placements={
             k: Placement(**_only_fields(Placement, v))

--- a/src/kicad_mcp/utils/firmware/intent.py
+++ b/src/kicad_mcp/utils/firmware/intent.py
@@ -426,8 +426,21 @@ def _only_fields(cls: type, d: dict[str, Any]) -> dict[str, Any]:
     extra fields loads (silently dropping the unknowns) instead of raising
     ``TypeError`` on ``cls(**d)`` — matching from_dict's documented forward-compat
     contract (a v4 schema or a typo'd hand-edited key must not crash load_intent)."""
-    known = {f.name for f in dataclasses.fields(cls)}
-    return {k: v for k, v in d.items() if k in known}
+    known = {f.name: f for f in dataclasses.fields(cls)}
+    out: dict[str, Any] = {}
+    for k, v in d.items():
+        f = known.get(k)
+        if f is None:
+            continue
+        # A hand-edited doc with `signals: null` (or any list/dict field set to
+        # null) would override the field's default_factory with None, so e.g.
+        # Bus(signals=None) then crashes on `bus.signals.get(...)`. Drop the key
+        # so the factory default (empty dict/list) applies. Optional scalar
+        # fields (resolved_part, etc.) keep their None.
+        if v is None and f.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
+            continue
+        out[k] = v
+    return out
 
 
 def from_dict(d: dict[str, Any]) -> DesignIntent:

--- a/src/kicad_mcp/utils/firmware/templates.py
+++ b/src/kicad_mcp/utils/firmware/templates.py
@@ -382,6 +382,12 @@ def _decide_part(bus: Bus, template_part: str, ex: Expansion) -> tuple[bool, str
     ``template_part``. Returns ``(place, origin)`` and stamps the bus + emits the
     honest gap. The three cases — the whole point of part resolution:
 
+      * ``part_provenance == "ambiguous"`` — firmware named MORE THAN ONE
+        candidate part → hold the bus unrealized. import_firmware already disclosed
+        it with a ``part_ambiguous`` gap, so DO NOT assume a default here (the old
+        code fell into the ``resolved_part is None`` branch and emitted a
+        contradictory ``assumed_part`` gap — "firmware names no specific part" —
+        then placed the default despite the named candidates).
       * ``resolved_part is None`` — firmware named no part for this bus → ASSUME
         ``template_part`` (place it, origin ``template``, ``part_is_assumption``),
         disclosed by an ``assumed_part`` gap.
@@ -393,6 +399,11 @@ def _decide_part(bus: Bus, template_part: str, ex: Expansion) -> tuple[bool, str
         SPH0645-for-INMP441 bug, refused.)
     """
     rp = bus.resolved_part
+    if bus.part_provenance == "ambiguous":
+        # >1 candidate named: held unrealized, never assumed. The part_ambiguous
+        # gap from import_firmware is the disclosure; emitting another here would
+        # duplicate it. The user disambiguates via board.yaml bus_part_overrides.
+        return False, ""
     if rp is None:
         bus.resolved_part = template_part
         bus.part_provenance = "assumed"

--- a/src/kicad_mcp/utils/firmware/templates.py
+++ b/src/kicad_mcp/utils/firmware/templates.py
@@ -501,6 +501,7 @@ def i2s_mic(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
         return ex
     mcu = intent.mcu.ref
     S = K.SPH0645
+    mic_idx = 0
     for bus in intent.buses:
         if bus.type != "I2S_IN":
             continue
@@ -509,9 +510,16 @@ def i2s_mic(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
         sd_g = _first(bus.signals, "SD", "DOUT")
         if bclk_g is None or ws_g is None or sd_g is None:
             continue
+        # Net-name prefix: unindexed "MIC" for the first I2S-input bus (the common
+        # single-mic board), then "MIC1", "MIC2", … for any additional buses. With
+        # >1 I2S_IN bus, a shared "MIC_BCLK"/"MIC_WS"/"MIC_SD" would collide and
+        # expand_intent's nets_by_name map would silently overwrite the first mic's
+        # nets, orphaning its MCU-side endpoints. Mirrors i2s_output_amps' I2S{idx}.
+        prefix = "MIC" if mic_idx == 0 else f"MIC{mic_idx}"
+        mic_idx += 1
         pl = intent.placements.get(bus.name)
         if pl is not None and pl.locus == "remote":
-            _emit_remote_mic(ex, alloc, mcu, bclk_g, ws_g, sd_g, pl)
+            _emit_remote_mic(ex, alloc, mcu, bclk_g, ws_g, sd_g, pl, prefix)
             continue
         place, mic_origin = _decide_part(bus, "SPH0645", ex)
         if not place:
@@ -526,33 +534,35 @@ def i2s_mic(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
                      ("+3V3", Endpoint(ref=c.ref, pin="1")),
                      ("GND", Endpoint(ref=c.ref, pin="2"))]
         ex.new_nets += [
-            _passive_net("MIC_BCLK", Endpoint(ref=mcu, gpio=bclk_g), Endpoint(ref=mic.ref, pin=S["bclk"])),
-            _passive_net("MIC_WS", Endpoint(ref=mcu, gpio=ws_g), Endpoint(ref=mic.ref, pin=S["ws"])),
-            _passive_net("MIC_SD", Endpoint(ref=mcu, gpio=sd_g), Endpoint(ref=mic.ref, pin=S["data"])),
+            _passive_net(f"{prefix}_BCLK", Endpoint(ref=mcu, gpio=bclk_g), Endpoint(ref=mic.ref, pin=S["bclk"])),
+            _passive_net(f"{prefix}_WS", Endpoint(ref=mcu, gpio=ws_g), Endpoint(ref=mic.ref, pin=S["ws"])),
+            _passive_net(f"{prefix}_SD", Endpoint(ref=mcu, gpio=sd_g), Endpoint(ref=mic.ref, pin=S["data"])),
         ]
     return ex
 
 
 def _emit_remote_mic(
     ex: Expansion, alloc: RefAllocator, mcu: str,
-    bclk_g: int, ws_g: int, sd_g: int, pl: Placement,
+    bclk_g: int, ws_g: int, sd_g: int, pl: Placement, prefix: str = "MIC",
 ) -> None:
     """Field-wired I2S mic: a screw terminal carries the three I2S signals plus a
-    +3V3/GND tap (power delivered over the wire)."""
+    +3V3/GND tap (power delivered over the wire). ``prefix`` namespaces the I2S
+    nets per bus ("MIC", "MIC1", …) so multiple remote mics don't collide."""
     device = pl.device or "I2S mic"
+    bclk_net, ws_net, sd_net = f"{prefix}_BCLK", f"{prefix}_WS", f"{prefix}_SD"
     positions = [
-        ConnectorPosition("MIC_BCLK", "BCLK"),
-        ConnectorPosition("MIC_WS", "WS"),
-        ConnectorPosition("MIC_SD", "SD"),
+        ConnectorPosition(bclk_net, "BCLK"),
+        ConnectorPosition(ws_net, "WS"),
+        ConnectorPosition(sd_net, "SD"),
         ConnectorPosition("+3V3", "+3V3"),
         ConnectorPosition("GND", "GND"),
     ]
     conn, te = _emit_connector(ex, alloc, positions, device=device, placement=pl,
                                connector_type="screw_terminal")
     ex.new_nets += [
-        _passive_net("MIC_BCLK", Endpoint(ref=mcu, gpio=bclk_g), te["MIC_BCLK"]),
-        _passive_net("MIC_WS", Endpoint(ref=mcu, gpio=ws_g), te["MIC_WS"]),
-        _passive_net("MIC_SD", Endpoint(ref=mcu, gpio=sd_g), te["MIC_SD"]),
+        _passive_net(bclk_net, Endpoint(ref=mcu, gpio=bclk_g), te[bclk_net]),
+        _passive_net(ws_net, Endpoint(ref=mcu, gpio=ws_g), te[ws_net]),
+        _passive_net(sd_net, Endpoint(ref=mcu, gpio=sd_g), te[sd_net]),
     ]
     ex.gaps.append(Gap(
         "remote_device",

--- a/src/kicad_mcp/utils/lcsc_db.py
+++ b/src/kicad_mcp/utils/lcsc_db.py
@@ -298,7 +298,10 @@ def _decode_attributes(attr_indices: list[int], lut: list[list]) -> dict[str, st
 def _tier_from_attributes(attr_indices: list[int], lut: list[list]) -> str:
     """Derive assembly_tier from resolved LUT attributes."""
     for idx in attr_indices:
-        if idx >= len(lut):
+        # Same guards as _decode_attributes: a float index passes a bare
+        # `>= len(lut)` check but raises TypeError on lut[idx]; a negative index
+        # silently reads the wrong entry. Either aborts/poisons the DB build.
+        if not isinstance(idx, int) or idx < 0 or idx >= len(lut):
             continue
         entry = lut[idx]
         if not isinstance(entry, list) or len(entry) < 2:
@@ -309,7 +312,15 @@ def _tier_from_attributes(attr_indices: list[int], lut: list[list]) -> str:
             continue
         values = data.get("values", {})
         primary = data.get("primary", "default")
-        val_entry = values.get(primary, [None])[0] if isinstance(values.get(primary), list) else None
+        # `values.get(primary, [None])[0]` IndexErrors when the value is an
+        # empty list `[]` (the [None] default only applies to a MISSING key, not
+        # an empty one) — one such component would abort the entire DB build.
+        val_entry_raw = values.get(primary)
+        val_entry = (
+            val_entry_raw[0]
+            if isinstance(val_entry_raw, list) and val_entry_raw and val_entry_raw[0] is not None
+            else None
+        )
         if name == "Basic/Extended":
             if isinstance(val_entry, str):
                 v = val_entry.lower()

--- a/src/kicad_mcp/utils/library_index.py
+++ b/src/kicad_mcp/utils/library_index.py
@@ -428,24 +428,25 @@ class LibraryIndex:
                     """,
                     (fts_query, limit),
                 ).fetchall()
+            results = [
+                {
+                    "library": r["library"],
+                    "name": r["name"],
+                    "full_name": f"{r['library']}:{r['name']}",
+                    "description": r["description"],
+                    "tags": r["tags"],
+                    "pad_count": r["pad_count"],
+                }
+                for r in rows
+            ]
+            return results
         except sqlite3.OperationalError as e:
             logger.warning("Footprint FTS query failed for %r: %s", query, e)
-            conn.close()
             return []
-
-        results = [
-            {
-                "library": r["library"],
-                "name": r["name"],
-                "full_name": f"{r['library']}:{r['name']}",
-                "description": r["description"],
-                "tags": r["tags"],
-                "pad_count": r["pad_count"],
-            }
-            for r in rows
-        ]
-        conn.close()
-        return results
+        finally:
+            # try/finally so a non-OperationalError (e.g. building results)
+            # can't leak the connection — repeated leaks exhaust the FD limit.
+            conn.close()
 
     # -------------------------------------------------------------------
     # Symbol index
@@ -566,24 +567,24 @@ class LibraryIndex:
                     """,
                     (fts_query, limit),
                 ).fetchall()
+            results = [
+                {
+                    "lib_id": r["lib_id"],
+                    "name": r["name"],
+                    "library": r["library"],
+                    "description": r["description"],
+                    "keywords": r["keywords"],
+                    "pin_count": r["pin_count"],
+                }
+                for r in rows
+            ]
+            return results
         except sqlite3.OperationalError as e:
             logger.warning("Symbol FTS query failed for %r: %s", query, e)
-            conn.close()
             return []
-
-        results = [
-            {
-                "lib_id": r["lib_id"],
-                "name": r["name"],
-                "library": r["library"],
-                "description": r["description"],
-                "keywords": r["keywords"],
-                "pin_count": r["pin_count"],
-            }
-            for r in rows
-        ]
-        conn.close()
-        return results
+        finally:
+            # try/finally so a non-OperationalError can't leak the connection.
+            conn.close()
 
     # -------------------------------------------------------------------
     # Shared helpers
@@ -599,6 +600,7 @@ class LibraryIndex:
         index stayed stale forever (h-library-stale)."""
         if not os.path.exists(self.db_path):
             return True
+        conn = None
         try:
             conn = self._connect()
             # Check table exists
@@ -675,6 +677,11 @@ class LibraryIndex:
         except (sqlite3.Error, ValueError) as e:
             # Corrupt metadata or DB-level error → force rebuild. Log so
             # repeated rebuilds (root cause: corruption) become diagnosable.
+            # Close the connection here too — this path runs on every staleness
+            # check against a corrupt DB, and a leak per check exhausts the FD
+            # limit. (conn may be None if _connect() itself raised.)
+            if conn is not None:
+                conn.close()
             logger.warning(
                 "Staleness check failed for %s (forcing rebuild): %s: %s",
                 lib_path, type(e).__name__, e,

--- a/src/kicad_mcp/utils/netlist_parser.py
+++ b/src/kicad_mcp/utils/netlist_parser.py
@@ -343,7 +343,7 @@ class SchematicParser:
             if label_match:
                 self.labels.append({
                     "type": "local",
-                    "text": label_match.group(1),
+                    "text": _unescape_sexpr(label_match.group(1)),
                     "position": {
                         "x": float(label_match.group(2)),
                         "y": float(label_match.group(3)),
@@ -366,7 +366,7 @@ class SchematicParser:
             if label_match:
                 self.global_labels.append({
                     "type": "global",
-                    "text": label_match.group(1),
+                    "text": _unescape_sexpr(label_match.group(1)),
                     "shape": label_match.group(2),
                     "position": {
                         "x": float(label_match.group(3)),
@@ -390,7 +390,7 @@ class SchematicParser:
             if label_match:
                 self.hierarchical_labels.append({
                     "type": "hierarchical",
-                    "text": label_match.group(1),
+                    "text": _unescape_sexpr(label_match.group(1)),
                     "shape": label_match.group(2),
                     "position": {
                         "x": float(label_match.group(3)),

--- a/src/kicad_mcp/utils/pattern_recognition.py
+++ b/src/kicad_mcp/utils/pattern_recognition.py
@@ -30,7 +30,11 @@ def identify_power_supplies(
     regulator_patterns = {
         "78xx": r"78\d\d|LM78\d\d|MC78\d\d",
         "79xx": r"79\d\d|LM79\d\d|MC79\d\d",
-        "LDO": r"LM\d{3}|LD\d{3}|AMS\d{4}|LT\d{4}|TLV\d{3}|AP\d{4}|MIC\d{4}|NCP\d{3}|LP\d{4}|L\d{2}|TPS\d{5}",
+        # `LM\d{3}(?!\d)`: match exactly-3-digit LM LDOs (LM317) but NOT a 4-digit
+        # prefix — bare `LM\d{3}` matched "LM259" inside "LM2596", shadowing the
+        # 4-digit buck pattern below so the LM2596 buck converter was misclassified
+        # as a linear LDO (prefix-shadow seam bug).
+        "LDO": r"LM\d{3}(?!\d)|LD\d{3}|AMS\d{4}|LT\d{4}|TLV\d{3}|AP\d{4}|MIC\d{4}|NCP\d{3}|LP\d{4}|L\d{2}|TPS\d{5}",
     }
 
     # Track refs already classified so a single component doesn't appear

--- a/src/kicad_mcp/utils/pattern_recognition.py
+++ b/src/kicad_mcp/utils/pattern_recognition.py
@@ -429,8 +429,11 @@ def identify_oscillators(
                 "has_load_capacitors": has_load_caps,
             })
 
-        # Oscillator ICs
-        if "OSC" in component_lib or "OSCILLATOR" in component_lib or re.search(
+        # Oscillator ICs. elif: a part is ONE kind of oscillator — an SMD
+        # crystal-oscillator module (lib_id has both "CRYSTAL" and "OSC", or
+        # ref X1 + "OSC") would otherwise be appended twice with conflicting
+        # types and double the oscillator count.
+        elif "OSC" in component_lib or "OSCILLATOR" in component_lib or re.search(
             r"OSC|OSCILLATOR", component_value, re.IGNORECASE
         ):
             oscillators.append({
@@ -440,8 +443,8 @@ def identify_oscillators(
                 "frequency": extract_frequency_from_value(component_value),
             })
 
-        # RC oscillators (555 timer, etc)
-        if re.search(
+        # RC oscillators (555 timer, etc) — elif for the same single-classification reason.
+        elif re.search(
             r"NE555|LM555|ICM7555|TLC555", component_value, re.IGNORECASE
         ) or "555" in component_lib:
             oscillators.append({

--- a/src/kicad_mcp/utils/placement/conventions.py
+++ b/src/kicad_mcp/utils/placement/conventions.py
@@ -80,14 +80,24 @@ def apply_conventions(
 ) -> list[ConventionEvent]:
     """Run all v1 conventions over the labeled, packed state.
 
-    Mutates ``pack.positions`` and ``pack.bboxes`` in place. Returns a
-    list of ``ConventionEvent`` records.
+    Mutates ``pack.positions`` in place (NOT ``pack.bboxes`` — no rule updates
+    bboxes, so ``pack.bboxes`` reflects the pre-convention packing; don't drive
+    collision/re-fit decisions off it after this runs). Returns a list of
+    ``ConventionEvent`` records.
     """
     events: list[ConventionEvent] = []
     components = netlist.get("components") or {}
     nets = netlist.get("nets") or {}
 
     max_tier = max(cluster_tier.values(), default=0)
+
+    # Snapshot the pre-convention horizontal extent ONCE. _rule_connector_edge
+    # pushes tier-0 connectors left of this and max-tier connectors right of it;
+    # reading the live (already-mutated) pack inside each call would let a second
+    # tier-0 connector cascade further left than the first (and likewise right).
+    _orig_xs = [x for x, _ in pack.positions.values()]
+    orig_leftmost_x = min(_orig_xs, default=0.0)
+    orig_rightmost_x = max(_orig_xs, default=0.0)
 
     for cid, members in members_by_cluster.items():
         label_obj = cluster_labels.get(cid)
@@ -105,6 +115,7 @@ def apply_conventions(
         ))
         events.extend(_rule_connector_edge(
             cid, members, label_obj, pack, cluster_tier, max_tier, column_pitch_mm,
+            orig_leftmost_x, orig_rightmost_x,
         ))
         events.extend(_rule_power_symbols_top_bottom(
             cid, members, components, pack, row_pitch_mm,
@@ -245,9 +256,15 @@ def _rule_connector_edge(
     cluster_tier: dict[str, int],
     max_tier: int,
     column_pitch_mm: float,
+    orig_leftmost_x: float,
+    orig_rightmost_x: float,
 ) -> list[ConventionEvent]:
     """Push connector-anchored clusters to the leftmost or rightmost
-    column based on signal-flow position."""
+    column based on signal-flow position.
+
+    ``orig_leftmost_x``/``orig_rightmost_x`` are the PRE-convention pack extent
+    (snapshotted by the caller), so two tier-0 connectors both target the same
+    column instead of cascading off the prior one's already-pushed position."""
     rule = RULE_CONNECTOR_EDGE
     if label.label != LABEL_CONNECTOR:
         return []
@@ -264,14 +281,15 @@ def _rule_connector_edge(
 
     affected: list[str] = []
     if tier == 0:
-        # Find leftmost x in current pack and push 0.5 column further left.
+        # Push 0.5 column left of the pre-convention leftmost column.
         if not pack.positions:
             return [_skip(cid, rule, "empty pack", [])]
-        leftmost_x = min(x for x, _ in pack.positions.values())
-        target_x = leftmost_x - column_pitch_mm * 0.5
+        target_x = orig_leftmost_x - column_pitch_mm * 0.5
     else:
-        rightmost_x = max(x for x, _ in pack.positions.values())
-        target_x = rightmost_x + column_pitch_mm * 0.5
+        # Push 0.5 column right of the pre-convention rightmost column.
+        if not pack.positions:
+            return [_skip(cid, rule, "empty pack", [])]
+        target_x = orig_rightmost_x + column_pitch_mm * 0.5
 
     for ref in members:
         if ref in pack.positions:

--- a/tests/integration/test_firmware_pcb_pipeline.py
+++ b/tests/integration/test_firmware_pcb_pipeline.py
@@ -398,17 +398,17 @@ def test_audio_s3_to_routed_pcb(mcp_server, tmp_path):
     assert r3["status"] == "ok" and not r3["unresolved_endpoints"]
 
     pro.write_text(json.dumps(_MINIMAL_PRO))
-    # best-of-6 (not 4): the §2 antenna overhang seats the MCU flush at a board
+    # best-of-10 (was 6): the §2 antenna overhang seats the MCU flush at a board
     # edge, which concentrates this dense I2S board and widens FreeRouter's
-    # run-to-run spread. Placement is deterministic and routes to 1–3 on a good
-    # pass; passes=6 pulls the median to ~1–2. The bound is the convention's
-    # observed-max + 1 (observed max 5 over many passes=6 runs) — loosened from 4
-    # to 6 to reflect the denser overhang layout, NOT to mask breakage: a broken
-    # board leaves far more than 6, and exact correctness is pinned by the by-ref
-    # connectivity invariants below. (Tightening this back is a placement-quality
-    # follow-up: cluster the I2S amps closer to the MCU so the overhang costs less.)
+    # run-to-run spread. passes=6 occasionally landed at 7 unrouted on a bad CI
+    # pass (observed 2026-06-03) — pure router nondeterminism, not breakage.
+    # best-of-N keeps the best of N independent attempts, so raising N shrinks the
+    # all-attempts-fail tail; the bound STAYS 6 (SPEC §9-A3: bump passes, never
+    # loosen the bound). Exact correctness is pinned by the by-ref connectivity
+    # invariants below; a broken board leaves far more than 6. (Tightening the
+    # bound is a placement-quality follow-up: cluster the amps closer to the MCU.)
     r4 = build(project_path=str(pro), board_width_mm=110, board_height_mm=90,
-               autoroute_passes=6, export_gerbers=False)
+               autoroute_passes=10, export_gerbers=False)
     assert r4["status"] == "ok"
     assert r4["pads_assigned"] > 0
     _assert_mostly_routed(r4, max_unrouted=6)            # dense I2S board + overhang spread

--- a/tests/integration/test_kicad_versions.py
+++ b/tests/integration/test_kicad_versions.py
@@ -137,6 +137,16 @@ def workspace(tmp_path):
     return tmp_path
 
 
+@pytest.fixture(scope="module", autouse=True)
+def _warm_library_index(mcp_server):
+    """A cold/stale library index intermittently returns 0 search results on the
+    self-hosted runner — flaked test_search_symbols and test_place_footprint_and_audit
+    (2026-06-03), the same cold-index failure mode the silk integration test guards
+    against. Force one rebuild (symbols + footprints) before any search test runs so
+    every search in this module sees a populated index."""
+    _get_tool(mcp_server, "library")({"operation": "rebuild_index", "kind": "both"})
+
+
 # ---------------------------------------------------------------------------
 # Category: Library search
 # ---------------------------------------------------------------------------

--- a/tests/test_bus_part_resolver.py
+++ b/tests/test_bus_part_resolver.py
@@ -34,6 +34,9 @@ def test_ambiguous_two_candidates_does_not_pick():
     assert bus.resolved_part is None
     assert res[0].reason == "ambiguous"
     assert res[0].candidates == ["INMP441", "SPH0645"]   # sorted, for a stable gap message
+    # The bus is MARKED ambiguous (distinct from no-evidence) so a later template
+    # holds it unrealized instead of assuming a default.
+    assert bus.part_provenance == "ambiguous"
 
 
 def test_no_serving_part_in_corpus_resolves_none():
@@ -42,6 +45,8 @@ def test_no_serving_part_in_corpus_resolves_none():
     res = resolve_bus_parts([bus], [_ev("MAX98357A")], _SERVES)
     assert bus.resolved_part is None
     assert res[0].reason == "none"
+    # No-evidence is NOT marked ambiguous → a template may assume-with-disclosure.
+    assert bus.part_provenance != "ambiguous"
 
 
 def test_two_same_type_buses_both_resolve():

--- a/tests/test_component_utils.py
+++ b/tests/test_component_utils.py
@@ -111,15 +111,11 @@ class TestExtractVoltageRealBugs:
         assert extract_voltage_from_regulator("7800") == "unknown"
 
     def test_negative_voltage_string_preserves_sign(self):
-        """A description containing '-3V' should not silently strip the sign.
-
-        The current implementation has a `-(\\d+\\.?\\d*)V` pattern in its
-        list but the unsigned pattern matches first and discards the minus.
-        """
-        # We assert the consumer-visible behaviour: the sign survives.
-        result = extract_voltage_from_regulator("REG -3V output")
-        assert result.startswith("-") or result == "unknown", \
-            f"Expected sign-preserving or 'unknown', got {result!r}"
+        """A description containing '-3V' must not silently strip the sign. The
+        signed pattern `-(\\d+\\.?\\d*)V` is listed before the unsigned one so the
+        minus survives. Pin the EXACT value: `startswith("-") or "unknown"` would
+        pass even if the signed pattern were deleted (falling through to unknown)."""
+        assert extract_voltage_from_regulator("REG -3V output") == "-3V"
 
 
 # -- extract_frequency_from_value tests --------------------------------------

--- a/tests/test_firmware_intent.py
+++ b/tests/test_firmware_intent.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from kicad_mcp.utils.firmware.intent import (
+    SCHEMA_VERSION,
     Gap,
     Net,
     build_intent,
@@ -141,6 +142,36 @@ def test_from_dict_drops_unknown_fields():
         doc["nets"][0]["endpoints"][0]["alien"] = 9
     intent = from_dict(doc)                                  # raised TypeError before the fix
     assert "future_v4_field" not in to_dict(intent)["mcu"]   # unknown was dropped
+
+
+def test_from_dict_null_factory_field_coerced_to_empty():
+    """A hand-edited doc with a default_factory field (Bus.signals: dict) set to
+    null must NOT override the factory with None — templates then crash on
+    bus.signals.get(...). _only_fields drops the None so the factory applies."""
+    doc = to_dict(_audio_intent())
+    assert doc.get("buses"), "fixture must have buses with signals"
+    doc["buses"][0]["signals"] = None
+    intent = from_dict(doc)
+    assert intent.buses[0].signals == {}            # factory default, not None
+
+
+def test_from_dict_top_level_null_collections_become_empty():
+    """`buses: null` (etc.) in a hand-edited doc: dict.get returns None for a
+    present-but-null key, and the list comprehensions would TypeError without the
+    `or []` guard. Each top-level collection must degrade to empty."""
+    intent = from_dict({
+        "schema_version": SCHEMA_VERSION,
+        "buses": None, "peripherals": None, "nets": None,
+        "gaps": None, "connector_legends": None,
+        "placements": None, "placement_hints": None,
+    })
+    assert intent.buses == []
+    assert intent.peripherals == []
+    assert intent.nets == []
+    assert intent.gaps == []
+    assert intent.connector_legends == []
+    assert intent.placements == {}
+    assert intent.placement_hints == {}
 
 def test_merge_preserves_user_items_and_resolved_gaps():
     fresh = _intent()

--- a/tests/test_firmware_templates.py
+++ b/tests/test_firmware_templates.py
@@ -279,8 +279,44 @@ def test_i2s_mic_instantiated():
     i = _audio()
     ex = i2s_mic(i, RefAllocator(i))
     assert [c.type for c in ex.components].count("SPH0645") == 1
-    nets = {n.name for n in ex.new_nets}
-    assert {"MIC_BCLK", "MIC_WS", "MIC_SD"} <= nets
+    # Exact set (not subset): a duplicate-named net from a collision would not
+    # change the set, so pin both the names AND the list length.
+    assert {n.name for n in ex.new_nets} == {"MIC_BCLK", "MIC_WS", "MIC_SD"}
+    assert len(ex.new_nets) == 3
+
+
+# Two I2S-input (mic) buses — exercises the per-bus net-name prefix. With a
+# hardcoded "MIC" prefix the second mic's MIC_BCLK/WS/SD collide with the first's
+# and expand_intent's nets_by_name silently overwrites them, orphaning the first
+# mic's MCU-side endpoints. The single-mic _AUDIO fixture never reaches this path.
+_AUDIO_2MIC = """\
+#define CMCA_MIC_BCLK 8
+#define CMCA_MIC_WS 9
+#define CMCA_MIC_SD 10
+#define CMCA_MIC2_BCLK 11
+#define CMCA_MIC2_WS 12
+#define CMCA_MIC2_SD 13
+"""
+
+
+def test_i2s_two_mics_get_distinct_non_colliding_nets():
+    i = build_intent(partition(parse_defines(_AUDIO_2MIC)),
+                     firmware_path="a.h", board_id="esp32-s3-devkitc-1")
+    i2s_in = [b for b in i.buses if b.type == "I2S_IN"]
+    assert len(i2s_in) == 2, "fixture must produce two I2S-input buses"
+
+    ex = i2s_mic(i, RefAllocator(i))
+    assert [c.type for c in ex.components].count("SPH0645") == 2
+    names = [n.name for n in ex.new_nets]
+    # 6 nets, all distinct — first bus unindexed "MIC", second "MIC1".
+    assert len(names) == 6
+    assert set(names) == {
+        "MIC_BCLK", "MIC_WS", "MIC_SD", "MIC1_BCLK", "MIC1_WS", "MIC1_SD",
+    }
+    # Every net keeps BOTH endpoints (MCU gpio + chip pin) — a collision/overwrite
+    # would orphan the first mic's MCU-side endpoint, dropping it below 2.
+    for n in ex.new_nets:
+        assert len(n.endpoints) == 2, f"{n.name} lost an endpoint to a collision"
 
 def test_i2c_device_header_with_pullups():
     i = _audio()

--- a/tests/test_firmware_templates.py
+++ b/tests/test_firmware_templates.py
@@ -318,6 +318,21 @@ def test_i2s_two_mics_get_distinct_non_colliding_nets():
     for n in ex.new_nets:
         assert len(n.endpoints) == 2, f"{n.name} lost an endpoint to a collision"
 
+def test_i2s_mic_ambiguous_bus_held_not_assumed():
+    """A bus the firmware names >1 candidate part for (part_provenance ==
+    'ambiguous') must be held UNREALIZED — no SPH0645 placed, and NO contradictory
+    'assumed_part' gap (which claims "firmware names no specific part"). The
+    part_ambiguous disclosure comes from import_firmware, not the template."""
+    i = _audio()
+    mic_bus = next(b for b in i.buses if b.type == "I2S_IN")
+    mic_bus.part_provenance = "ambiguous"      # as resolve_bus_parts marks it
+    ex = i2s_mic(i, RefAllocator(i))
+    assert [c.type for c in ex.components].count("SPH0645") == 0   # nothing assumed/placed
+    assert ex.new_nets == []                                      # bus left unrealized
+    assert not any(g.kind == "assumed_part" for g in ex.gaps), \
+        "must not emit a contradictory assumed_part gap for an ambiguous bus"
+
+
 def test_i2c_device_header_with_pullups():
     i = _audio()
     ex = i2c_device_header(i, RefAllocator(i))

--- a/tests/test_lcsc.py
+++ b/tests/test_lcsc.py
@@ -446,6 +446,27 @@ class TestAttributeLutHelpers:
         assert _package_from_attributes([], self.SAMPLE_LUT) == ""
         assert _tier_from_attributes([], self.SAMPLE_LUT) == "extended"
 
+    # --- malformed-index guards: one bad component must not abort the DB build ---
+
+    def test_tier_float_index_ignored(self):
+        # A float index passes a naive `>= len(lut)` check but raises TypeError on
+        # lut[idx]. Guard must skip it (not crash the whole build).
+        assert _tier_from_attributes([1.5], self.SAMPLE_LUT) == "extended"
+
+    def test_tier_negative_index_ignored(self):
+        # A negative index is a valid Python list index → silently reads the WRONG
+        # entry. Guard must reject it.
+        assert _tier_from_attributes([-1], self.SAMPLE_LUT) == "extended"
+
+    def test_tier_empty_value_list_ignored(self):
+        # values["default"] == [] : `values.get(primary, [None])[0]` IndexErrors
+        # (the [None] default only applies to a MISSING key, not an empty one) —
+        # one such JLCPCB component would abort the entire shard build.
+        lut = [["Basic/Extended", {"primary": "default", "values": {"default": []}}]]
+        assert _tier_from_attributes([0], lut) == "extended"
+        assert _package_from_attributes([0], [["Package", {"primary": "default",
+                                                           "values": {"default": []}}]]) == ""
+
 
 class TestParametricAttributeCapture:
     """m-resolved-attrs: parametric attributes must be captured end-to-end,

--- a/tests/test_mounting_holes.py
+++ b/tests/test_mounting_holes.py
@@ -2,7 +2,9 @@
 itself is integration-gated (real KiCad); this covers the defaults-merge logic.
 Boundary-focused per CLAUDE.md: None vs {} vs partial-override vs count=0.
 """
-from kicad_mcp.tools.pcb_pipeline import _resolve_mounting_holes
+from unittest.mock import patch
+
+from kicad_mcp.tools.pcb_pipeline import _resolve_mounting_holes, _step_add_mounting_holes
 
 _DEFAULT = {"count": 4, "drill_mm": 3.2, "inset_mm": 3.5, "keepout_mm": 1.5}
 
@@ -29,3 +31,28 @@ def test_unknown_keys_ignored_only_known_merged():
     # _resolve only copies known keys (validation/rejection is the sidecar's job).
     assert _resolve_mounting_holes({"count": 2, "bogus": 9}) == \
         {"count": 2, "drill_mm": 3.2, "inset_mm": 3.5, "keepout_mm": 1.5}
+
+
+@patch("kicad_mcp.tools.pcb_pipeline.run_pcbnew_script")
+def test_keepout_allows_pads_blocks_pour(mock_run):
+    """The per-hole keepout must NOT disallow pads — the mounting hole's own NPTH
+    pad (a bare 3.2mm hole, no copper) would otherwise self-flag as an
+    items_not_allowed DRC error. It MUST disallow zone fills (the copper pour) —
+    that's what actually keeps the screw-head annulus clear, and was missing."""
+    mock_run.return_value = {"status": "ok"}
+    _step_add_mounting_holes("/tmp/x.kicad_pcb", {"count": 4, "drill_mm": 3.2,
+                                                  "inset_mm": 3.5, "keepout_mm": 1.5})
+    script = mock_run.call_args[0][0]
+    assert "SetDoNotAllowTracks(True)" in script
+    assert "SetDoNotAllowVias(True)" in script
+    assert "SetDoNotAllowPads(False)" in script        # NPTH pad must not self-flag
+    assert "SetDoNotAllowZoneFills(True)" in script      # pour kept off the annulus
+    assert "SetDoNotAllowPads(True)" not in script
+
+
+def test_count_zero_emits_no_script():
+    # count=0 returns early without building/running a pcbnew script.
+    with patch("kicad_mcp.tools.pcb_pipeline.run_pcbnew_script") as mock_run:
+        r = _step_add_mounting_holes("/tmp/x.kicad_pcb", {"count": 0})
+        assert r["holes_added"] == 0
+        mock_run.assert_not_called()

--- a/tests/test_mounting_holes.py
+++ b/tests/test_mounting_holes.py
@@ -46,7 +46,10 @@ def test_keepout_allows_pads_blocks_pour(mock_run):
     assert "SetDoNotAllowTracks(True)" in script
     assert "SetDoNotAllowVias(True)" in script
     assert "SetDoNotAllowPads(False)" in script        # NPTH pad must not self-flag
-    assert "SetDoNotAllowZoneFills(True)" in script      # pour kept off the annulus
+    # pour kept off the annulus, version-robust: KiCad 10 ZoneFills / KiCad 9
+    # CopperPour (a 10-only call broke the 9.0 integration job).
+    assert "SetDoNotAllowZoneFills(True)" in script
+    assert "SetDoNotAllowCopperPour(True)" in script
     assert "SetDoNotAllowPads(True)" not in script
 
 

--- a/tests/test_netlist_tools.py
+++ b/tests/test_netlist_tools.py
@@ -80,6 +80,30 @@ class TestExtractNetlistSchematic:
         result = asyncio.run(fn(operation="netlist", ctx=None, path=sch_file))
         assert result["success"] is False
 
+    @patch("kicad_mcp.tools.netlist.analyze_netlist")
+    @patch("kicad_mcp.tools.netlist._parse_netlist")
+    def test_forwards_regex_fallback_incompleteness(
+        self, mock_extract, mock_analyze, analyze_server, sch_file
+    ):
+        # When kicad-cli is unavailable the parser falls back to regex, which
+        # can't trace connectivity → empty pin lists. The result MUST carry
+        # parser_path/incomplete/incomplete_reason so the caller doesn't trust a
+        # clean-looking success over silently-missing connectivity.
+        mock_extract.return_value = {
+            "component_count": 1, "net_count": 0,
+            "components": {}, "nets": {},
+            "parser_path": "regex",
+            "incomplete": True,
+            "incomplete_reason": "regex fallback: hierarchical sub-schematics not resolved",
+        }
+        mock_analyze.return_value = {"summary": "incomplete"}
+        fn = _get_tool_fn(analyze_server, "analyze")
+        result = asyncio.run(fn(operation="netlist", ctx=None, path=sch_file))
+        assert result["success"] is True
+        assert result["parser_path"] == "regex"
+        assert result["incomplete"] is True
+        assert "hierarchical" in result["incomplete_reason"]
+
 
 # -- analyze.netlist — project input ----------------------------------------
 

--- a/tests/test_new_tools.py
+++ b/tests/test_new_tools.py
@@ -320,6 +320,10 @@ class TestPreRouteCheck:
         assert "pad.GetPosition()" in script or "fp.Pads()" in script
         # Route ready flag
         assert "route_ready" in script
+        # Pad-gap math must come from the spliced PAD_GAP_HELPER (single source of
+        # truth shared with pad_clearances), NOT a drifted inline copy — that
+        # divergence was the bug. The helper defines pad_signed_gap().
+        assert "pad_signed_gap" in script
 
 
 # -- set_design_rules project file tests ------------------------------------
@@ -621,6 +625,26 @@ class TestAutoroutePreflight:
         mock_fix.assert_not_called()  # No overlaps, so no fix attempted
         assert result["preflight"]["pad_violations"] == 3
 
+    @patch("kicad_mcp.tools.pcb_autoroute._run_full_autoroute")
+    @patch("kicad_mcp.tools.pcb_autoroute._run_preflight")
+    def test_async_worker_runs_preflight(self, mock_preflight, mock_route):
+        """The async start/worker path must run the SAME preflight the sync `run`
+        path does (it used to skip it). Call the worker directly to avoid thread
+        timing flakiness."""
+        from kicad_mcp.tools import pcb_autoroute as ar
+        mock_preflight.return_value = {"auto_fix_applied": True, "components_moved": 1}
+        mock_route.return_value = {"status": "ok", "tracks_after": 50, "vias_after": 5}
+        ar._autoroute_worker(
+            job_id="test-preflight-job",
+            pcb_path="/tmp/board.kicad_pcb",
+            jar_path="/fake.jar", java_path="/usr/bin/java",
+            passes=1, remove_zones=True,
+        )
+        mock_preflight.assert_called_once_with("/tmp/board.kicad_pcb")
+        # preflight info must be attached to the routed result
+        assert mock_route.return_value["preflight"] == {"auto_fix_applied": True,
+                                                         "components_moved": 1}
+
 
 # -- Pipeline tests ----------------------------------------------------------
 
@@ -894,6 +918,85 @@ class TestBuildPcbFromSchematic:
         mock_route.assert_not_called()
         mock_zones.assert_not_called()
         mock_gerbers.assert_not_called()
+
+    @patch("kicad_mcp.tools.pcb_pipeline._step_add_mounting_holes")
+    @patch("kicad_mcp.tools.pcb_pipeline._step_export_gerbers")
+    @patch("kicad_mcp.tools.pcb_pipeline._step_add_zones_and_fill")
+    @patch("kicad_mcp.tools.pcb_pipeline._step_autoroute")
+    @patch("kicad_mcp.tools.pcb_pipeline._step_smart_placement")
+    @patch("kicad_mcp.tools.pcb_pipeline._step_inject_nets_and_assign_pads")
+    @patch("kicad_mcp.tools.pcb_pipeline._step_load_footprints")
+    @patch("kicad_mcp.tools.pcb_pipeline._step_create_pcb_and_outline")
+    @patch("kicad_mcp.tools.pcb_pipeline._step_extract_netlist")
+    def test_footprint_load_failure_is_fatal(
+        self, mock_netlist, mock_create, mock_place, mock_nets,
+        mock_optimize, mock_route, mock_zones, mock_gerbers, mock_holes,
+        mcp_server, tmp_path,
+    ):
+        """A footprint that fails to load is fatal: the pipeline must NOT proceed
+        to build a board silently missing components (the load step reports
+        error_count but no top-level 'error' key, so _record alone wouldn't halt)."""
+        (tmp_path / "test.kicad_pro").write_text("{}")
+        (tmp_path / "test.kicad_sch").write_text("(kicad_sch)")
+        mock_netlist.return_value = {
+            "status": "ok",
+            "components": {"R1": {"reference": "R1", "value": "10k", "footprint": "Resistor_SMD:R_0603"}},
+            "components_without_footprint": [],
+            "nets": {"SIG": [{"component": "R1", "pin": "1"}]},
+            "component_count": 1, "net_count": 1, "skipped_count": 0,
+        }
+        mock_create.return_value = {"status": "ok", "width_mm": 30, "height_mm": 20, "auto_sized": True}
+        # No top-level "error" — only error_count / errors, the masking shape.
+        mock_place.return_value = {"status": "ok", "placed_count": 0,
+                                   "errors": ["Footprint 'R_0603' not found for R1"],
+                                   "error_count": 1}
+        fn = _get_tool_fn(mcp_server, "build_pcb_from_schematic")
+        result = fn(str(tmp_path / "test.kicad_pro"))
+        assert "error" in result
+        assert "load" in result["error"].lower()
+        mock_nets.assert_not_called()       # halted right after the load step
+        mock_route.assert_not_called()      # never routed an incomplete board
+
+    @patch("kicad_mcp.tools.pcb_pipeline._step_add_mounting_holes")
+    @patch("kicad_mcp.tools.pcb_pipeline._step_export_gerbers")
+    @patch("kicad_mcp.tools.pcb_pipeline._step_add_zones_and_fill")
+    @patch("kicad_mcp.tools.pcb_pipeline._step_autoroute")
+    @patch("kicad_mcp.tools.pcb_pipeline._step_smart_placement")
+    @patch("kicad_mcp.tools.pcb_pipeline._step_inject_nets_and_assign_pads")
+    @patch("kicad_mcp.tools.pcb_pipeline._step_load_footprints")
+    @patch("kicad_mcp.tools.pcb_pipeline._step_create_pcb_and_outline")
+    @patch("kicad_mcp.tools.pcb_pipeline._step_extract_netlist")
+    def test_zone_fill_failure_does_not_discard_routed_board(
+        self, mock_netlist, mock_create, mock_place, mock_nets,
+        mock_optimize, mock_route, mock_zones, mock_gerbers, mock_holes,
+        mcp_server, tmp_path,
+    ):
+        """Zone fill is a finishing step: a RuntimeError there must be recorded,
+        not propagated — the already-routed board is the valuable result."""
+        (tmp_path / "test.kicad_pro").write_text("{}")
+        (tmp_path / "test.kicad_sch").write_text("(kicad_sch)")
+        mock_netlist.return_value = {
+            "status": "ok",
+            "components": {"R1": {"reference": "R1", "value": "10k", "footprint": "Resistor_SMD:R_0603"}},
+            "components_without_footprint": [],
+            "nets": {"SIG": [{"component": "R1", "pin": "1"}]},
+            "component_count": 1, "net_count": 1, "skipped_count": 0,
+        }
+        mock_create.return_value = {"status": "ok", "width_mm": 30, "height_mm": 20, "auto_sized": True}
+        mock_place.return_value = {"status": "ok", "placed_count": 1, "errors": [], "error_count": 0}
+        mock_nets.return_value = {"status": "ok", "pads_assigned": 1, "nets_created": 1, "total_nets": 1}
+        mock_optimize.return_value = {"status": "ok", "components_placed": 1}
+        mock_route.return_value = {"status": "ok", "tracks_after": 20, "vias_after": 2,
+                                   "unconnected_after_routing": 0}
+        mock_zones.side_effect = RuntimeError("zone fill boom")   # finishing step explodes
+        mock_holes.return_value = {"status": "ok", "holes_added": 0, "positions": []}
+
+        fn = _get_tool_fn(mcp_server, "build_pcb_from_schematic")
+        result = fn(str(tmp_path / "test.kicad_pro"))
+        assert result["status"] == "ok"                 # routed board preserved
+        assert result["tracks"] == 20
+        assert "error" in result["steps"]["zones"]       # failure recorded
+        assert "non-fatal" in result["steps"]["zones"]["error"]
 
 
 class TestFinalizePadAssignment:

--- a/tests/test_new_tools.py
+++ b/tests/test_new_tools.py
@@ -1056,3 +1056,19 @@ class TestRoutedIncompleteCount:
     def test_none_when_unreported(self):
         # autoroute errored before the import/measure step.
         assert self._c() is None
+
+
+class TestCreateStepMinThroughDrill:
+    """The create step must lower the board's min through-hole drill to 0.2mm so
+    standard ESP32/MCU module thermal vias (0.2mm) don't trip drill_out_of_range
+    against KiCad's 0.3mm default (finding A from the board-regen gate)."""
+
+    @patch("kicad_mcp.tools.pcb_pipeline.run_pcbnew_script")
+    def test_create_script_sets_min_through_drill(self, mock_run):
+        from kicad_mcp.tools.pcb_pipeline import _step_create_pcb_and_outline
+        mock_run.return_value = {"status": "ok"}
+        # explicit size (>0) skips estimation → first script call is board create
+        _step_create_pcb_and_outline("/tmp/x.kicad_pcb", 90, 75, components={})
+        create_script = mock_run.call_args_list[0][0][0]
+        assert "m_MinThroughDrill" in create_script
+        assert "pcbnew.FromMM(0.2)" in create_script

--- a/tests/test_pattern_recognition.py
+++ b/tests/test_pattern_recognition.py
@@ -370,6 +370,18 @@ class TestIdentifyOscillators:
         osc_ic = [r for r in result if r["type"] == "oscillator_ic"]
         assert len(osc_ic) >= 1
 
+    def test_crystal_osc_module_classified_once(self):
+        # SMD crystal-oscillator module: lib_id contains BOTH "CRYSTAL" and "OSC"
+        # (and ref starts with X). The crystal branch and oscillator-IC branch are
+        # elif, so it must be classified exactly ONCE — separate `if`s would
+        # double-count it with conflicting types.
+        components = {"X1": _comp("16MHz", lib_id="Oscillator:SG8002_Crystal_OSC_SMD")}
+        result = identify_oscillators(components, {})
+        assert len(result) == 1, f"dual-match part double-classified: {result}"
+        assert result[0]["component"] == "X1"
+        # ref-prefix crystal branch wins (it's first).
+        assert result[0]["type"] == "crystal_oscillator"
+
 
 # ===========================================================================
 # identify_digital_interfaces

--- a/tests/test_pattern_recognition.py
+++ b/tests/test_pattern_recognition.py
@@ -113,18 +113,31 @@ class TestIdentifyPowerSupplies:
             "LM7805 already classified as linear — should not also appear as switching"
 
     def test_switching_regulator_buck_first_match(self):
-        # LM2596 matches buck (LM\d{4}) — should be classified as buck, not
-        # also boost or buck_boost (break prevents further pattern checks).
+        # LM2596 is a buck converter. The loose LDO pattern `LM\d{3}` used to match
+        # "LM259" inside "LM2596" and (linear-runs-first) claim it as a linear LDO,
+        # so it appeared 0 times in switching. With the prefix anchored it now
+        # correctly classifies as exactly one buck switching regulator, and must
+        # NOT also appear as a linear regulator.
         components = {
             "U2": _comp("LM2596"),
             "L1": _comp("68uH"),
         }
         result = identify_power_supplies(components, {})
-        switching = [r for r in result if r["type"] == "switching_regulator"]
-        # If it fires, it must be exactly one entry for U2
-        u2_entries = [r for r in switching if r["main_component"] == "U2"]
-        assert len(u2_entries) <= 1, \
-            f"LM2596 should appear at most once in switching regulators, got: {u2_entries}"
+        u2_switching = [r for r in result
+                        if r["type"] == "switching_regulator" and r["main_component"] == "U2"]
+        u2_linear = [r for r in result
+                     if r["type"] == "linear_regulator" and r["main_component"] == "U2"]
+        assert len(u2_switching) == 1, f"LM2596 must be one buck entry, got: {u2_switching}"
+        assert u2_switching[0]["subtype"] == "buck"
+        assert u2_linear == [], f"LM2596 must NOT be classified linear, got: {u2_linear}"
+
+    def test_lm317_three_digit_ldo_still_linear(self):
+        # Guard the prefix-anchor fix doesn't break real 3-digit LM LDOs: LM317
+        # must still classify as a linear regulator.
+        result = identify_power_supplies({"U1": _comp("LM317")}, {})
+        u1_linear = [r for r in result
+                     if r["type"] == "linear_regulator" and r["main_component"] == "U1"]
+        assert len(u1_linear) == 1 and u1_linear[0]["subtype"] == "LDO"
 
 
 # ===========================================================================

--- a/tests/test_pcb_autoroute.py
+++ b/tests/test_pcb_autoroute.py
@@ -371,6 +371,20 @@ def test_nudge_separates_overlap_in_open_space():
     assert not _overlap(a.bbox(), b.bbox())
 
 
+def test_nudge_acts_on_touching_courtyards():
+    """gap == 0 (courtyards sharing exactly one edge) must count as overlapping —
+    KiCad DRC flags it as courtyards_overlap. The helper's AABB is non-strict
+    (<=); a strict `<` would treat touching as clear and never nudge (count 0).
+    half=5 → R1 bbox (45..55), R2 bbox (55..65): right edge of a == left edge of b."""
+    a = _FakeFP("R1", 50, 50, nets=2)
+    b = _FakeFP("R2", 60, 50, nets=1)
+    count, moved = _make_nudge()(_FakeBoard([a, b]), 0.5, 3)
+    assert count >= 1 and "R2" in moved, "touching courtyards must be nudged apart"
+    # strictly separated afterward (no longer even touching)
+    ax, bx = a.bbox(), b.bbox()
+    assert ax[2] < bx[0] or bx[2] < ax[0] or ax[3] < bx[1] or bx[3] < ax[1]
+
+
 def test_nudge_never_moves_a_footprint_off_board():
     """h-autoroute-nudge: R2 overlaps R1 at the board's right edge, so the
     separating move would go off-board. The shared helper keeps it inside the

--- a/tests/test_pcb_board.py
+++ b/tests/test_pcb_board.py
@@ -196,6 +196,27 @@ class TestSetDesignRules:
         assert result["design_rules"]["min_track_width_mm"] == 0.25
 
     @patch("kicad_mcp.tools.pcb_board.run_pcbnew_script")
+    def test_script_applies_all_rules_and_preserves_layer_count(
+        self, mock_run, pcb_server, pcb_with_project
+    ):
+        # Mocks can't catch a rule that's reported-but-not-written, so inspect the
+        # generated pcbnew script directly. Regression for: min_through_hole_diameter
+        # + min_copper_edge_clearance were echoed but never applied to the board,
+        # and SetCopperLayerCount(2) silently demoted multi-layer boards.
+        mock_run.return_value = {"status": "ok", "design_rules": {}}
+        fn = _get_pcb_fn(pcb_server)
+        fn("set_design_rules", pcb_path=pcb_with_project["pcb_path"],
+           min_through_hole_diameter_mm=0.15, min_copper_edge_clearance_mm=0.35)
+        script = mock_run.call_args[0][0]
+        assert "m_MinThroughDrill" in script, "through-hole rule must be written to the board"
+        assert "m_CopperEdgeClearance" in script, "edge-clearance rule must be written to the board"
+        # the five always-applied rules are still there
+        for attr in ("m_TrackMinWidth", "m_MinClearance", "m_ViasMinSize",
+                     "m_ViasMinDrill", "m_HoleToHoleMin"):
+            assert attr in script
+        assert "SetCopperLayerCount" not in script, "must not clobber the board's layer count"
+
+    @patch("kicad_mcp.tools.pcb_board.run_pcbnew_script")
     def test_updates_project_file(self, mock_run, pcb_server, pcb_with_project):
         pcb_path = pcb_with_project["pcb_path"]
         pro_path = pcb_with_project["pro_path"]

--- a/tests/test_pcb_drc_fix.py
+++ b/tests/test_pcb_drc_fix.py
@@ -163,3 +163,42 @@ class TestGeometryHelperInjected:
 # is marked ``@pytest.mark.requires_kicad``.  The tests above exercise the
 # injected helper string at the same semantic level the subprocess uses,
 # which is the closest we can get without a KiCad install.
+
+
+# ---------------------------------------------------------------------------
+# _categorize_violations — pure, in-process classification (the silk-vs-routing
+# keyword-order seam). Regression for: silk_clearance / silk_mask_clearance
+# contain BOTH "silk" and "clearance"; a routing-first fallback misclassified
+# them as routing → needless clear-and-reroute. The fallback must be silk-first.
+# ---------------------------------------------------------------------------
+
+from kicad_mcp.tools.pcb_drc_fix import _categorize_violations  # noqa: E402
+
+
+def _group_of(violation_type):
+    groups = _categorize_violations({violation_type: 1})
+    for name, entries in groups.items():
+        if any(e["message"] == violation_type for e in entries):
+            return name
+    return None
+
+
+class TestCategorizeViolations:
+    def test_silk_clearance_is_silkscreen_not_routing(self):
+        # contains "clearance" (routing kw) AND "silk" (silk kw) — silk wins.
+        assert _group_of("silk_clearance") == "silkscreen"
+
+    def test_silk_mask_clearance_is_silkscreen_not_routing(self):
+        assert _group_of("silk_mask_clearance") == "silkscreen"
+
+    def test_plain_clearance_is_routing(self):
+        assert _group_of("clearance") == "routing"
+
+    def test_silk_over_copper_is_silkscreen(self):
+        assert _group_of("silk_over_copper") == "silkscreen"
+
+    def test_courtyard_overlap_is_placement(self):
+        assert _group_of("courtyards_overlap") == "placement"
+
+    def test_unknown_type_is_other(self):
+        assert _group_of("some_future_violation") == "other"

--- a/tests/test_pcb_panelize.py
+++ b/tests/test_pcb_panelize.py
@@ -321,6 +321,29 @@ class TestEnumValidation:
         assert "error" in result
         assert "tooling" in result["error"]
 
+    # -- fiducials (was unvalidated → bad value reached KiKit with an opaque error) --
+
+    def test_fiducials_invalid_rejected(self, panelize_server, pcb_file):
+        fn = _get_tool_fn(panelize_server, "panelize_pcb")
+        with (
+            patch("kicad_mcp.tools.pcb_panelize.platform.system", return_value="Linux"),
+            patch("kicad_mcp.tools.pcb_panelize.shutil.which", return_value="/usr/bin/kikit"),
+        ):
+            result = fn(pcb_file, fiducials="invalid")
+        assert "error" in result
+        assert "fiducials" in result["error"]
+
+    def test_fiducials_2fid_near_miss_rejected(self, panelize_server, pcb_file):
+        """'2fid' looks plausible (3fid/4fid exist) but is not valid."""
+        fn = _get_tool_fn(panelize_server, "panelize_pcb")
+        with (
+            patch("kicad_mcp.tools.pcb_panelize.platform.system", return_value="Linux"),
+            patch("kicad_mcp.tools.pcb_panelize.shutil.which", return_value="/usr/bin/kikit"),
+        ):
+            result = fn(pcb_file, fiducials="2fid")
+        assert "error" in result
+        assert "fiducials" in result["error"]
+
 
 # -- kikit discovery tests ---------------------------------------------------
 

--- a/tests/test_placement_conventions.py
+++ b/tests/test_placement_conventions.py
@@ -264,8 +264,9 @@ class TestConnectorEdge:
         )
         applied = _events_by_rule(events, RULE_CONNECTOR_EDGE)
         assert any(e.code == "convention_applied" for e in applied)
-        # J1's x should now be less than the original leftmost (50.0).
-        assert pack.positions["J1"][0] < 50.0
+        # Pin the exact target: 0.5 column left of the original leftmost (50.0).
+        # A relational `< 50.0` would pass even for a near-zero offset.
+        assert pack.positions["J1"][0] == 50.0 - 25.4 * 0.5
 
     def test_last_tier_connector_pushed_right(self):
         members = {"c0": ["U1"], "c1": ["J1"]}
@@ -279,8 +280,30 @@ class TestConnectorEdge:
         )
         applied = _events_by_rule(events, RULE_CONNECTOR_EDGE)
         assert any(e.code == "convention_applied" for e in applied)
-        # J1's x should now be greater than the original rightmost (100.0).
-        assert pack.positions["J1"][0] > 100.0
+        # Pin the exact target: 0.5 column right of the original rightmost (100.0).
+        assert pack.positions["J1"][0] == 100.0 + 25.4 * 0.5
+
+    def test_two_tier_0_connectors_do_not_cascade(self):
+        # Both tier-0 connectors must target the SAME column (0.5 left of the
+        # pre-convention leftmost). The old bug read the MUTATED pack per call,
+        # so the 2nd connector pushed off the 1st's already-moved position and
+        # cascaded further left.
+        members = {"c0": ["J1"], "c1": ["J2"], "c2": ["U1"]}
+        labels = {
+            "c0": _label(LABEL_CONNECTOR, "J1"),
+            "c1": _label(LABEL_CONNECTOR, "J2"),
+            "c2": _label(LABEL_MCU, "U1"),
+        }
+        pack = _pack({"J1": (50.0, 30.0), "J2": (60.0, 30.0), "U1": (100.0, 30.0)})
+        apply_conventions(
+            members_by_cluster=members, cluster_labels=labels,
+            netlist={"components": {r: _comp(r) for r in ["J1", "J2", "U1"]}, "nets": {}},
+            pack=pack, cluster_tier={"c0": 0, "c1": 0, "c2": 1},
+            column_pitch_mm=25.4, row_pitch_mm=12.7,
+        )
+        target = 50.0 - 25.4 * 0.5            # 0.5 col left of pre-convention leftmost
+        assert pack.positions["J1"][0] == target
+        assert pack.positions["J2"][0] == target   # NOT cascaded further left
 
     def test_middle_tier_connector_skipped(self):
         members = {"c0": ["U1"], "c1": ["J1"], "c2": ["U2"]}

--- a/tests/test_placement_topology.py
+++ b/tests/test_placement_topology.py
@@ -177,6 +177,13 @@ class TestSparseClusterBoundary:
             _netlist(refs, nets), schematic_path=f"/tmp/n{n}.kicad_sch",
         )
 
+    def test_size_below_max_emits_sparse_warning(self):
+        # 2 members (SPARSE_CLUSTER_MAX - 1) → below the boundary, still sparse.
+        # Pins the `<=` (not `==`): a `< 3` regression would drop this case.
+        part = self._connected_cluster_of_size(SPARSE_CLUSTER_MAX - 1)
+        codes = [e["code"] for e in part.events]
+        assert "sparse_cluster" in codes
+
     def test_size_exactly_max_emits_sparse_warning(self):
         # 3 members (== SPARSE_CLUSTER_MAX) → warning per spec
         part = self._connected_cluster_of_size(SPARSE_CLUSTER_MAX)

--- a/tests/test_schematic.py
+++ b/tests/test_schematic.py
@@ -138,6 +138,68 @@ class TestAddAndListComponents:
         result = _call(fn, "remove_component", reference="R99")
         assert "error" in result
 
+    def test_remove_component_multi_removes_only_named(self, sch_server):
+        # Multi-component: a "remove first in list regardless of reference" bug
+        # (the move_component filter()-footgun class) would pass a 1-component
+        # test but fail here.
+        fn = _get_schematic_fn(sch_server)
+        _call(fn, "add_component", lib_id="Device:R", reference="R1", value="10k",
+              position=[100, 100])
+        _call(fn, "add_component", lib_id="Device:R", reference="R2", value="22k",
+              position=[120, 100])
+        _call(fn, "add_component", lib_id="Device:C", reference="C1", value="100nF",
+              position=[140, 100])
+        result = _call(fn, "remove_component", reference="R2")
+        assert result["status"] == "ok"
+        refs = {c["reference"] for c in _call(fn, "list_components")["components"]}
+        assert refs == {"R1", "C1"}                 # only R2 gone, not "the first one"
+
+
+# -- move_component tests ----------------------------------------------------
+
+class TestMoveComponent:
+    """Regression coverage for the critical filter()-footgun: move_component used
+    `components.filter(reference=ref)` which silently returns ALL components, so
+    [0] moved the WRONG one while reporting status=ok. A single-component test
+    masks it (matches[0] is the only component); these use ≥2."""
+
+    @pytest.fixture(autouse=True)
+    def _create_schematic(self, sch_server):
+        fn = _get_schematic_fn(sch_server)
+        _call(fn, "create", name="test")
+        _call(fn, "add_component", lib_id="Device:R", reference="R1", value="10k",
+              position=[100, 100])
+        _call(fn, "add_component", lib_id="Device:R", reference="R2", value="22k",
+              position=[120, 100])
+        _call(fn, "add_component", lib_id="Device:C", reference="C1", value="100nF",
+              position=[140, 100])
+        self._fn = fn
+
+    def _pos(self, ref):
+        comps = _call(self._fn, "list_components")["components"]
+        c = next(c for c in comps if c["reference"] == ref)
+        return c.get("position")
+
+    def test_moves_only_the_named_component(self, sch_server):
+        before_r1 = self._pos("R1")
+        before_c1 = self._pos("C1")
+        result = _call(self._fn, "move_component", reference="R2", position=[60, 60])
+        assert result["status"] == "ok"
+        assert result["reference"] == "R2"
+        # R2 actually moved to (snapped) ~(60,60)...
+        r2 = self._pos("R2")
+        assert abs(r2[0] - 60) < 1.0 and abs(r2[1] - 60) < 1.0
+        # ...and R1 / C1 did NOT move (the bug would have moved matches[0] = R1).
+        assert self._pos("R1") == before_r1
+        assert self._pos("C1") == before_c1
+
+    def test_unknown_reference_is_error_not_silent_move(self, sch_server):
+        before = {r: self._pos(r) for r in ("R1", "R2", "C1")}
+        result = _call(self._fn, "move_component", reference="R99", position=[60, 60])
+        assert "error" in result                    # not status=ok on a phantom ref
+        # nothing moved
+        assert {r: self._pos(r) for r in ("R1", "R2", "C1")} == before
+
 
 # -- add_wire tests ----------------------------------------------------------
 

--- a/tests/test_schematic_layout.py
+++ b/tests/test_schematic_layout.py
@@ -347,7 +347,14 @@ class TestApplyAndClearCache:
     ):
         """Real schematic with no U1; state targets U1; apply must report
         an error for that ref against the real ksa lookup, not via a
-        stub-induced AttributeError."""
+        stub-induced AttributeError.
+
+        Because U1 is the ONLY target, applied==0 and every target failed —
+        the save is a no-op, so apply must return status="error"
+        (code="no_components_applied") rather than a misleading "ok" that the
+        caller would trust as a successful placement. (Mirrors the
+        _finalize_pad_assignment "requested work, did nothing → hard error"
+        principle.)"""
         self._isolate_cache(tmp_path, monkeypatch)
         sch_path = _build_real_sch(tmp_path, [
             ("R1", "10k", (50, 50)),
@@ -362,7 +369,8 @@ class TestApplyAndClearCache:
         })
 
         result = schematic_layout_fn(operation="apply", state_id="eeee5555ffff6666")
-        assert result["status"] == "ok"
+        assert result["status"] == "error"
+        assert result["code"] == "no_components_applied"
         assert result["applied"] == 0
         assert len(result["errors"]) == 1
         assert result["errors"][0]["ref"] == "U1"

--- a/tests/test_schematic_layout.py
+++ b/tests/test_schematic_layout.py
@@ -604,8 +604,9 @@ class TestApplyMovesOnlyTargetedRefs:
         r1_after = sch_after.components.get("R1").position
         r2_after = sch_after.components.get("R2").position
         c1_after = sch_after.components.get("C1").position
-        # R1 moved to (or near) the requested (100, 100), grid-snapped.
-        assert abs(r1_after.x - 100) < 2 and abs(r1_after.y - 100) < 2
+        # R1 moved to the requested (100, 100), within half a 1.27mm grid step
+        # (< 2 was loose enough to pass a move to 99 — a wrong-place bug).
+        assert abs(r1_after.x - 100) < 0.7 and abs(r1_after.y - 100) < 0.7
         # R2 and C1 must NOT have moved — the bug used to overwrite them.
         assert (r2_after.x, r2_after.y) == (r2_pos_before.x, r2_pos_before.y)
         assert (c1_after.x, c1_after.y) == (c1_pos_before.x, c1_pos_before.y)


### PR DESCRIPTION
Release-readiness pass for 0.11.0. Every fix verified against the real pcbnew API (KiCad 9 + 10 where relevant); full unit suite green throughout (479 → **2143 passed**), testability ratchet unchanged.

## Docs / cross-agent
- Corrected stale tool references + counts; added the `design` router to TOOLS/README.
- Added `AGENT-INSTRUCTIONS.md` + server `instructions` so non-Claude agents get the operating guide (CLAUDE.md is gitignored / Claude-only).

## Cold code review (fan-out, verified before fixing)
- **Critical:** `move_component` used `filter(reference=…)` which silently returns *all* components → moved the wrong one and reported ok. → `components.get()`.
- **High (9):** touching-courtyard detection in keepout auto-fix; pre-route pad-gap drift → spliced `PAD_GAP_HELPER`; `set_design_rules` now writes through-hole/edge-clearance + stops clobbering layer count; footprint-load failure made fatal (was silently building incomplete boards); zones/gerber failures can't discard a routed board; `drc autofix` checks FreeRouter availability *before* clearing routing; async autoroute runs the shared preflight; I2S mic net-name collision on a 2nd bus; netlist incompleteness forwarding; lcsc tier-attr guards.
- **Medium (11):** oscillator double-classification, silk-vs-routing keyword order, fiducials validation, premature keepout event, mutable default, event-context early return, `from_dict` null coercion, label unescaping, sqlite connection leaks, `suggest_cards` skipped list, config.h ambiguity warning, connector-edge cascade.

## Cold test review
- Regression tests pinning every fix above (a revert now fails) — the single-element-masking gap that hid the `move_component` bug.
- Surfaced + fixed a new source bug: `from_dict` `d.get(k, [])` returned `None` for present-but-null keys (`buses: null` → TypeError).
- Strengthened weak/relational assertions to exact-value pins.

## Deferred findings resolved
- **#3 ambiguous-part:** an ambiguous bus emitted contradictory gaps and assumed a default despite named candidates → now held unrealized (`part_provenance="ambiguous"`).
- **#7 LM2596:** prefix-shadow seam — loose `LM\d{3}` matched inside `LM2596`, misclassifying the buck converter as a linear LDO → anchored `LM\d{3}(?!\d)`.

## Clean-room board-regeneration gate
Regenerated all five golden boards (speed-cal, audio_s3, track-geometry, audio-remote, audio-remote multi-edge) and eyeballed renders. Two systematic DRC findings surfaced (pre-existing; integration tests don't run DRC) and fixed:
- **Mounting-hole keepout self-flagged its own NPTH pad** (`items_not_allowed`) — disallowed pads, and now also disallows zone fills (the pour was never actually kept off the screw annulus).
- **Module thermal vias (0.2mm) tripped the default 0.3mm min-hole** (`drill_out_of_range`) — create step now sets `min_through_hole = 0.2mm` (JLCPCB standard PTH min).

After both fixes, all five boards regenerate, route fully (DRC `unconnected=0`), and carry **zero must-fix DRC violations** — only cosmetic silk + acceptable thermal relief remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)