### PR TITLE
test(integration): 360s timeout for passes=10 routing tests

### DIFF
--- a/tests/integration/test_firmware_pcb_pipeline.py
+++ b/tests/integration/test_firmware_pcb_pipeline.py
@@ -361,6 +361,12 @@ def test_firmware_to_routed_pcb(mcp_server, tmp_path):
     assert {"U1", "U3"} <= refs_on("I2C_SDA")
 
 
+# best-of-10 FreeRouter on the dense ESP32-S3 board (128 pads) runs past the
+# global --timeout=120 under concurrent CI load (it timed out post-merge on main
+# when the tag fired Release + Tests + Integration at once). Give the passes=10
+# routing tests a realistic per-test budget; the 120s default still guards the
+# fast tests against genuine hangs. (passes stays 10 / bound stays 6 per §9-A3.)
+@pytest.mark.timeout(360)
 def test_audio_s3_to_routed_pcb(mcp_server, tmp_path):
     """The SECOND board shape: an ESP32-S3 audio node (CMCA_* naming, I2S amp
     buses, #if target block). Exercises the generalized recognition +
@@ -924,6 +930,7 @@ def test_approval_gate_audio_remote(mcp_server, tmp_path):
     assert sc.board_size_mm is not None and sc.mounting_holes is not None
 
 
+@pytest.mark.timeout(360)  # passes=10 routing — same budget as audio_s3 (above)
 def test_track_geometry_to_routed_pcb(mcp_server, tmp_path):
     """The THIRD board shape: an I2C sensor-hub (track-geometry car). Exercises
     the generalization that matters here — MULTIPLE address-declared devices,


### PR DESCRIPTION
Post-merge, `test_audio_s3_to_routed_pcb` timed out (>120s) on `main` (both KiCad 9 + 10), so the Integration workflow went red — while PR #71's identical content had passed.

**Cause:** the `passes=6→10` bump from #71 (to clear a 7-vs-6 unrouted flake) pushed best-of-10 FreeRouter on the dense ESP32-S3 board past the integration workflow's global `--timeout=120`. On `main` the tag push fired Release + Tests + Integration concurrently on the self-hosted runners, so each routing pass ran slower and tipped over; PR #71 squeaked under on a quieter runner.

**Fix:** `@pytest.mark.timeout(360)` on the two `passes=10` routing tests (audio_s3 + track_geometry). The marker overrides the global 120s for just those; the fast tests keep the 120s hang-guard. `passes` stays 10 and the unrouted bound stays 6 (SPEC §9-A3) — this is a wall-clock budget, not a correctness change. `27 passed, 1 timed out` last run, so the pipeline itself is sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)