### PR TITLE
firmware: off-board & expander terminals (+ KiCad 9/10 cross-version symbol resolution)

### DIFF
--- a/docs/SPEC_expander_terminals.md
+++ b/docs/SPEC_expander_terminals.md
@@ -1,0 +1,98 @@
+# SPEC: Expander-port terminals (MCP23017 GPA/GPB → labeled terminals) — v2, post-cold-review
+
+Status: DRAFT, cold-reviewed (3 severity tiers). **Do not implement in the writing session.** v2 resolves the review's contradictions/gaps; the diff from v1 is in §0.
+
+## 0. What the cold review changed (read first)
+
+- **Core mechanism CONFIRMED (KiCad 10).** An endpoint `{ref=<MCP>, pin="GPA0"}` resolves: `generate.py:resolve_pin` → `resolve_pin_token` → exact pin-name match on the symbol (GPA0 → pad 21). `synthesize_connector`/`_emit_connector` are **agnostic about the far end** — a terminal whose other endpoint is a chip pin places/legends exactly like one wired to the MCU. So the design is buildable.
+- **BLOCKER — KiCad 9.** The MCP23017 card's `lib_id: Interface_Expansion:MCP23017x-x-SO` exists **only in KiCad 10**; KiCad 9 names it `MCP23017_SO`. The CI matrix runs both. On KiCad 9 the MCP23017 chip already fails to place (pre-existing card issue), so tapping its pins yields unwired nets. → §9 makes this an explicit dependency/risk; the expander feature inherits the MCP23017's cross-version symbol resolution and must not be the thing that "discovers" it in the field.
+- **7 contradictions resolved** (§4 decisions): `ports:int` kept (it's the MCP **hardware** register order + the user's explicit count, not a firmware guess); `ports>16` is a disclosed **error**, not a silent cap; `single`-over-16 emits a **gap** + pin-header fallback (recommend per_bank); `power` default `3v3` reframed as a declared convenience (carve-out in §3), `none` available; `_emit_connector` reuse **decided yes** (tier-1 confirmed compatible); `group: per_sensor` is the schema default (Q5 closed); duplicate `net_prefix` is a **SidecarError at load**.
+- **Schema cascade fully enumerated** (§5) incl. the sites v1 review taught us: `BoardSidecar`, `load_sidecar`, `_KNOWN_SIDECAR_KEYS`, `_validate`, `apply_sidecar`, `test_known_keys_all_accepted`, `SCHEMA_VERSION` bump (6→7), the sidecar **docstring example**, and the `DesignIntent` field shape (now committed).
+- **mcp23017.yaml gains a `port_pins` enumeration** as the validation source of truth (avoids needing KiCad at unit-test time).
+
+## 1. Problem
+(unchanged) The MCP23017 is placed with its I2C side wired but GPA0-7/GPB0-7 float; the up-to-16 TCRT5000 sensors that wire there are absent. Firmware gives a count + register convention + position table but no per-sensor `#define` (register-addressed at runtime). This case requires an explicit board.yaml declaration.
+
+## 2. Current state (grounded, file:line)
+- `mcp23017.yaml`: roles `{SDA, SCL: SCK, INT}`, supply/ground, address straps; **GPA/GPB not modeled**.
+- KiCad 10 symbol `Interface_Expansion:MCP23017x-x-SO`: pins `GPA0..GPA7` (pads 21-28), `GPB0..GPB7` (pads 1-8). KiCad 9: `MCP23017_SO` (different lib_id) — see BLOCKER §0/§9.
+- `Endpoint.pin` (intent.py:43) is consumed by `generate.resolve_pin` (generate.py:89-107) via `resolve_pin_token` (mcu_pinmap.py:50-66) — exact, case-sensitive name match. Already exercised by passive/USB pads.
+- Connector synth: `synthesize_connector` (connectors.py:104-188) far-end-agnostic; `_emit_connector` (templates.py:120-157) sets silk legend + field-wiring placement heuristic.
+- Schema guards: `_KNOWN_SIDECAR_KEYS` (sidecar.py:127), `BoardSidecar` (sidecar.py:94), `load_sidecar` (sidecar.py:315), `_validate` (sidecar.py:223), `apply_sidecar` (sidecar.py:349), `test_known_keys_all_accepted` (test_firmware_sidecar.py:208), `SCHEMA_VERSION=6` (intent.py:29). `_REALIZED_LOCI` (sidecar.py:472) — NOT touched (this feature bypasses `placements`).
+- Expand: `_REGISTRY` list (templates.py:793); `expand_intent` runs `_inject_terminal_loci` then the registry; `RefAllocator`/`nets_by_name` built once before the loop. `new_nets` append has **no collision guard** (templates.py:840).
+
+## 3. Goals / non-goals (carve-out added)
+**Goals.** Declare an expander's sensor ports → labeled terminal(s) tapping the floating GPAn/GPBn pins + power. Honest-by-construction: explicit board.yaml.
+**Non-goals.** Auto-read `NUM_SENSORS`; synthesize the TCRT5000 silicon (LED resistor/pull-up live on the breakout); non-MCP23017 expanders in v2.0.
+**Carve-out (review #4):** the power rail at the terminal is **user-declared topology**, not an inference about the sensor. `power: 3v3` is a convenience default (most sensor breakouts want board power on a 3-wire terminal); `power: none` for self-powered breakouts. This is distinct from synthesizing the sensor's internal parts.
+
+## 4. Design (decisions baked in)
+### board.yaml surface
+```yaml
+expander_terminals:
+  U3:                    # expander ref (a placed peripheral). Bypasses placement:.
+    device: TCRT5000     # silk label + connector value
+    ports: 6             # int N => first N ports in MCP hardware order GPA0..GPA7,GPB0..GPB7
+                         #   (HARDWARE register order, not a firmware guess);
+                         # OR explicit list: [GPA0, GPA1, GPB0]
+    group: per_sensor    # per_sensor (DEFAULT) | per_bank | single
+    power: 3v3           # 3v3 (DEFAULT, convenience) | 5v | none
+    net_prefix: SENSOR   # default = device value; MUST be unique across entries
+```
+**Decisions:**
+- `ports: int` — allowed. N maps to the first N pins in the MCP23017 **hardware register order** (GPA0-7 then GPB0-7). This is a hardware fact + the user's explicit count, not a firmware-convention guess (resolves review #1). `> 16` → **disclosed error, no synthesis** (delete any "cap"; resolves review #5).
+- `group` — `per_sensor` default (N × `[signal, +power, GND]`); `per_bank` (one terminal per used GP bank); `single` (all + power — if >16 positions, emit a **gap** and fall back to a pin header; recommend per_bank instead). Disclosure is always a **Gap** (non-fatal, user-visible), never a bare log (resolves review #3).
+- `power` — `3v3` convenience default / `5v` / `none`. **`5v` requires the `+5V` rail to exist** (the usb_programming/CP2102 block ran); if absent, emit a gap and treat as `none` (resolves review-scope #10).
+- `net_prefix` — default = `device`; **must be unique across all `expander_terminals` entries** → `SidecarError` at load on duplicate (resolves review #7/#14). Nets `{prefix}_{i}`.
+
+### Net synthesis
+New template `expander_terminals(intent, alloc)` appended to `_REGISTRY` (after the device templates; the MCP is already placed and is NOT remote, so no `remote_peripherals` interaction — §7 asserts this). For each declared port pin: create a **new net** `{prefix}_{i}` = `[Endpoint(ref=expander_ref, pin="GPAn"), <terminal position>]`; **guard against name collision** with `nets_by_name` (rename `{prefix}_{i}_{ref}` + gap, or refuse — see §6). Terminal(s) + `+power`/`GND` via `_emit_connector` (decided reuse; resolves review #2), grouped per `group`.
+
+### DesignIntent shape (committed; resolves scope #3)
+Add `DesignIntent.expander_terminals: dict[str, ExpanderSpec]` keyed by expander ref, where `ExpanderSpec` is a small dataclass `{device, ports: list[str], group, power, net_prefix}` (the `ports:int` shorthand is expanded to a pin-name list at sidecar-apply time, so the template sees only resolved pin names). `to_dict`/`from_dict` get an explicit branch; `SCHEMA_VERSION` 6 → 7.
+
+### Port-pin validation source (resolves scope #7)
+Add a `port_pins: [GPA0..GPB7]` stanza to `mcp23017.yaml`. `_validate_expander_terminals` checks each requested pin against the card's `port_pins` (data-only; no KiCad needed at test time). Unknown pin (`GPC0`) or `ports` exceeding `len(port_pins)` → SidecarError/gap.
+
+## 5. Implementation touchpoints (complete)
+- **intent.py**: `ExpanderSpec` dataclass; `DesignIntent.expander_terminals` field; `to_dict`/`from_dict` branch; `SCHEMA_VERSION` 6→7.
+- **sidecar.py**: `BoardSidecar.expander_terminals` field (+ field comment); `load_sidecar` constructor line; `"expander_terminals"` in `_KNOWN_SIDECAR_KEYS`; `_validate_expander_terminals` called from `_validate` (ref present? pins valid vs card `port_pins`? group/power valid? net_prefix unique?); `apply_sidecar` block populating `intent.expander_terminals` (resolve `ports:int`→pin list here; defer "ref not yet placed" to template-time, see §6); **module docstring example** gains the block.
+- **templates.py**: `expander_terminals` template + register in `_REGISTRY`; reuse `_emit_connector`; net-collision guard.
+- **devices/peripherals/mcp23017.yaml**: add `port_pins` enumeration.
+- **generate.py**: no change expected (MCP stays placed; new nets wire by pin name) — confirm via the integration test.
+- **tests**: see §7. **`test_known_keys_all_accepted` (test_firmware_sidecar.py:208) MUST add the key + assert the round-trip** (the 3-source CI guard; scope #2).
+
+## 6. Edge cases / seams
+- `ports>16` or list longer than `port_pins` → SidecarError/gap, no synthesis.
+- `single` >16 positions → gap + pin-header fallback (recommend per_bank).
+- bad pin name / unknown expander ref / ref not a placed peripheral → gap, no crash. (Ref-existence checked at template-expand time, since placement happens during expand.)
+- multiple expanders → distinct refs; **unique net_prefix enforced at load**.
+- net-name collision with an existing net → guard in the template (namespace by ref + gap); do NOT silently append a duplicate-named net (templates.py:840 has no guard today).
+- expander I2C/INT side already wired — only tap GPA/GPB; never touch existing nets.
+- `power: 5v` with no `+5V` rail → gap, treat as `none`.
+- `power: none` → `[signal, GND]` per sensor (2-pos) — confirm 2-pos screw terminal is in the Phoenix range (yes, 2..16).
+- `per_bank` when only GPA used → one terminal (no empty GPB terminal).
+- `ports: 0`/empty → no-op + note.
+- KiCad 9 (BLOCKER §0): MCP not placed → endpoints unresolved. Gate or accept as known limitation (§9).
+
+## 7. Test plan
+- per_sensor: N ports → N terminals, each tapping the correct `GPAn` pad + power + GND; nets named/labeled; each net carries the expander-pin endpoint.
+- per_bank / single variants: expected terminal count/positions; `single`>16 → gap + pin-header.
+- `ports:int` and the equivalent explicit list → identical result.
+- validation: bad pin / over-16 / unknown ref / duplicate net_prefix → SidecarError or gap (accept/reject matrix), no crash.
+- `power: 5v` with no +5V rail → gap + downgrade.
+- **Regression gate (scope #8):** `test_generate_speedcal_end_to_end` (test_firmware_generate.py:75) still passes unchanged WITHOUT an expander_terminals block (MCP I2C side untouched, `components_placed` unchanged).
+- **No double-emit (scope #11):** after `expander_terminals` runs, the MCP23017 is NOT in `offboard_refs` and `remote_peripherals` emits no terminal for it.
+- **`test_known_keys_all_accepted` (scope #2):** add `expander_terminals` + assert round-trip.
+- **Integration (scope #9):** a `test_expander_terminals_to_routed_pcb` (pattern: test_firmware_pcb_pipeline.py:1010) — board.yaml with `expander_terminals: {U3: {device: TCRT5000, ports: 6}}` on the speed-cal (or a minimal MCP) fixture → full import→expand→generate→build_pcb → 6 terminals route DRC-clean, GPA0-5 connected. **This is where KiCad-9 vs 10 surfaces — run on the matrix.**
+- at/below/above on ports count (0, 16, 17).
+
+## 8. Decisions still open for the implementer (small)
+- Net-collision behavior: rename-with-gap vs refuse. (Recommend rename `{prefix}_{i}_{ref}` + gap, since the user's intent is clear.)
+- `per_bank` terminal labeling (GPA bank vs GPB bank silk text).
+
+## 9. Dependency / risk: KiCad 9 MCP23017 symbol
+The MCP23017 card's `lib_id` resolves only on KiCad 10. This is **pre-existing** (not introduced here) but the expander feature is the first to depend on the MCP's *port* pins, so a KiCad-9 build would silently produce unwired sensor nets. Options, in order: (a) fix `mcp23017.yaml` to a lib_id that resolves on BOTH 9 and 10 (verify whether the library's symbol-aliasing resolves `MCP23017_SO`↔`MCP23017x-x-SO`, or add a per-version card) — **a separate prerequisite fix**, ideally done first; (b) gate `expander_terminals` on KiCad 10 with a clear gap on 9; (c) accept as a documented limitation. Recommend (a) as a standalone fix before/with implementation, and an integration test on BOTH matrix versions to prove it.
+
+## 10. Process note
+Cold-reviewed via 3 severity-tier subagents. Implementation is a SEPARATE session/turn. Companion to SPEC_offboard_terminals (v1 shipped). The KiCad-9 MCP23017 symbol fix (§9) is a recommended prerequisite.

--- a/docs/SPEC_offboard_terminals.md
+++ b/docs/SPEC_offboard_terminals.md
@@ -1,0 +1,100 @@
+# SPEC: Off-board peripheral → labeled terminal (v2, post-cold-review)
+
+Status: DRAFT, cold-reviewed (3 subagents: external-assumptions / contradictions / scope). **Do not implement in this session** (Spec Review Rule). v2 incorporates the review; the diff from v1 is summarized in §0.
+
+## 0. What the cold review changed (read this first)
+
+- **2 BLOCKERS killed v1's risky path.** (a) board.yaml *cannot* key an un-carded peripheral by firmware name — `_apply_placement` only resolves `periph_by_ref`/`bus_by_name`; an unknown name → `placement_unknown_target` gap, ignored (`sidecar.py:488–511`). (b) Orphan nets carry **no machine-readable peripheral attribution** — the peripheral name lives only in the gap *string*, not on the `Net` object (`intent.py:386–392`). Both blockers hit ONLY the "auto-terminal for un-carded orphans" idea (v1 §4a options B/C). **Both are sidestepped entirely by terminal-only device cards** (a card gives a ref → nets become attributed → flows through the existing `remote_peripherals` path). → **v2 recommends cards as the v1 mechanism.**
+- **CRITICAL contradiction resolved.** The auto-fallback would have emitted a terminal for an INMP441 I2S bus that was *not* declared remote, contradicting the honest chip-refusal. Rule added (§4): the terminal path applies to **carded terminal-devices and explicitly `locus:remote` buses only** — never an automatic fallback on un-declared bus peripherals.
+- **Facts corrected.** The user's three examples: **ICS-43434 — done** (remote-mic terminal + now on-board); **LD2410 — already done** (UART remote terminal; integration-tested at `test_firmware_pcb_pipeline.py:458`); **TCRT5000 — the genuinely-unhandled case, and it's the *expander-array* flavor** (sensors hang off MCP23017 ports; firmware never `#define`s their pins, so there are NO MCU-side orphan nets — the v1 "linchpin" does NOT apply to TCRT5000). So TCRT5000 is inherently board.yaml-driven.
+- **`external_io` confirmed dead; `power:` doesn't exist** and adding it touches a 3-source schema lockstep + `SCHEMA_VERSION`. SPI buses exist and were omitted. Several existing tests *pin the current refusal behavior* and will invert.
+
+## 1. Problem (unchanged)
+
+Off-board breakout peripherals must appear on the main PCB as labeled (screw) terminals carrying signals + power. Today this works for carded-ref devices and the I2S-mic/UART buses (via `locus:remote`), but a recognized-but-uncarded part has no way to become a terminal.
+
+## 2. Current state (corrected)
+
+Locus: board.yaml `placement:` → `Placement` in `intent.placements`; single dispatch `intent.is_remote()`. `_REALIZED_LOCI` (`sidecar.py:472`) = exactly `{(bus,I2S_IN,remote),(bus,UART,remote),(bus,I2S_OUT,on_board_with_remote_io),(ref,None,remote)}`; anything else non-`on_board` → `placement_unsupported` gap.
+
+**Handled (labeled terminal today):** carded ref + `remote` → `remote_peripherals` (uses `ex.joins`); I2S_IN bus + `remote` → `_emit_remote_mic` (uses `ex.new_nets`, has MIC/MIC1 prefix); UART bus + `remote` → `_emit_remote_uart`; I2S_OUT `on_board_with_remote_io` → amp on-board + speaker terminal; manual `extra_connectors`.
+**Connector machinery:** `synthesize_connector` builds `Connector:Screw_Terminal_01x{N}` for any N; Phoenix MKDS-1,5 footprint for N∈2..16, pin-header fallback for N=1 or N>16 (`connectors.py:36–82`).
+
+**Gaps (no terminal):**
+1. **Un-carded loose part with MCU signals** (piezo `PIEZO_ADC`, track switches `TRACK_SW1/2`): signals survive as orphan nets but with no peripheral attribution on the `Net`.
+2. **Expander-port arrays** (TCRT5000 ×N on MCP23017): no MCU-side signals at all → not representable without board.yaml.
+3. **I2C bus-level remote** → `placement_unsupported` (no `_emit_remote_i2c`).
+4. **SPI bus remote** → not modeled at all (omitted from advisory + registry + `_REALIZED_LOCI`).
+5. **I2S_OUT fully remote** (amp on breakout) → only `on_board_with_remote_io` exists.
+6. **`external_io`** → dead metadata (no template reads it).
+
+## 3. Goals / non-goals (G1 qualified)
+
+**G1.** Every firmware-named off-board peripheral **whose signals the tool can see** becomes a labeled terminal. **G2.** No *silent* orphan for such a peripheral — terminal or disclosed gap. **G3.** Honest-by-construction: a realized terminal comes from an explicit declaration (a card, or a `locus:remote` directive) — never an un-declared heuristic. **G4.** Adding a new remote bus type is cheap.
+**Non-goals:** synthesizing sensor silicon on-board; inferring expander-port wiring without board.yaml; auto-guessing 3V3-vs-5V without evidence; auto-terminalizing un-declared bus peripherals (would break the chip-refusal invariant).
+
+## 4. Design — staged, lowest-risk first
+
+### v1 — Terminal-only device cards (resolves both blockers + the honesty contradiction)
+
+A **terminal-only card**: a device card whose realization IS a labeled screw terminal (no chip). Add `tcrt5000.yaml` (single sensor) + generic `switch.yaml` / `analog_sensor.yaml`, marked e.g. `realize: terminal` (new card field) with a screw-terminal footprint and role→signal map. Effect:
+- The card gives the peripheral a **ref** → it enters `periph_by_ref` (blocker (a) gone) and its nets become attributed `"peripheral"` nets (blocker (b) gone).
+- A terminal-only card can **default to a terminal** with NO honesty cost — the card *is* the explicit declaration that this part is a wire-out (G3 satisfied). No `locus:remote` needed, though `on_board` could be disallowed/ignored for these.
+- Reuses `remote_peripherals` / the unified emitter; gets silk legend, ref alloc, multi-instance prefixing for free.
+
+This is the **ICS-43434 pattern applied to terminal-only devices.** It covers gap #1 (loose parts) for any part we card. It does NOT cover gap #2 (expander arrays) — that's board.yaml.
+
+**Rule (resolves CRITICAL contradiction #1):** the terminal-only-card default applies ONLY to cards explicitly marked terminal-only. Bus-typed peripherals (I2S_IN/OUT, UART, I2C, SPI) are NEVER auto-terminalized — they require explicit `locus:remote`. So an INMP441 I2S bus with no `locus:remote` still hits the honest chip-refusal; it does not silently become a terminal.
+
+### v1.1 — Generalize the emitter (refactor, behavior-preserving)
+
+Collapse `_emit_remote_mic` / `_emit_remote_uart` / `remote_peripherals` into one `emit_terminal(signals, power_rail, label, connector_type, net_mode)`. **Watch:** mic/uart create nets (`ex.new_nets`) while `remote_peripherals` joins existing nets (`ex.joins`); the unified emitter needs a `net_mode` param. Preserve the MIC/MIC1 prefix and per-emitter power-pin ordering via tests (snapshot current output first).
+
+### v2 — Bus-remote completeness (each additive)
+
+- **I2C remote:** add `_emit_remote_i2c` (SCL/SDA/+3V3/GND; decide: omit the on-board pull-ups, analogous to the mic's bypass-cap suppression). Add `(bus,I2C,remote)` to `_REALIZED_LOCI`; add I2C to the field-wired advisory; flip `test_apply_flags_unrealized_locus_on_i2c_bus`.
+- **SPI remote:** model it (MOSI/MISO/SCK/CS/+3V3/GND); add to advisory + `_REALIZED_LOCI` + registry.
+- **I2S_OUT fully remote:** new branch (no amp, terminal carries BCLK/LRC/DIN/+3V3/GND); add `(bus,I2S_OUT,remote)`.
+
+### v2 — Expander-port arrays + board.yaml surface
+
+- `expander_terminals:` (or extend `placement:`) declaring expander ref + port ranges → labeled terminal(s). Firmware-blind (like `extra_connectors`); the ONLY way to express TCRT5000-on-MCP23017. Must be added to `_KNOWN_SIDECAR_KEYS` the moment it's documented (else hard "unknown key" error).
+- `power: 3v3|5v` per-remote (breakout supply); default 3V3. **Schema cascade (do all or CI breaks):** field on `Placement` (`intent.py:91`), `_validate_placement` (`sidecar.py:140`), `load_sidecar` construction (`sidecar.py:491`), `from_dict`/`_only_fields` (`intent.py:479`), `_KNOWN_SIDECAR_KEYS` 3-source set + `test_known_keys_all_accepted` (`test_firmware_sidecar.py:208`), `SCHEMA_VERSION` bump (`intent.py:29`).
+- **`external_io`:** revive as the partial-remote signal-selector for `on_board_with_remote_io`, OR formally deprecate. Pick one; today it's load-bearing in §7 prose but dead in code.
+
+## 5. Implementation checklist (touchpoints the review surfaced — don't miss these)
+
+- [ ] `_REALIZED_LOCI` + `_apply_placement`: terminal-only cards are `ref`-keyed (already realized as `(ref,None,remote)`), so **v1 may need NO `_REALIZED_LOCI` change** if the card defaults to terminal without a locus directive — confirm the dispatch. Each v2 bus-remote adds one tuple.
+- [ ] New card field (`realize: terminal`): `cards.py` validator + the realization dispatch in `templates.py`/`intent.py`.
+- [ ] `generate.py:53` schematic-exclusion: terminal-only carded devices have a ref → `is_remote`/terminal check must exclude them from schematic chip placement appropriately.
+- [ ] Tests that PIN current behavior and will change: `test_firmware_placement_locus.py:114–149` (the I2C-remote-unsupported assertion inverts in v2); add the uncarded/terminal-card cases.
+- [ ] **Integration test:** `test_firmware_pcb_pipeline.py` has remote mic+UART coverage but NONE for a terminal-only-card part routed to a board — add one (piezo/switch/TCRT5000 → terminal, DRC-clean).
+- [ ] Tool-count 4-file lockstep ONLY if a new `design` operation is exposed (the emitter is internal, so likely N/A — confirm).
+- [ ] `advise_unspecified_placement` (`sidecar.py:444`) covers only I2S/UART buses; G2 implies loose orphan parts should be nudged too — extend or accept they're silent until carded.
+
+## 6. Test plan (per threshold/seam rule)
+
+- Terminal-only card → labeled screw terminal with correct signals + power + silk; no orphan remains; multi-instance non-colliding (MIC/MIC1 precedent).
+- **Invariant pin:** an I2S/UART/I2C bus naming an unrealizable chip WITHOUT `locus:remote` still REFUSES (no auto-terminal) — guards contradiction #1.
+- Carded `remote_peripherals` + `_emit_remote_mic`/`_emit_remote_uart` outputs unchanged after the §v1.1 unification (snapshot before/after).
+- at/below/above on the realization predicate: terminal-only card / chip card / bus+remote / bus-no-remote / uncarded-no-card.
+- v2: I2C/SPI/I2S_OUT remote terminals; `power:` rail selection; `expander_terminals`; flip the inverted `placement_unsupported` tests.
+
+## 7. Resolved questions (from the review)
+
+1. Orphan-net survival: TRUE for loose MCU-signal parts (piezo/switch) but the attribution is only in gap text → **avoid relying on it; use cards** (v1). FALSE for TCRT5000 (behind expander, no MCU nets) → board.yaml only.
+2. board.yaml keying an uncarded name: **not supported today; cards avoid needing it.**
+3. `synthesize_connector` arbitrary-N: OK (Phoenix 2–16; mind the >16 fallback for big expander terminals).
+4. Honesty: terminal-only **cards** are explicit declarations → no G3 tension. The un-declared auto-fallback is dropped from the plan.
+5. LD2410/ICS-43434 already handled; TCRT5000 is the expander case.
+
+## 8. Open questions remaining for the implementer
+
+- Should a terminal-only card default to terminal with no locus directive, or still require `locus:remote`? (v1 recommends default-terminal; confirm it doesn't surprise anyone wanting an on-board variant.)
+- I2C/SPI remote terminal: include or omit the pull-ups/CS-strap that the on-board header adds?
+- `external_io`: revive (preferred) or deprecate?
+- Is the loose-part **auto** terminal (without a card, via a new `Net.peripheral_hint` field) worth a v3, or do cards + `extra_connectors` cover the real need? (speed-cal's piezo/switches could just be cards.)
+
+## 9. Process note
+
+Cold-reviewed via 3 severity-tier subagents (this session). Implementation is a SEPARATE session/turn. v1 (terminal-only cards) is the recommended first slice — small, blocker-free, mirrors the shipped ICS-43434 work.

--- a/src/kicad_mcp/utils/firmware/cards.py
+++ b/src/kicad_mcp/utils/firmware/cards.py
@@ -158,6 +158,7 @@ def validate_peripheral_card(card: dict[str, Any]) -> list[str]:
         errs.append(f"{where}: module must be a bool")
     _validate_aliases(card.get("aliases"), where, errs)
     _validate_alt_lib_ids(card.get("alt_lib_ids"), where, errs)
+    _validate_port_pins(card.get("port_pins"), where, errs)
     _validate_serves(card.get("serves"), where, errs)
     _validate_config(card.get("config"), where, errs)
     _validate_realize(card.get("realize"), where, errs)
@@ -186,6 +187,19 @@ def _validate_alt_lib_ids(alts: Any, where: str, errs: list[str]) -> None:
         return
     if not isinstance(alts, list) or not all(valid_lib_id(a) for a in alts):
         errs.append(f"{where}: alt_lib_ids must be a list of 'Library:Symbol' ids")
+
+
+def _validate_port_pins(pins: Any, where: str, errs: list[str]) -> None:
+    """``port_pins`` is optional (I/O expanders only); when present it must be a
+    non-empty list of non-empty pin-name strings — the GPA/GPB port pins that
+    board.yaml ``expander_terminals`` may tap. Integration tier checks they exist
+    on the real symbol; here we only pin the shape."""
+    if pins is None:
+        return
+    if not isinstance(pins, list) or not pins or not all(
+        isinstance(p, str) and p.strip() for p in pins
+    ):
+        errs.append(f"{where}: port_pins must be a non-empty list of pin-name strings")
 
 
 def _validate_serves(serves: Any, where: str, errs: list[str]) -> None:

--- a/src/kicad_mcp/utils/firmware/cards.py
+++ b/src/kicad_mcp/utils/firmware/cards.py
@@ -157,6 +157,7 @@ def validate_peripheral_card(card: dict[str, Any]) -> list[str]:
     if not isinstance(card["module"], bool):
         errs.append(f"{where}: module must be a bool")
     _validate_aliases(card.get("aliases"), where, errs)
+    _validate_alt_lib_ids(card.get("alt_lib_ids"), where, errs)
     _validate_serves(card.get("serves"), where, errs)
     _validate_config(card.get("config"), where, errs)
     _validate_realize(card.get("realize"), where, errs)
@@ -173,6 +174,18 @@ def _validate_aliases(aliases: Any, where: str, errs: list[str]) -> None:
         isinstance(a, str) and a.strip() for a in aliases
     ):
         errs.append(f"{where}: aliases must be a list of non-empty strings")
+
+
+def _validate_alt_lib_ids(alts: Any, where: str, errs: list[str]) -> None:
+    """``alt_lib_ids`` is optional; when present it must be a list of well-formed
+    ``Library:Symbol`` ids — older-KiCad names for the SAME symbol the card's
+    ``lib_id`` names on the newest version (resolve_symbol tries them in order).
+    Distinct from ``aliases`` (alternate firmware part-NAME spellings); each entry
+    here is a lib_id, so it is validated by the same ``valid_lib_id`` rule (Rule 3)."""
+    if alts is None:
+        return
+    if not isinstance(alts, list) or not all(valid_lib_id(a) for a in alts):
+        errs.append(f"{where}: alt_lib_ids must be a list of 'Library:Symbol' ids")
 
 
 def _validate_serves(serves: Any, where: str, errs: list[str]) -> None:

--- a/src/kicad_mcp/utils/firmware/cards.py
+++ b/src/kicad_mcp/utils/firmware/cards.py
@@ -43,6 +43,12 @@ _PROJECT_DIR = Path("firmware-devices")
 
 _BUSES = frozenset({"I2C", "SPI", "I2S", "UART", None})
 
+# Valid values for the optional ``realize`` field on a peripheral card.
+# ``terminal`` = the device is ALWAYS realized as a screw terminal (no chip
+# symbol is placed); the card IS the wire-out declaration and no board.yaml
+# ``locus: remote`` directive is needed.  Absence = default chip-down behavior.
+_REALIZE_VALUES = frozenset({"terminal"})
+
 # What a card may declare it ``serves`` — the bus a part can be RESOLVED onto.
 # Deliberately FINER than ``_BUSES``: a bus is directional at resolution time
 # (``Bus.type`` is ``I2S_IN`` / ``I2S_OUT``), so a mic card serves ``I2S_IN`` and
@@ -153,6 +159,7 @@ def validate_peripheral_card(card: dict[str, Any]) -> list[str]:
     _validate_aliases(card.get("aliases"), where, errs)
     _validate_serves(card.get("serves"), where, errs)
     _validate_config(card.get("config"), where, errs)
+    _validate_realize(card.get("realize"), where, errs)
     return errs
 
 
@@ -177,6 +184,19 @@ def _validate_serves(serves: Any, where: str, errs: list[str]) -> None:
     if serves not in _SERVES_BUS_TYPES:
         errs.append(
             f"{where}: serves {serves!r} not in {sorted(_SERVES_BUS_TYPES)}"
+        )
+
+
+def _validate_realize(realize: Any, where: str, errs: list[str]) -> None:
+    """``realize`` is optional; when present it declares how this peripheral is
+    always realized, overriding the default chip-down path.  Only ``"terminal"``
+    is a valid value (v1) — the device is ALWAYS a screw-terminal wire-out and
+    no board.yaml ``locus: remote`` directive is required."""
+    if realize is None:
+        return
+    if realize not in _REALIZE_VALUES:
+        errs.append(
+            f"{where}: realize {realize!r} not in {sorted(_REALIZE_VALUES)}"
         )
 
 
@@ -243,6 +263,23 @@ def recognized_part_names(
                 )
             out[raw] = canonical
     return out
+
+
+def terminal_card_types(
+    peripherals: dict[str, dict[str, Any]]
+) -> frozenset[str]:
+    """Return the set of canonical type keys whose cards declare ``realize:
+    terminal`` — devices that are ALWAYS realized as screw terminals (no
+    chip-down placement, no board.yaml ``locus: remote`` required).
+
+    Consumed by ``templates.py:_inject_terminal_loci`` to auto-assign a remote
+    placement before any template runs, so power_tree / device_config skip
+    their glue for these devices (same path as an explicitly-remote carded
+    peripheral)."""
+    return frozenset(
+        key for key, card in peripherals.items()
+        if card.get("realize") == "terminal"
+    )
 
 
 def part_serves_map(

--- a/src/kicad_mcp/utils/firmware/devices/peripherals/ics-43434.yaml
+++ b/src/kicad_mcp/utils/firmware/devices/peripherals/ics-43434.yaml
@@ -1,0 +1,21 @@
+# ICS-43434 I2S MEMS microphone (TDK InvenSense) — the IN-STOCK successor to the
+# EOL INMP441. Unlike INMP441 it has a real KiCad symbol (Sensor_Audio:ICS-43434),
+# so the i2s_mic template can actually PLACE it (not just resolve-and-refuse).
+# `serves: I2S_IN` lets the resolver bind it when firmware names it; the "ICS43434"
+# alias covers the un-hyphenated spelling (canonical key is ICS43434 either way).
+#
+# Pin names VERIFIED against the Sensor_Audio:ICS-43434 symbol and DIFFER from
+# SPH0645: bit clock = SCK (not BCLK), data out = SD (not DATA), L/R select = LR
+# (not SEL). The realization is mirrored in knowledge.py K.ICS43434 (which the
+# i2s_mic template actually consumes) — keep the two in sync.
+type: ICS-43434
+aliases: ["ICS43434"]
+lib_id: Sensor_Audio:ICS-43434
+value: ICS-43434
+bus: I2S
+serves: I2S_IN
+footprint: Sensor_Audio:InvenSense_ICS-43434-6_3.5x2.65mm
+roles: {WS: WS, BCLK: SCK, DATA: SD, SEL: LR}
+supply_pins: ["VDD"]
+ground_pins: ["GND"]
+module: false

--- a/src/kicad_mcp/utils/firmware/devices/peripherals/mcp23017.yaml
+++ b/src/kicad_mcp/utils/firmware/devices/peripherals/mcp23017.yaml
@@ -10,6 +10,12 @@ value: MCP23017
 bus: I2C
 footprint: Package_SO:SOIC-28W_7.5x17.9mm_P1.27mm
 roles: {SDA: SDA, SCL: SCK, INT: INTA, INTA: INTA}
+# The 16 GPA/GPB I/O port pins in MCP23017 hardware register order (GPA0..7 then
+# GPB0..7). Source of truth for expander_terminals validation (data-only, so the
+# sidecar validator needs no KiCad at unit-test time). Identical names on KiCad
+# 9 and 10 (only the supply pins differ across versions — see above).
+port_pins: [GPA0, GPA1, GPA2, GPA3, GPA4, GPA5, GPA6, GPA7,
+            GPB0, GPB1, GPB2, GPB3, GPB4, GPB5, GPB6, GPB7]
 # Supply/ground by PAD NUMBER (9, 10), not name: KiCad 9 names them VDD/VSS but
 # KiCad 10 names them V_{DD}/V_{SS} — pad numbers are identical on both, so they
 # resolve version-independently. (These two pins are the symbol's ONLY other

--- a/src/kicad_mcp/utils/firmware/devices/peripherals/mcp23017.yaml
+++ b/src/kicad_mcp/utils/firmware/devices/peripherals/mcp23017.yaml
@@ -1,13 +1,21 @@
 # MCP23017 16-bit I2C GPIO expander (chip-down SOIC).
 # NB: the I2C clock pin is named "SCK" on this symbol, not "SCL".
 type: MCP23017
+# KiCad 10 renamed this symbol family: MCP23017_SO (KiCad 9) -> MCP23017x-x-SO
+# (KiCad 10). Primary = the newest name; alt_lib_ids carries the KiCad-9 name so
+# the card builds on both (resolve_symbol uses whichever the library has).
 lib_id: Interface_Expansion:MCP23017x-x-SO
+alt_lib_ids: ["Interface_Expansion:MCP23017_SO"]
 value: MCP23017
 bus: I2C
 footprint: Package_SO:SOIC-28W_7.5x17.9mm_P1.27mm
 roles: {SDA: SDA, SCL: SCK, INT: INTA, INTA: INTA}
-supply_pins: ["V_{DD}"]
-ground_pins: ["V_{SS}"]
+# Supply/ground by PAD NUMBER (9, 10), not name: KiCad 9 names them VDD/VSS but
+# KiCad 10 names them V_{DD}/V_{SS} — pad numbers are identical on both, so they
+# resolve version-independently. (These two pins are the symbol's ONLY other
+# cross-version difference; every signal/strap/INT pin name matches.)
+supply_pins: ["9"]
+ground_pins: ["10"]
 module: false
 config:
   # A2 A1 A0 select 0x20..0x27 (LSB-first); RESET held high (active-low).

--- a/src/kicad_mcp/utils/firmware/devices/peripherals/piezo.yaml
+++ b/src/kicad_mcp/utils/firmware/devices/peripherals/piezo.yaml
@@ -1,0 +1,28 @@
+# Piezo transducer / buzzer wired from a single ADC or GPIO.
+# Terminal-only: no chip-down symbol; the device connects via flying leads to a
+# screw terminal on the main board.  `realize: terminal` means the card itself IS
+# the declaration that this part is always a wire-out — no board.yaml
+# `locus: remote` directive required.
+#
+# Firmware hint: `PIEZO_ADC_PIN 34` -> peripheral_hint="PIEZO", role="ADC".
+# One signal pin in the terminal (the GPIO/ADC line), plus +3V3 and GND taps.
+#
+# lib_id / footprint are placeholder BOM entries only — this peripheral is never
+# placed as a schematic symbol (always excluded via locus=remote).  The actual
+# screw terminal is synthesized at expand_intent time by the remote_peripherals
+# template via synthesize_connector.
+# `PIEZO` matches PIEZO_*_PIN (speed-cal); `BUZZER` matches BUZZER_PIN
+# (track-geometry's LEDC buzzer — intentionally treated as an off-board wire-out).
+# Aliases are hint-stems; PIEZO_*_PIN already yields hint "PIEZO" so no PIEZO_*
+# alias is needed.
+type: PIEZO
+aliases: ["BUZZER"]
+lib_id: Connector_Generic:Conn_01x01
+value: Piezo (terminal)
+bus: null
+footprint: Connector_PinHeader_2.54mm:PinHeader_1x01_P2.54mm_Vertical
+roles: {ADC: "1", SIGNAL: "1", OUT: "1", PIN: "1"}
+supply_pins: []
+ground_pins: []
+module: false
+realize: terminal

--- a/src/kicad_mcp/utils/firmware/devices/peripherals/sph0645.yaml
+++ b/src/kicad_mcp/utils/firmware/devices/peripherals/sph0645.yaml
@@ -1,9 +1,11 @@
 # SPH0645LM4H I2S MEMS microphone. Formalizes the knowledge.py SPH0645 constant.
 # `serves: I2S_IN` lets the resolver bind it when the firmware names it; the
-# `SPH0645LM4H` alias covers the full datasheet spelling. (The audio-node mic is
-# actually an INMP441 — once that symbol exists and is named, the resolver binds
-# INMP441 instead; until then an INMP441 mention resolves to a part_unavailable
-# gap rather than silently substituting this part.)
+# `SPH0645LM4H` alias covers the full datasheet spelling. SPH0645 is also the
+# default mic the i2s_mic template assumes for an I2S-input bus that names no part.
+# (For the EOL INMP441, the in-stock successor ICS-43434 — see ics-43434.yaml, which
+# has its own KiCad symbol + K.ICS43434 realization — is the buildable replacement.
+# A bare INMP441 mention still resolves to a part_unavailable gap rather than
+# silently substituting any other mic.)
 type: SPH0645
 aliases: ["SPH0645LM4H"]
 lib_id: Sensor_Audio:SPH0645LM4H

--- a/src/kicad_mcp/utils/firmware/devices/peripherals/switch.yaml
+++ b/src/kicad_mcp/utils/firmware/devices/peripherals/switch.yaml
@@ -1,0 +1,23 @@
+# Generic GPIO switch / digital input (track switch, reed switch, limit switch,
+# push button, etc.).  Terminal-only: no chip-down symbol; the switch connects
+# via flying leads to a screw terminal on the main board.  `realize: terminal`
+# means the card itself IS the declaration that this part is always a wire-out.
+#
+# Aliases are HINT-STEMS (the macro prefix before the role), NOT full macro names:
+# `SWITCH_PIN`->"SWITCH", `TRACK_SW1_PIN`->"TRACK", `LIMIT_HOME_PIN`->"LIMIT".
+# `TRACK` is the mr-esp32 speed-cal stem (TRACK_SW1/SW2 polarity switches) and
+# is safe — no other board defines a TRACK_*_PIN. (Avoid 2-letter stems like
+# "SW": too generic.) For an unlisted project stem, add a project-local card.
+#
+# lib_id / footprint are placeholder BOM entries only — never placed as a symbol.
+type: SWITCH
+aliases: ["TRACK", "LIMIT", "REED"]
+lib_id: Connector_Generic:Conn_01x01
+value: Switch (terminal)
+bus: null
+footprint: Connector_PinHeader_2.54mm:PinHeader_1x01_P2.54mm_Vertical
+roles: {SW: "1", PIN: "1", SIGNAL: "1", STATE: "1"}
+supply_pins: []
+ground_pins: []
+module: false
+realize: terminal

--- a/src/kicad_mcp/utils/firmware/devices/peripherals/tcrt5000.yaml
+++ b/src/kicad_mcp/utils/firmware/devices/peripherals/tcrt5000.yaml
@@ -1,0 +1,22 @@
+# TCRT5000 reflective optical sensor (single discrete, MCU-side GPIO).
+# This card is for the SINGLE-SENSOR case where firmware names one GPIO directly
+# (`TCRT5000_DOUT_PIN 5` -> peripheral_hint="TCRT5000", role="DOUT").
+#
+# NOT for the 16×TCRT5000 array wired through a MCP23017 expander — that case has
+# no MCU-side GPIO signals at all, so it can't be handled by any firmware-visible
+# card; it requires explicit board.yaml `expander_terminals:` (v2 scope).
+#
+# Terminal-only: no chip-down symbol (the TCRT5000 is a through-hole sensor
+# on flying leads).  `realize: terminal` means the card IS the wire-out declaration.
+#
+# lib_id / footprint are placeholder BOM entries only — never placed as a symbol.
+type: TCRT5000
+lib_id: Connector_Generic:Conn_01x01
+value: TCRT5000 (terminal)
+bus: null
+footprint: Connector_PinHeader_2.54mm:PinHeader_1x01_P2.54mm_Vertical
+roles: {DOUT: "1", OUT: "1", SIGNAL: "1", ADC: "1"}
+supply_pins: ["1"]
+ground_pins: []
+module: false
+realize: terminal

--- a/src/kicad_mcp/utils/firmware/generate.py
+++ b/src/kicad_mcp/utils/firmware/generate.py
@@ -8,10 +8,10 @@ their MCU pin labeled — the far end is left open, matching the intent's gap.
 """
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 from kicad_mcp.utils.firmware.intent import DesignIntent, is_remote
-from kicad_mcp.utils.firmware.knowledge import role_to_pin_name
+from kicad_mcp.utils.firmware.knowledge import is_terminal_card_type, role_to_pin_name
 from kicad_mcp.utils.firmware.mcu_pinmap import (
     gpio_to_pin_number,
     resolve_pin_token,
@@ -43,16 +43,23 @@ def generate_schematic(intent: DesignIntent, schematic_path: str) -> dict[str, A
     sch = ksa.create_schematic("firmware_gen")
 
     # --- place components (MCU first, then peripherals) ---
-    to_place: list[tuple[str, Optional[str], str, Optional[str]]] = [
+    to_place: list[tuple[str, str | None, str, str | None]] = [
         (intent.mcu.ref, intent.mcu.lib_id, intent.mcu.part, intent.mcu.footprint)
     ]
-    # Remote peripherals are field-wired (a terminal carries their nets), so they
-    # are documented in the BOM but never placed as a symbol — their original pin
-    # endpoints then drop out of the wiring loop (ref not in ``placed``), leaving
-    # only the synthesized terminal wired. (See remote_peripherals template.)
+    # Off-board peripherals are field-wired (a terminal carries their nets), so
+    # they are documented in the BOM but never placed as a symbol — their original
+    # pin endpoints then drop out of the wiring loop (ref not in ``placed``),
+    # leaving only the synthesized terminal wired (see remote_peripherals). A
+    # peripheral is off-board if it's declared remote OR its card is
+    # ``realize: terminal`` — the latter is intrinsically remote even on a raw
+    # (non-expanded) intent, before _inject_terminal_loci has run.
+    offboard_refs = {
+        p.ref for p in intent.peripherals
+        if is_remote(intent, p.ref) or is_terminal_card_type(p.type)
+    }
     to_place += [
         (p.ref, p.lib_id, p.value or p.type, p.footprint)
-        for p in intent.peripherals if not is_remote(intent, p.ref)
+        for p in intent.peripherals if p.ref not in offboard_refs
     ]
 
     placed: dict[str, Any] = {}
@@ -117,6 +124,11 @@ def generate_schematic(intent: DesignIntent, schematic_path: str) -> dict[str, A
     for net in intent.nets:
         for ep in net.endpoints:
             if ep.ref not in placed:
+                # Off-board peripherals are intentionally excluded from placement
+                # (a terminal connector handles their signals); their original
+                # endpoints are not wired and must not be flagged as unresolved.
+                if ep.ref in offboard_refs:
+                    continue
                 unresolved.append({"net": net.name, "ref": ep.ref,
                                    "reason": "component not placed"})
                 continue

--- a/src/kicad_mcp/utils/firmware/generate.py
+++ b/src/kicad_mcp/utils/firmware/generate.py
@@ -11,7 +11,11 @@ from __future__ import annotations
 from typing import Any
 
 from kicad_mcp.utils.firmware.intent import DesignIntent, is_remote
-from kicad_mcp.utils.firmware.knowledge import is_terminal_card_type, role_to_pin_name
+from kicad_mcp.utils.firmware.knowledge import (
+    is_terminal_card_type,
+    resolve_symbol,
+    role_to_pin_name,
+)
 from kicad_mcp.utils.firmware.mcu_pinmap import (
     gpio_to_pin_number,
     resolve_pin_token,
@@ -58,8 +62,10 @@ def generate_schematic(intent: DesignIntent, schematic_path: str) -> dict[str, A
     sch = ksa.create_schematic("firmware_gen")
 
     # --- place components (MCU first, then peripherals) ---
-    to_place: list[tuple[str, str | None, str, str | None]] = [
-        (intent.mcu.ref, intent.mcu.lib_id, intent.mcu.part, intent.mcu.footprint)
+    # Tuple: (ref, lib_id, alt_lib_ids, value, footprint). alt_lib_ids carries
+    # older-KiCad names for a renamed symbol; the MCU never needs them ([]).
+    to_place: list[tuple[str, str | None, list[str], str, str | None]] = [
+        (intent.mcu.ref, intent.mcu.lib_id, [], intent.mcu.part, intent.mcu.footprint)
     ]
     # Off-board peripherals are field-wired (a terminal carries their nets), so
     # they are documented in the BOM but never placed as a symbol — their original
@@ -73,25 +79,29 @@ def generate_schematic(intent: DesignIntent, schematic_path: str) -> dict[str, A
         if is_remote(intent, p.ref) or is_terminal_card_type(p.type)
     }
     to_place += [
-        (p.ref, p.lib_id, p.value or p.type, p.footprint)
+        (p.ref, p.lib_id, list(p.alt_lib_ids), p.value or p.type, p.footprint)
         for p in intent.peripherals if p.ref not in offboard_refs
     ]
 
     placed: dict[str, Any] = {}
     symbols: dict[str, Any] = {}
     component_errors: list[dict[str, Any]] = []
-    for i, (ref, lib_id, value, footprint) in enumerate(to_place):
+    for i, (ref, lib_id, alts, value, footprint) in enumerate(to_place):
         if not lib_id:
             component_errors.append({"ref": ref, "error": "no lib_id in intent"})
             continue
-        sym = cache.get_symbol(lib_id)
+        # Try the primary lib_id then any cross-version alternates; use whichever
+        # name actually exists in the running library for the placement.
+        resolved_lib_id, sym = resolve_symbol(cache, lib_id, alts)
         if sym is None:
-            component_errors.append({"ref": ref, "error": f"symbol {lib_id!r} not found"})
+            tried = ", ".join(repr(c) for c in (lib_id, *alts))
+            component_errors.append({"ref": ref, "error": f"no symbol found (tried {tried})"})
             continue
+        assert resolved_lib_id is not None  # sym present => a candidate resolved
         col, row = i % _COLS, i // _COLS
         pos = (25.4 + col * _PITCH_MM, 25.4 + row * _PITCH_MM)
         try:
-            comp = sch.components.add(lib_id=lib_id, reference=ref, value=value,
+            comp = sch.components.add(lib_id=resolved_lib_id, reference=ref, value=value,
                                       position=pos, footprint=footprint)
         except Exception as e:  # noqa: BLE001 - record + continue, don't abort the build
             component_errors.append({"ref": ref, "error": f"add failed: {e}"})

--- a/src/kicad_mcp/utils/firmware/generate.py
+++ b/src/kicad_mcp/utils/firmware/generate.py
@@ -20,6 +20,21 @@ from kicad_mcp.utils.firmware.mcu_pinmap import (
 _PITCH_MM = 63.5
 _COLS = 4
 
+
+def _build_status(component_errors: list, unresolved: list, any_placed: bool) -> str:
+    """Three-state status for a (partial) schematic build.
+
+    ``ok`` only when nothing was dropped and every endpoint that should have
+    wired did. A dropped component or an unresolved endpoint means the saved
+    schematic is incomplete: ``partial`` if at least something was placed,
+    ``error`` if nothing was. Mirrors pcb_nets' ok/partial/error so callers see
+    one consistent contract — and so a version-renamed/typo'd lib_id surfaces
+    instead of silently reporting ``ok`` on a board missing a chip.
+    """
+    if not component_errors and not unresolved:
+        return "ok"
+    return "partial" if any_placed else "error"
+
 # Power-rail name -> KiCad power symbol lib_id (verified to resolve).
 _RAIL_LIB = {
     "+3V3": "power:+3V3", "+5V": "power:+5V",
@@ -175,7 +190,7 @@ def generate_schematic(intent: DesignIntent, schematic_path: str) -> dict[str, A
 
     sch.save(schematic_path)
     return {
-        "status": "ok",
+        "status": _build_status(component_errors, unresolved, bool(placed)),
         "schematic_path": schematic_path,
         "components_placed": len(placed),
         "component_errors": component_errors,

--- a/src/kicad_mcp/utils/firmware/intent.py
+++ b/src/kicad_mcp/utils/firmware/intent.py
@@ -26,7 +26,7 @@ from kicad_mcp.utils.firmware.parse import (
     address_base,
 )
 
-SCHEMA_VERSION = 6  # v6: Bus part resolution (resolved_part/part_provenance/part_is_assumption)
+SCHEMA_VERSION = 7  # v7: Peripheral.alt_lib_ids (cross-version symbol names)
 
 # Gap categories firmware is structurally blind to — always emitted so the doc
 # is honest about what a human/LLM must still supply.
@@ -63,6 +63,11 @@ class Peripheral:
     ref: str
     type: str
     lib_id: Optional[str] = None
+    # Older-KiCad names for the same symbol (KiCad 10 renamed MCP23017_SO ->
+    # MCP23017x-x-SO); the generator tries these in order when lib_id is absent
+    # from the running library. Carried on the intent (not baked at build time)
+    # so resolution happens against the live library at generate time.
+    alt_lib_ids: list[str] = field(default_factory=list)
     value: Optional[str] = None
     footprint: Optional[str] = None
     bus: Optional[str] = None
@@ -311,8 +316,10 @@ def build_intent(
             continue
         placed_module = placed_module or info["module"]
         p = Peripheral(
-            ref=f"U{next_ref}", type=t, lib_id=info["lib_id"], value=info["value"],
-            footprint=info["footprint"], bus=info["bus"], address=address,
+            ref=f"U{next_ref}", type=t, lib_id=info["lib_id"],
+            alt_lib_ids=list(info.get("alt_lib_ids", []) or []),
+            value=info["value"], footprint=info["footprint"], bus=info["bus"],
+            address=address,
         )
         next_ref += 1
         peripherals.append(p)

--- a/src/kicad_mcp/utils/firmware/intent.py
+++ b/src/kicad_mcp/utils/firmware/intent.py
@@ -26,7 +26,7 @@ from kicad_mcp.utils.firmware.parse import (
     address_base,
 )
 
-SCHEMA_VERSION = 7  # v7: Peripheral.alt_lib_ids (cross-version symbol names)
+SCHEMA_VERSION = 8  # v8: DesignIntent.expander_terminals (GPA/GPB -> labeled terminals)
 
 # Gap categories firmware is structurally blind to — always emitted so the doc
 # is honest about what a human/LLM must still supply.
@@ -109,6 +109,23 @@ class Placement:
 
 
 @dataclass
+class ExpanderSpec:
+    """A board.yaml ``expander_terminals`` entry (keyed by expander peripheral ref
+    in ``DesignIntent.expander_terminals``): tap an I/O-expander's floating GPA/GPB
+    port pins out to labeled screw terminal(s).
+
+    Honest-by-construction — firmware can't know this (the sensors are
+    register-addressed at runtime, no per-sensor #define), so it must be declared.
+    The ``ports: int`` board.yaml shorthand is expanded to a concrete pin-name list
+    at sidecar-apply time, so templates only ever see resolved pin names."""
+    device: str                        # silk label + connector value (e.g. TCRT5000)
+    ports: list[str] = field(default_factory=list)   # resolved pin names: [GPA0, GPA1, ...]
+    group: str = "per_sensor"          # per_sensor | per_bank | single
+    power: str = "3v3"                 # 3v3 | 5v | none
+    net_prefix: str = ""               # net base name; filled from device at apply if empty
+
+
+@dataclass
 class Mcu:
     ref: str
     part: str
@@ -161,6 +178,10 @@ class DesignIntent:
     # PCB-layer concern, distinct from `placements` (the firmware-semantic locus
     # channel).  Validated by edge_terminal.normalize_hint before use.
     placement_hints: dict[str, dict[str, Any]] = field(default_factory=dict)
+    # board.yaml expander_terminals: tap an I/O-expander's GPA/GPB port pins out to
+    # labeled terminals. Keyed by the expander's peripheral ref. Set by
+    # apply_sidecar, consumed by the expander_terminals template.
+    expander_terminals: dict[str, "ExpanderSpec"] = field(default_factory=dict)
     provenance: dict[str, Any] = field(default_factory=dict)
 
 
@@ -488,6 +509,10 @@ def from_dict(d: dict[str, Any]) -> DesignIntent:
             for k, v in (d.get("placements", {}) or {}).items()
         },
         placement_hints=d.get("placement_hints", {}) or {},
+        expander_terminals={
+            k: ExpanderSpec(**_only_fields(ExpanderSpec, v))
+            for k, v in (d.get("expander_terminals", {}) or {}).items()
+        },
         provenance=d.get("provenance", {}),
     )
 

--- a/src/kicad_mcp/utils/firmware/knowledge.py
+++ b/src/kicad_mcp/utils/firmware/knowledge.py
@@ -20,15 +20,20 @@ explicit gap rather than guessing.
 """
 from __future__ import annotations
 
-from typing import Any, Optional, TypedDict, cast
+from typing import Any, TypedDict, cast
 
-from kicad_mcp.utils.firmware.cards import compute_address_straps, load_cards
+from kicad_mcp.utils.firmware.cards import (
+    compute_address_straps,
+    load_cards,
+    recognized_part_names,
+)
 from kicad_mcp.utils.firmware.parse import canonical_type, idf_target_defines
 
 __all__ = [
     "McuInfo", "PeripheralInfo", "resolve_mcu", "resolve_mcu_by_part",
     "resolve_peripheral", "role_to_pin_name", "compute_address_straps",
     "mcp23017_address_straps", "mpu6050_ad0_strap",
+    "is_terminal_card_type",
 ]
 
 
@@ -52,7 +57,7 @@ class McuInfo(TypedDict):
 class _PeripheralInfoBase(TypedDict):
     lib_id: str
     value: str
-    bus: Optional[str]
+    bus: str | None
     footprint: str
     # firmware signal-role (upper-cased) -> symbol pin NAME or NUMBER
     roles: dict[str, str]
@@ -66,11 +71,12 @@ class _PeripheralInfoBase(TypedDict):
 class PeripheralInfo(_PeripheralInfoBase, total=False):
     config: dict[str, Any]            # address_strap + static_ties (device_config)
     decoupling: list[dict[str, Any]]  # optional per-IC bypass override
+    realize: str                      # "terminal" = always a screw-terminal wire-out
 
 
 # --- card cache (loaded once from the packaged + override dirs) ---------------
 
-_CACHE: Optional[tuple[dict[str, dict[str, Any]], list[dict[str, Any]]]] = None
+_CACHE: tuple[dict[str, dict[str, Any]], list[dict[str, Any]]] | None = None
 
 
 def _cards() -> tuple[dict[str, dict[str, Any]], list[dict[str, Any]]]:
@@ -167,7 +173,7 @@ MCP23017_RESET_PIN = "~{RESET}"
 MPU6050_AD0_PIN = "5"
 
 
-def mcp23017_address_straps(address: int) -> Optional[list[tuple[str, str]]]:
+def mcp23017_address_straps(address: int) -> list[tuple[str, str]] | None:
     """[(addr_pin, rail)] for an MCP23017 I2C address (0x20..0x27), else None.
     Thin wrapper over the MCP23017 card's address-strap spec."""
     info = resolve_peripheral("MCP23017")
@@ -176,7 +182,7 @@ def mcp23017_address_straps(address: int) -> Optional[list[tuple[str, str]]]:
     return compute_address_straps(info["config"]["address_strap"], address)
 
 
-def mpu6050_ad0_strap(address: int) -> Optional[tuple[str, str]]:
+def mpu6050_ad0_strap(address: int) -> tuple[str, str] | None:
     """(ad0_pin, rail) for an MPU-6050 I2C address (0x68/0x69), else None. Thin
     wrapper over the MPU6050 card; unpacks the single-bit list back to a tuple."""
     info = resolve_peripheral("MPU6050")
@@ -188,7 +194,7 @@ def mpu6050_ad0_strap(address: int) -> Optional[tuple[str, str]]:
 
 # --- resolution --------------------------------------------------------------
 
-def resolve_mcu(board_id: Optional[str]) -> Optional[McuInfo]:
+def resolve_mcu(board_id: str | None) -> McuInfo | None:
     """Map a platformio ``board =`` id to an MCU card. Exact ``board_match`` /
     ``part`` first, then the card with the LONGEST ``board_match`` substring in
     the id (deterministic; no hand-ordered precedence — removes the Rule-3 seam
@@ -197,7 +203,7 @@ def resolve_mcu(board_id: Optional[str]) -> Optional[McuInfo]:
         return None
     key = board_id.strip().lower()
     _, mcus = _cards()
-    best: Optional[dict[str, Any]] = None
+    best: dict[str, Any] | None = None
     best_len = -1
     for card in mcus:
         matches = [str(s).lower() for s in card["board_match"]] + [str(card["part"]).lower()]
@@ -222,7 +228,7 @@ def resolve_mcu(board_id: Optional[str]) -> Optional[McuInfo]:
     return cast(McuInfo, best)
 
 
-def resolve_mcu_by_part(part: Optional[str]) -> Optional[McuInfo]:
+def resolve_mcu_by_part(part: str | None) -> McuInfo | None:
     """Look up MCU facts by part string (templates have ``intent.mcu.part``)."""
     if not part:
         return None
@@ -233,17 +239,37 @@ def resolve_mcu_by_part(part: Optional[str]) -> Optional[McuInfo]:
     return None
 
 
-def resolve_peripheral(type_name: Optional[str]) -> Optional[PeripheralInfo]:
-    """Map a peripheral type (e.g. ``MCP23017``, derived from ``MCP23017_ADDR``
-    or a pin macro's name prefix) to its card."""
+def resolve_peripheral(type_name: str | None) -> PeripheralInfo | None:
+    """Map a peripheral type/hint (e.g. ``MCP23017`` from ``MCP23017_ADDR``, or a
+    pin-macro prefix like ``PIEZO``/``TRACK``) to its card. The name may be the
+    card's canonical ``type`` OR one of its ``aliases`` (e.g. hint ``TRACK`` ->
+    SWITCH card, ``BUZZER`` -> PIEZO) — alias resolution uses the same raw->canonical
+    registry as the free-text part extractor, so the hint path and the comment-scan
+    path can never disagree on what a name resolves to."""
     if not type_name:
         return None
     peris, _ = _cards()
-    card = peris.get(canonical_type(type_name))
+    canon = canonical_type(type_name)
+    card = peris.get(canon)
+    if card is None:
+        alias_to_canon = {
+            canonical_type(raw): ckey
+            for raw, ckey in recognized_part_names(peris).items()
+        }
+        ckey = alias_to_canon.get(canon)
+        card = peris.get(ckey) if ckey else None
     return cast(PeripheralInfo, card) if card is not None else None
 
 
-def role_to_pin_name(type_name: str, role: Optional[str]) -> Optional[str]:
+def is_terminal_card_type(type_name: str | None) -> bool:
+    """True if the peripheral card for ``type_name`` (canonical type OR alias)
+    declares ``realize: terminal`` — meaning it is ALWAYS a screw-terminal
+    wire-out and no board.yaml ``locus: remote`` directive is required."""
+    info = resolve_peripheral(type_name)
+    return info is not None and info.get("realize") == "terminal"
+
+
+def role_to_pin_name(type_name: str, role: str | None) -> str | None:
     """Translate a firmware signal-role to the device symbol's pin NAME/NUMBER,
     or None if unknown (caller flags it)."""
     info = resolve_peripheral(type_name)

--- a/src/kicad_mcp/utils/firmware/knowledge.py
+++ b/src/kicad_mcp/utils/firmware/knowledge.py
@@ -20,6 +20,7 @@ explicit gap rather than guessing.
 """
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Any, TypedDict, cast
 
 from kicad_mcp.utils.firmware.cards import (
@@ -72,6 +73,12 @@ class PeripheralInfo(_PeripheralInfoBase, total=False):
     config: dict[str, Any]            # address_strap + static_ties (device_config)
     decoupling: list[dict[str, Any]]  # optional per-IC bypass override
     realize: str                      # "terminal" = always a screw-terminal wire-out
+    # Older-KiCad names for the SAME symbol, tried in order when ``lib_id`` (the
+    # newest name) is absent from the running library. KiCad 10 renamed whole
+    # symbol families (MCP23017_SO -> MCP23017x-x-SO); listing the prior name here
+    # lets one card build on both versions. Resolved against the live library, so
+    # no KiCad-version detection is needed (see resolve_symbol).
+    alt_lib_ids: list[str]
 
 
 # --- card cache (loaded once from the packaged + override dirs) ---------------
@@ -259,6 +266,31 @@ def resolve_peripheral(type_name: str | None) -> PeripheralInfo | None:
         ckey = alias_to_canon.get(canon)
         card = peris.get(ckey) if ckey else None
     return cast(PeripheralInfo, card) if card is not None else None
+
+
+def resolve_symbol(
+    cache: Any, lib_id: str | None, alt_lib_ids: Iterable[str] = (),
+) -> tuple[str | None, Any]:
+    """Resolve a component to a real KiCad symbol, trying the primary ``lib_id``
+    then any cross-version alternates in order; return ``(resolved_lib_id, sym)``
+    or ``(None, None)``.
+
+    The alternates let a card name a symbol KiCad RENAMED across versions
+    (``MCP23017_SO`` in KiCad 9 -> ``MCP23017x-x-SO`` in KiCad 10): the first
+    candidate that actually exists in the running library wins. Resolving against
+    the live library — not a version string — means no KiCad-version detection is
+    needed and a future rename only adds a name to the card.
+
+    Single source of truth for cross-version symbol resolution (CLAUDE.md Rule 3):
+    consumed by the generator (placement) and the card integration validator (pin
+    existence), so neither re-encodes the candidate rule.
+    """
+    for candidate in (lib_id, *alt_lib_ids):
+        if candidate:
+            sym = cache.get_symbol(candidate)
+            if sym is not None:
+                return candidate, sym
+    return None, None
 
 
 def is_terminal_card_type(type_name: str | None) -> bool:

--- a/src/kicad_mcp/utils/firmware/knowledge.py
+++ b/src/kicad_mcp/utils/firmware/knowledge.py
@@ -79,6 +79,10 @@ class PeripheralInfo(_PeripheralInfoBase, total=False):
     # lets one card build on both versions. Resolved against the live library, so
     # no KiCad-version detection is needed (see resolve_symbol).
     alt_lib_ids: list[str]
+    # For I/O expanders: the GPA/GPB port pins in hardware register order — the
+    # data-only validation source for board.yaml expander_terminals (no KiCad at
+    # unit-test time). See ExpanderSpec / _validate_expander_terminals.
+    port_pins: list[str]
 
 
 # --- card cache (loaded once from the packaged + override dirs) ---------------

--- a/src/kicad_mcp/utils/firmware/knowledge.py
+++ b/src/kicad_mcp/utils/firmware/knowledge.py
@@ -104,6 +104,17 @@ SPH0645 = {
     "ws": "WS", "bclk": "BCLK", "data": "DATA", "sel": "SEL",
     "vdd": "VDD", "gnd": "GND",
 }
+# ICS-43434 (TDK InvenSense) — in-stock I2S MEMS mic, the successor to the EOL
+# INMP441. Pin names VERIFIED against the KiCad Sensor_Audio:ICS-43434 symbol and
+# DIFFER from SPH0645 on three pins: bit clock is "SCK" (not BCLK), data is "SD"
+# (not DATA), L/R-select is "LR" (not SEL). Keep in sync with the resolution card
+# devices/peripherals/ics-43434.yaml.
+ICS43434 = {
+    "lib_id": "Sensor_Audio:ICS-43434", "value": "ICS-43434",
+    "footprint": "Sensor_Audio:InvenSense_ICS-43434-6_3.5x2.65mm",
+    "ws": "WS", "bclk": "SCK", "data": "SD", "sel": "LR",
+    "vdd": "VDD", "gnd": "GND",
+}
 # (Module headers — 1x02 speaker / 1x04 I2C+UART — are now synthesized via
 # connectors.synthesize_connector, which owns symbol+footprint selection.)
 

--- a/src/kicad_mcp/utils/firmware/sidecar.py
+++ b/src/kicad_mcp/utils/firmware/sidecar.py
@@ -41,6 +41,7 @@ expander_terminals:            # tap an I/O-expander's GPA/GPB pins out to termi
     ports: 6                   # first N port pins (GPA0..7,GPB0..7), or a list [GPA0, GPB3]
     group: per_sensor          # per_sensor (default) | per_bank | single
     power: 3v3                 # 3v3 (default) | 5v | none
+    net_prefix: SENSOR         # net base name (default = device); unique across entries
 ```
 
 Unknown top-level keys are REJECTED (a typo like ``board_size`` for
@@ -346,6 +347,10 @@ def _validate_expander_terminals(d: dict[str, Any], errs: list[str]) -> None:
                 errs.append(f"{where}: ports list must be pin-name strings")
             elif valid_pins and (bad := [p for p in ports if p not in valid_pins]):
                 errs.append(f"{where}: unknown port pin(s) {bad} — valid: {valid_pins}")
+            elif len(set(ports)) != len(ports):
+                # each port maps to one terminal position; a repeat would short two
+                # positions onto one expander pad.
+                errs.append(f"{where}: ports has duplicate pin(s) {sorted(ports)}")
         else:
             errs.append(f"{where}: ports must be an int count or a list of pin names")
         grp = spec.get("group")

--- a/src/kicad_mcp/utils/firmware/sidecar.py
+++ b/src/kicad_mcp/utils/firmware/sidecar.py
@@ -35,6 +35,12 @@ mounting_holes:                # corner fixture holes (firmware-blind mechanical
   drill_mm: 3.2                # M3 = 3.2, M2.5 = 2.7
   inset_mm: 3.5                # hole-centre inset from each board edge
   keepout_mm: 1.5              # no-copper margin beyond the drill
+expander_terminals:            # tap an I/O-expander's GPA/GPB pins out to terminals
+  U3:                          # the expander's peripheral ref (a placed MCP23017)
+    device: TCRT5000           # silk label + connector value
+    ports: 6                   # first N port pins (GPA0..7,GPB0..7), or a list [GPA0, GPB3]
+    group: per_sensor          # per_sensor (default) | per_bank | single
+    power: 3v3                 # 3v3 (default) | 5v | none
 ```
 
 Unknown top-level keys are REJECTED (a typo like ``board_size`` for
@@ -57,6 +63,7 @@ from kicad_mcp.utils.firmware.connectors import (
 )
 from kicad_mcp.utils.firmware.intent import (
     DesignIntent,
+    ExpanderSpec,
     Gap,
     Net,
     Placement,
@@ -118,6 +125,10 @@ class BoardSidecar:
     # (a tighter second pass). Size lever — only applies to auto-sized boards. See
     # SPEC_Post_Placement_Board_Refit.md.
     board_refit: Optional[bool] = None
+    # tap an I/O-expander's floating GPA/GPB port pins out to labeled terminals,
+    # keyed by the expander's peripheral ref (e.g. U3). Firmware-blind (sensors are
+    # register-addressed at runtime). See ExpanderSpec / SPEC_expander_terminals.md.
+    expander_terminals: dict[str, dict[str, Any]] = field(default_factory=dict)
 
 
 # Top-level board.yaml keys. An unknown key is a loud error (catches a typo like
@@ -128,9 +139,15 @@ _KNOWN_SIDECAR_KEYS = frozenset({
     "power_source", "board_size_mm", "extra_connectors",
     "placement", "placement_hints", "mounting_holes", "bus_part_overrides",
     "terminal_distribution", "terminal_centering", "board_refit",
+    "expander_terminals",
 })
 
 _TERMINAL_DISTRIBUTIONS = frozenset({"single_edge", "multi_edge"})
+
+# expander_terminals (v2): per-entry sub-keys + the closed value sets.
+_KNOWN_EXPANDER_KEYS = frozenset({"device", "ports", "group", "power", "net_prefix"})
+_EXPANDER_GROUPS = frozenset({"per_sensor", "per_bank", "single"})
+_EXPANDER_POWER = frozenset({"3v3", "5v", "none"})
 
 _KNOWN_BUS_OVERRIDE_KEYS = frozenset({"part", "footprint"})
 
@@ -268,7 +285,88 @@ def _validate(d: dict[str, Any]) -> list[str]:
     _validate_hints(d, errs)
     _validate_mounting_holes(d, errs)
     _validate_bus_part_overrides(d, errs)
+    _validate_expander_terminals(d, errs)
     return errs
+
+
+def _expander_port_pins() -> list[str]:
+    """The valid GPA/GPB port-pin names for v2.0 (MCP23017-only — non-goal: other
+    expanders). Data-only: reads the MCP23017 card's ``port_pins`` (no KiCad). The
+    board.yaml entry is keyed by ref and the chip type isn't known at load time, so
+    we validate against this canonical set; expand-time confirms the ref is a
+    placed MCP23017. When more expanders are supported this becomes per-type."""
+    from kicad_mcp.utils.firmware.knowledge import resolve_peripheral
+    info = resolve_peripheral("MCP23017")
+    return list(info.get("port_pins", [])) if info else []
+
+
+def _validate_expander_terminals(d: dict[str, Any], errs: list[str]) -> None:
+    """``expander_terminals`` is optional: a mapping of expander ref -> spec. Each
+    spec taps the expander's GPA/GPB pins out to terminals. Validated here (no
+    KiCad): known sub-keys, ports (int count <= available, or a list of real port
+    pins), group/power in their value sets, and net_prefix UNIQUE across entries
+    (so two devices can't fight over the same net namespace). Ref-existence (is it
+    a placed MCP23017?) is deferred to expand time, where placement happens."""
+    et = d.get("expander_terminals")
+    if et is None:
+        return
+    if not isinstance(et, dict):
+        errs.append("expander_terminals must be a mapping of expander-ref -> spec")
+        return
+    valid_pins = _expander_port_pins()
+    seen_prefix: dict[str, str] = {}   # effective net_prefix -> the ref that claimed it
+    for ref, spec in et.items():
+        where = f"expander_terminals[{ref!r}]"
+        if not _VALID_REF.match(str(ref)):
+            errs.append(f"{where}: {ref!r} is not a KiCad ref (e.g. U3)")
+        if not isinstance(spec, dict):
+            errs.append(f"{where}: must be a mapping")
+            continue
+        unknown = set(spec) - _KNOWN_EXPANDER_KEYS
+        if unknown:
+            errs.append(f"{where}: unknown key(s) {sorted(unknown)} — "
+                        f"valid: {sorted(_KNOWN_EXPANDER_KEYS)}")
+        dev = spec.get("device")
+        if dev is not None and not (isinstance(dev, str) and dev.strip()):
+            errs.append(f"{where}: device must be a non-empty string")
+        # ports: required — an int count, or an explicit list of port-pin names.
+        ports = spec.get("ports")
+        if ports is None:
+            errs.append(f"{where}: ports is required (an int count or a list of pin names)")
+        elif isinstance(ports, bool):
+            errs.append(f"{where}: ports must be an int count or a list of pin names")
+        elif isinstance(ports, int):
+            if ports < 0:
+                errs.append(f"{where}: ports {ports} must be >= 0")
+            elif valid_pins and ports > len(valid_pins):
+                errs.append(f"{where}: ports {ports} exceeds the {len(valid_pins)} "
+                            f"available expander port pins")
+        elif isinstance(ports, list):
+            if not all(isinstance(p, str) for p in ports):
+                errs.append(f"{where}: ports list must be pin-name strings")
+            elif valid_pins and (bad := [p for p in ports if p not in valid_pins]):
+                errs.append(f"{where}: unknown port pin(s) {bad} — valid: {valid_pins}")
+        else:
+            errs.append(f"{where}: ports must be an int count or a list of pin names")
+        grp = spec.get("group")
+        if grp is not None and grp not in _EXPANDER_GROUPS:
+            errs.append(f"{where}: group {grp!r} not in {sorted(_EXPANDER_GROUPS)}")
+        pwr = spec.get("power")
+        if pwr is not None and pwr not in _EXPANDER_POWER:
+            errs.append(f"{where}: power {pwr!r} not in {sorted(_EXPANDER_POWER)}")
+        np = spec.get("net_prefix")
+        if np is not None and not (isinstance(np, str) and np.strip()):
+            errs.append(f"{where}: net_prefix must be a non-empty string")
+        # Uniqueness is on the EFFECTIVE prefix (net_prefix else device) — two
+        # entries that both default to the same device would silently collide nets.
+        prefix = (np if isinstance(np, str) and np.strip()
+                  else dev if isinstance(dev, str) and dev.strip() else None)
+        if prefix is not None:
+            if prefix in seen_prefix:
+                errs.append(f"{where}: net_prefix {prefix!r} duplicates "
+                            f"{seen_prefix[prefix]} — must be unique across entries")
+            else:
+                seen_prefix[prefix] = where
 
 
 def _validate_bus_part_overrides(d: dict[str, Any], errs: list[str]) -> None:
@@ -324,6 +422,7 @@ def load_sidecar(path: str) -> BoardSidecar:
         terminal_distribution=data.get("terminal_distribution"),
         terminal_centering=data.get("terminal_centering"),
         board_refit=data.get("board_refit"),
+        expander_terminals=dict(data.get("expander_terminals", {}) or {}),
     )
 
 
@@ -431,6 +530,29 @@ def apply_sidecar(
             bus.resolved_part = str(spec["part"])
             bus.part_provenance = "user"
             bus.part_is_assumption = False
+
+    # Expander terminals: resolve the `ports:int` shorthand to concrete pin names
+    # (first N in MCP hardware order) HERE, so the template sees only pin names.
+    # net_prefix defaults to device (then ref); group/power take their defaults.
+    # Ref-existence + "is it an MCP23017" is checked at expand time (placement).
+    if sidecar.expander_terminals:
+        port_pins = _expander_port_pins()
+        for ref, spec in sidecar.expander_terminals.items():
+            device = str(spec.get("device") or "") or str(ref)
+            ports = spec.get("ports")
+            if isinstance(ports, int) and not isinstance(ports, bool):
+                pins = list(port_pins[:ports])
+            elif isinstance(ports, list):
+                pins = [str(p) for p in ports]
+            else:
+                pins = []
+            intent.expander_terminals[str(ref)] = ExpanderSpec(
+                device=device,
+                ports=pins,
+                group=str(spec.get("group") or "per_sensor"),
+                power=str(spec.get("power") or "3v3"),
+                net_prefix=str(spec.get("net_prefix") or device),
+            )
 
     return intent
 

--- a/src/kicad_mcp/utils/firmware/templates.py
+++ b/src/kicad_mcp/utils/firmware/templates.py
@@ -797,6 +797,14 @@ _SCREW_MAX = 16
 
 _RAIL_FOR_POWER = {"3v3": "+3V3", "5v": "+5V", "none": None}
 
+# The peripherals that SOURCE the +5V rail — power_tree's regulator and the USB
+# programming block (the only two sites that emit ("+5V", ...) onto ex.power).
+# Used to detect +5V availability: those templates run BEFORE expander_terminals
+# and have already been added to intent.peripherals, but the rail NETS aren't
+# merged until after the template loop, so checking intent.nets would always
+# (wrongly) see no +5V.
+_FIVE_V_SOURCES = frozenset({"AMS1117", "USB_C", "CP2102"})
+
 
 def _emit_expander_terminal(
     ex: Expansion, alloc: RefAllocator, expander_ref: str,
@@ -837,7 +845,7 @@ def expander_terminals(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
         return ex
     periph_by_ref = {p.ref: p for p in intent.peripherals}
     existing_net_names = {n.name for n in intent.nets}
-    rails_present = {n.name for n in intent.nets if n.kind == "power"}
+    has_5v = any(p.type in _FIVE_V_SOURCES for p in intent.peripherals)
 
     for ref, spec in intent.expander_terminals.items():
         p = periph_by_ref.get(ref)
@@ -855,9 +863,10 @@ def expander_terminals(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
             continue
 
         # Power rail tap is declared topology (not a sensor inference). 5v needs the
-        # +5V rail to exist (USB/regulator block ran) — else disclose + drop to none.
+        # +5V rail to exist (a regulator/USB block sources it) — else disclose +
+        # drop to none, so we never hang a sourceless +5V pin on the terminal.
         rail = _RAIL_FOR_POWER[spec.power]
-        if rail == "+5V" and "+5V" not in rails_present:
+        if rail == "+5V" and not has_5v:
             ex.gaps.append(Gap(
                 "expander_terminals_power",
                 f"expander_terminals[{ref!r}]: power: 5v but no +5V rail on this "

--- a/src/kicad_mcp/utils/firmware/templates.py
+++ b/src/kicad_mcp/utils/firmware/templates.py
@@ -502,16 +502,27 @@ def i2s_output_amps(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
     return ex
 
 
+# Buildable I2S-input mics, keyed by the canonical resolved-part string the bus
+# resolver produces (canonical_type: hyphen-stripped, upper — so "ICS-43434" → key
+# "ICS43434"). A firmware-named mic in this registry is placed as that exact part;
+# an EOL/unrecognized mic with no realization (e.g. INMP441 — no KiCad symbol) is
+# deliberately absent, so _decide_part refuses to substitute the default rather
+# than silently swapping parts.
+_MIC_REALIZATIONS = {"SPH0645": K.SPH0645, "ICS43434": K.ICS43434}
+_DEFAULT_MIC = "SPH0645"
+
+
 def i2s_mic(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
-    """Each I2S-input bus -> an SPH0645 MEMS mic (SEL→GND, VDD bypass), UNLESS the
-    bus is declared ``remote`` in board.yaml — then the mic is field-wired and the
-    bus crosses to a screw terminal instead of an on-board chip (no chip, no
-    bypass: the device's support glue lives at the device)."""
+    """Each I2S-input bus -> a MEMS mic (SEL/LR→GND, VDD bypass): the specific part
+    the firmware names when it's one we can realize (SPH0645 or ICS-43434), else the
+    SPH0645 default. A firmware-named mic with no realization (e.g. EOL INMP441) is
+    refused, not substituted. UNLESS the bus is declared ``remote`` in board.yaml —
+    then the mic is field-wired and the bus crosses to a screw terminal instead of an
+    on-board chip (no chip, no bypass: the device's support glue lives at the device)."""
     ex = Expansion()
     if intent.mcu is None:
         return ex
     mcu = intent.mcu.ref
-    S = K.SPH0645
     mic_idx = 0
     for bus in intent.buses:
         if bus.type != "I2S_IN":
@@ -532,11 +543,16 @@ def i2s_mic(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
         if pl is not None and pl.locus == "remote":
             _emit_remote_mic(ex, alloc, mcu, bclk_g, ws_g, sd_g, pl, prefix)
             continue
-        place, mic_origin = _decide_part(bus, "SPH0645", ex)
+        # Build the firmware-named mic if we can realize it; else fall back to the
+        # default part so _decide_part either assumes it (rp is None) or refuses it
+        # (rp names a different, unrealizable part — the INMP441 case).
+        build_part = bus.resolved_part if bus.resolved_part in _MIC_REALIZATIONS else _DEFAULT_MIC
+        S = _MIC_REALIZATIONS[build_part]
+        place, mic_origin = _decide_part(bus, build_part, ex)
         if not place:
             continue   # firmware declares a different mic we can't realize (gapped)
-        mic = Peripheral(ref=alloc.next("MK"), type="SPH0645", lib_id=S["lib_id"],
-                         value="SPH0645LM4H", footprint=S["footprint"], origin=mic_origin)
+        mic = Peripheral(ref=alloc.next("MK"), type=build_part, lib_id=S["lib_id"],
+                         value=S["value"], footprint=S["footprint"], origin=mic_origin)
         c = _cap(alloc, "100nF", K.FP_C_BYPASS)
         ex.components += [mic, c]
         ex.power += [("+3V3", Endpoint(ref=mic.ref, pin=S["vdd"])),

--- a/src/kicad_mcp/utils/firmware/templates.py
+++ b/src/kicad_mcp/utils/firmware/templates.py
@@ -40,6 +40,30 @@ from kicad_mcp.utils.firmware.intent import (
 from kicad_mcp.utils.firmware.power_names import RAILS as _RAILS
 
 
+def _inject_terminal_loci(intent: DesignIntent) -> None:
+    """For every carded peripheral whose card declares ``realize: terminal``,
+    inject a synthetic ``Placement(locus="remote")`` into ``intent.placements``
+    (if no explicit user directive already exists for that ref).  Also stamps
+    ``p.locus = "remote"`` on the ``Peripheral`` record.
+
+    This MUST run before any template that inspects ``is_remote`` / ``_peripheral_is_remote``
+    (i.e. before power_tree, device_config, etc.) so that glue suppression and
+    placement exclusion work correctly for terminal-only devices — they are
+    treated exactly like an explicitly-remote carded peripheral from this point.
+
+    The honesty contract: the card itself IS the explicit declaration that this
+    part is always a wire-out (G3 satisfied).  No board.yaml directive is
+    required (and no ``placement_unsupported`` gap is raised) because the locus
+    is injected here, not validated by _apply_placement."""
+    for p in intent.peripherals:
+        if p.ref in intent.placements:
+            continue   # user override takes precedence — honor it
+        if K.is_terminal_card_type(p.type):
+            pl = Placement(locus="remote", device=p.value or p.type)
+            intent.placements[p.ref] = pl
+            p.locus = "remote"
+
+
 def _first(signals: dict[str, int], *roles: str) -> Optional[int]:
     """First present role's GPIO, else None — preserving a GPIO of 0.
     ``signals.get(a) or signals.get(b)`` wrongly falls through when a maps to
@@ -785,6 +809,10 @@ _REGISTRY: list[tuple[str, Callable[[DesignIntent, RefAllocator], Expansion]]] =
 
 def expand_intent(intent: DesignIntent) -> DesignIntent:
     """Run all templates over ``intent`` (mutated in place and returned)."""
+    # Inject synthetic remote placements for terminal-only cards BEFORE any
+    # template runs, so is_remote() / _peripheral_is_remote() returns True for
+    # them and glue suppression (power_tree, device_config) fires correctly.
+    _inject_terminal_loci(intent)
     alloc = RefAllocator(intent)
     rail_endpoints: dict[str, list[Endpoint]] = {}
     nets_by_name = {n.name: n for n in intent.nets}

--- a/src/kicad_mcp/utils/firmware/templates.py
+++ b/src/kicad_mcp/utils/firmware/templates.py
@@ -790,6 +790,127 @@ def remote_peripherals(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
     return ex
 
 
+# Max positions for a Phoenix screw terminal (Connector:Screw_Terminal_01x{N});
+# beyond this `single` grouping falls back to a pin header. Mirrors
+# connectors._PHOENIX_RANGE (2..16).
+_SCREW_MAX = 16
+
+_RAIL_FOR_POWER = {"3v3": "+3V3", "5v": "+5V", "none": None}
+
+
+def _emit_expander_terminal(
+    ex: Expansion, alloc: RefAllocator, expander_ref: str,
+    signals: list[tuple[str, str]], *, rail: Optional[str], device: str,
+    value: str, force_header: bool = False,
+) -> None:
+    """Emit ONE terminal for ``signals`` (each ``(new_net_name, port_pin)``) plus
+    the power/GND rail positions, and wire each signal into a NEW net joining the
+    expander's port pin to the terminal position. Power rails are delivered as taps
+    (folded onto ``ex.power`` by ``_emit_connector``)."""
+    positions = [ConnectorPosition(net_name, pin) for net_name, pin in signals]
+    if rail is not None:
+        positions.append(ConnectorPosition(rail, rail))
+    positions.append(ConnectorPosition("GND", "GND"))
+    ctype = "pin_header" if (force_header or len(positions) > _SCREW_MAX) else "screw_terminal"
+    _conn, sig_eps = _emit_connector(ex, alloc, positions, device=device,
+                                     value=value, connector_type=ctype)
+    for net_name, pin in signals:
+        ex.new_nets.append(Net(
+            name=net_name, kind="passive", confidence="high", origin="template",
+            endpoints=[Endpoint(ref=expander_ref, pin=pin), sig_eps[net_name]],
+        ))
+
+
+def expander_terminals(intent: DesignIntent, alloc: RefAllocator) -> Expansion:
+    """Tap a placed I/O-expander's floating GPA/GPB pins out to labeled screw
+    terminal(s), per a board.yaml ``expander_terminals`` declaration. Each tapped
+    port pin gets a NEW net ``{prefix}_{i}`` joining the expander pin to a terminal
+    position; +power/GND are delivered over the terminal as rail taps. The
+    expander's I2C/INT side is untouched (only GPA/GPB are tapped), and the MCP is
+    a normally-placed peripheral so ``remote_peripherals`` never sees it.
+
+    Honest-by-construction: only fires for a user declaration, and only when the
+    named ref is actually a placed MCP23017 — otherwise a Gap, never a silent
+    no-op or a board missing its sensor terminals."""
+    ex = Expansion()
+    if not intent.expander_terminals:
+        return ex
+    periph_by_ref = {p.ref: p for p in intent.peripherals}
+    existing_net_names = {n.name for n in intent.nets}
+    rails_present = {n.name for n in intent.nets if n.kind == "power"}
+
+    for ref, spec in intent.expander_terminals.items():
+        p = periph_by_ref.get(ref)
+        if p is None or p.type != "MCP23017":
+            ex.gaps.append(Gap(
+                "expander_terminals_unresolved",
+                f"board.yaml expander_terminals[{ref!r}] is not a placed MCP23017 "
+                f"expander (got {p.type if p else 'no such ref'!r}); no terminals "
+                "synthesized."))
+            continue
+        if not spec.ports:
+            ex.gaps.append(Gap(
+                "expander_terminals_empty",
+                f"expander_terminals[{ref!r}]: no ports declared; nothing to tap."))
+            continue
+
+        # Power rail tap is declared topology (not a sensor inference). 5v needs the
+        # +5V rail to exist (USB/regulator block ran) — else disclose + drop to none.
+        rail = _RAIL_FOR_POWER[spec.power]
+        if rail == "+5V" and "+5V" not in rails_present:
+            ex.gaps.append(Gap(
+                "expander_terminals_power",
+                f"expander_terminals[{ref!r}]: power: 5v but no +5V rail on this "
+                "board; wiring signal + GND only."))
+            rail = None
+
+        # One NEW net per tapped pin. Namespace on collision (the expand_intent
+        # new_nets append has no guard) and disclose it, never silently duplicate.
+        port_nets: list[tuple[str, str]] = []   # (net_name, port_pin)
+        for i, pin in enumerate(spec.ports):
+            base = f"{spec.net_prefix}_{i}"
+            name = base
+            if name in existing_net_names:
+                name = f"{base}_{ref}"
+                ex.gaps.append(Gap(
+                    "expander_terminals_net_collision",
+                    f"expander_terminals[{ref!r}]: net {base!r} already exists; "
+                    f"using {name!r}."))
+            existing_net_names.add(name)
+            port_nets.append((name, pin))
+
+        device = spec.device
+        if spec.group == "per_sensor":
+            for net_name, pin in port_nets:
+                _emit_expander_terminal(ex, alloc, ref, [(net_name, pin)],
+                                        rail=rail, device=device, value=device)
+        elif spec.group == "per_bank":
+            banks: dict[str, list[tuple[str, str]]] = {}
+            for net_name, pin in port_nets:
+                banks.setdefault(pin[:3], []).append((net_name, pin))   # GPA / GPB
+            for bank in sorted(banks):
+                _emit_expander_terminal(ex, alloc, ref, banks[bank], rail=rail,
+                                        device=device, value=f"{device} {bank}")
+        else:  # single
+            total = len(port_nets) + (1 if rail else 0) + 1   # signals + power + GND
+            force_header = total > _SCREW_MAX
+            if force_header:
+                ex.gaps.append(Gap(
+                    "expander_terminals_single_overflow",
+                    f"expander_terminals[{ref!r}]: 'single' needs {total} positions "
+                    f"(> {_SCREW_MAX}-way screw terminal); using a pin header — "
+                    "consider group: per_bank."))
+            _emit_expander_terminal(ex, alloc, ref, port_nets, rail=rail,
+                                    device=device, value=device, force_header=force_header)
+
+        ex.gaps.append(Gap(
+            "expander_terminals",
+            f"expander_terminals[{ref!r}]: {len(spec.ports)} {device} port(s) tapped "
+            f"to terminal(s) (group={spec.group}, power={spec.power}).",
+            resolved=True, resolved_by="board.yaml"))
+    return ex
+
+
 _REGISTRY: list[tuple[str, Callable[[DesignIntent, RefAllocator], Expansion]]] = [
     ("power_tree", power_tree),
     ("decoupling", decoupling),
@@ -802,6 +923,9 @@ _REGISTRY: list[tuple[str, Callable[[DesignIntent, RefAllocator], Expansion]]] =
     ("uart_device_header", uart_device_header),
     ("device_config", device_config),
     ("remote_peripherals", remote_peripherals),
+    # After remote_peripherals: the MCP is on-board (never remote), and power_tree
+    # has already created the rails the +power taps merge into.
+    ("expander_terminals", expander_terminals),
 ]
 
 

--- a/tests/fixtures/firmware/audio_ics43434/config.h
+++ b/tests/fixtures/firmware/audio_ics43434/config.h
@@ -1,0 +1,34 @@
+#pragma once
+// Part-resolution + realization fixture: the I2S microphone bus NAMES an ICS-43434.
+// Because the ICS-43434 has a real KiCad symbol, the resolver binds it AND the
+// i2s_mic template places it (the in-stock-successor exercise). The ONLY bare part
+// name in this file is the mic itself — naming any other part, even in a comment,
+// would feed the resolver too (it scans comments). See test_part_resolution_ics43434.py.
+
+#if CONFIG_IDF_TARGET_ESP32S3
+// --- I2S output bus 0 (stereo amp pair) ---
+#define CMCA_I2S_BCLK         15
+#define CMCA_I2S_LRC          16
+#define CMCA_I2S_DIN          17
+#define CMCA_I2S_SAMPLE_RATE  22050   // config, NOT a pin (seam guard)
+// --- I2S output bus 1 ---
+#define CMCA_I2S2_BCLK        35
+#define CMCA_I2S2_LRC         36
+#define CMCA_I2S2_DIN         37
+// --- I2C OLED ---
+#define CMCA_OLED_SDA         47
+#define CMCA_OLED_SCL         48
+#define CMCA_OLED_ADDR        0x3C
+// --- UART presence sensor (LD2410) ---
+#define CMCA_PRESENCE_RX_PIN  18
+#define CMCA_PRESENCE_TX_PIN  21
+// --- I2S microphone: ICS-43434 ---
+#define CMCA_MIC_BCLK         8
+#define CMCA_MIC_WS           9
+#define CMCA_MIC_SD           10
+#else
+// legacy WROOM-32 prototype block (must be dropped by #if selection)
+#define CMCA_I2S_BCLK         26
+#define CMCA_I2S_LRC          25
+#define CMCA_I2S_DIN          27
+#endif

--- a/tests/fixtures/firmware/audio_ics43434/platformio.ini
+++ b/tests/fixtures/firmware/audio_ics43434/platformio.ini
@@ -1,0 +1,12 @@
+; Fixture platformio.ini for the S3 audio harness (ICS-43434 mic variant). Two envs
+; (a legacy esp32dev first, then the production S3) — exercises the multi-board=
+; "prefer last known" detection.
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino
+
+[env:esp32-s3]
+platform = espressif32
+board = esp32-s3-devkitc-1
+framework = arduino

--- a/tests/fixtures/firmware/expander_demo/board.yaml
+++ b/tests/fixtures/firmware/expander_demo/board.yaml
@@ -1,0 +1,9 @@
+# Firmware-blind: the MCP23017 (U3) fans 6 TCRT5000 reflectance sensors out to
+# screw terminals. Firmware addresses them by MCP register at runtime, so the
+# per-sensor wiring exists only here, with provenance.
+expander_terminals:
+  U3:
+    device: TCRT5000
+    ports: 6
+    group: per_sensor
+    power: 3v3

--- a/tests/fixtures/firmware/expander_demo/config.h
+++ b/tests/fixtures/firmware/expander_demo/config.h
@@ -1,0 +1,12 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+// Expander-terminals integration fixture: ESP32-WROOM + HX711 + an MCP23017 I2C
+// GPIO expander (U3). The board.yaml taps the MCP's GPA0..GPA5 out to 6 labeled
+// TCRT5000 reflectance-sensor terminals — firmware can't know this (the sensors
+// are addressed by MCP register at runtime, no per-sensor #define).
+#define I2C_SDA_PIN    21
+#define I2C_SCL_PIN    22
+#define MCP23017_ADDR  0x27
+#define HX711_DOUT_PIN 16
+#define HX711_SCK_PIN  17
+#endif

--- a/tests/fixtures/firmware/expander_demo/platformio.ini
+++ b/tests/fixtures/firmware/expander_demo/platformio.ini
@@ -1,0 +1,4 @@
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino

--- a/tests/fixtures/firmware/terminal_devices/config.h
+++ b/tests/fixtures/firmware/terminal_devices/config.h
@@ -1,0 +1,18 @@
+#pragma once
+// Fixture for terminal-only device card tests (v1).
+// Devices under test: PIEZO (single ADC GPIO) + TCRT5000 (single digital out).
+// ONLY the part names being tested appear in this file — naming any extra
+// recognized part would feed the part extractor too (it scans comments) and
+// could bleed into unrelated resolution assertions.
+//
+// No SWITCH card is exercised here to keep the fixture minimal; the SWITCH card
+// is covered by unit tests in test_terminal_device_cards.py.
+
+#if CONFIG_IDF_TARGET_ESP32
+#define PIEZO_ADC_PIN        35   // Piezo transducer ADC line
+#define TCRT5000_DOUT_PIN    34   // Single reflective optical sensor
+#else
+// Fallback (must be dead branch — excluded by #if selection above)
+#define PIEZO_ADC_PIN        -1
+#define TCRT5000_DOUT_PIN    -1
+#endif

--- a/tests/fixtures/firmware/terminal_devices/platformio.ini
+++ b/tests/fixtures/firmware/terminal_devices/platformio.ini
@@ -1,0 +1,5 @@
+; Fixture platformio.ini for terminal device card tests.
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino

--- a/tests/integration/test_device_cards.py
+++ b/tests/integration/test_device_cards.py
@@ -47,10 +47,15 @@ def _all_cards():
 def test_card_pins_exist_on_symbol(kind, name, card, pins):
     from kicad_sch_api.library.cache import get_symbol_cache
 
+    from kicad_mcp.utils.firmware.knowledge import resolve_symbol
     from kicad_mcp.utils.firmware.mcu_pinmap import resolve_pin_token
 
-    sym = get_symbol_cache().get_symbol(card["lib_id"])
-    assert sym is not None, f"{kind} {name}: symbol {card['lib_id']!r} not found"
+    # Resolve via the same cross-version helper the generator uses, so a card
+    # whose symbol KiCad renamed (MCP23017_SO/MCP23017x-x-SO) validates on BOTH
+    # the KiCad 9 and KiCad 10 matrix legs.
+    candidates = [card["lib_id"], *card.get("alt_lib_ids", [])]
+    _, sym = resolve_symbol(get_symbol_cache(), card["lib_id"], card.get("alt_lib_ids", []))
+    assert sym is not None, f"{kind} {name}: no symbol resolved from {candidates}"
     missing = [p for p in pins if resolve_pin_token(sym, p) is None]
     assert not missing, (
         f"{kind} {name} ({card['lib_id']}): pins not on symbol: {missing}. "

--- a/tests/integration/test_device_cards.py
+++ b/tests/integration/test_device_cards.py
@@ -25,6 +25,10 @@ def _pins_for_peripheral(card):
     if strap:
         pins += list(strap["pin_bits"])
     pins += [t["pin"] for t in cfg.get("static_ties", []) or []]
+    # I/O-expander port pins (GPA0..GPB7) — the source of truth for
+    # expander_terminals; verify every one resolves on the real symbol (so a typo
+    # in a pin a `ports:` list could request is caught on BOTH KiCad versions).
+    pins += list(card.get("port_pins", []) or [])
     return pins
 
 

--- a/tests/integration/test_firmware_pcb_pipeline.py
+++ b/tests/integration/test_firmware_pcb_pipeline.py
@@ -28,6 +28,7 @@ CONFIG_H = FIXTURE / "config.h"
 AUDIO_CONFIG_H = FIXTURE / "audio_s3" / "config.h"
 TRACK_GEOM_CONFIG_H = FIXTURE / "track_geometry" / "config.h"
 SIDECAR_CONFIG_H = FIXTURE / "sidecar_demo" / "config.h"
+EXPANDER_CONFIG_H = FIXTURE / "expander_demo" / "config.h"
 
 _MINIMAL_PRO = {
     "board": {"design_settings": {}},
@@ -1069,3 +1070,62 @@ def test_sidecar_to_routed_pcb(mcp_server, tmp_path):
                    for x in nl["nets"].get(net, []))
 
     assert has_pwr_in("+5V") and has_pwr_in("GND")
+
+
+@pytest.mark.timeout(360)  # 6 sensor terminals -> dense; passes=10 like the others
+def test_expander_terminals_to_routed_pcb(mcp_server, tmp_path):
+    """v2: a board.yaml expander_terminals block taps a placed MCP23017's floating
+    GPA0..GPA5 pins out to 6 labeled TCRT5000 screw terminals → full
+    import→expand→generate→routed PCB. THIS is where the KiCad 9-vs-10 MCP23017
+    symbol rename surfaces (the chip must place + its port pins wire on BOTH), so
+    it runs on the whole matrix — the regression gate for cross-version resolution
+    feeding a real port-pin-dependent feature."""
+    design = _tool(mcp_server, "design")
+    build = _tool(mcp_server, "build_pcb_from_schematic")
+    intent = tmp_path / "intent.yaml"
+    sch = tmp_path / "exp.kicad_sch"
+    pro = tmp_path / "exp.kicad_pro"
+
+    r1 = design(operation="import_firmware", firmware_path=str(EXPANDER_CONFIG_H),
+                out_path=str(intent))
+    assert r1["status"] == "ok"
+    assert r1["sidecar"] is not None                       # board.yaml auto-detected
+    # HX711 -> U2, MCP23017 -> U3 (alphabetical); the expander is the chip we tap.
+    assert {p["type"] for p in r1["summary"]["peripherals"]} == {"HX711", "MCP23017"}
+
+    r2 = design(operation="expand_templates", intent_path=str(intent))
+    assert r2["status"] == "ok"
+
+    r3 = design(operation="generate_schematic", intent_path=str(intent),
+                schematic_path=str(sch))
+    # On KiCad 9 the MCP23017 resolves via alt_lib_ids and its GPA pins wire out;
+    # a regression there would leave the sensor nets unresolved (caught here).
+    assert r3["status"] == "ok" and not r3["unresolved_endpoints"]
+
+    pro.write_text(json.dumps(_MINIMAL_PRO))
+    # Generous board: 6 three-pos terminals + core is roomy at 130x100 (the test
+    # gates the feature + cross-version wiring, not tight packing). passes=10 for
+    # the marginal KiCad-9 router (SPEC §9-A3: bump passes, hold the bound).
+    r4 = build(project_path=str(pro), board_width_mm=130, board_height_mm=100,
+               autoroute_passes=10, export_gerbers=False, add_mounting_holes=False)
+    assert r4["status"] == "ok"
+    assert r4["pads_assigned"] > 0
+    _assert_mostly_routed(r4, max_unrouted=2)
+    assert r4["steps"]["zones"]["zones_added"] >= 1
+
+    from kicad_mcp.utils.netlist_parser import extract_netlist_via_cli
+    nl = extract_netlist_via_cli(str(sch))
+    assert nl is not None
+    comps = nl["components"]
+    # 6 TCRT5000 screw terminals placed (value carries the device).
+    terms = {ref for ref, c in comps.items() if c.get("value") == "TCRT5000"}
+    assert len(terms) == 6
+
+    def refs_on(net):
+        return {x["component"] for x in nl["nets"].get(net, [])}
+    # Each formerly-floating GPA0..GPA5 pin now wires the expander (U3) to a sensor
+    # terminal — the core invariant of the feature, proven on the real netlist.
+    for i in range(6):
+        members = refs_on(f"TCRT5000_{i}")
+        assert "U3" in members, f"TCRT5000_{i} missing the expander pin: {members}"
+        assert members & terms, f"TCRT5000_{i} not landed on a terminal: {members}"

--- a/tests/integration/test_firmware_pcb_pipeline.py
+++ b/tests/integration/test_firmware_pcb_pipeline.py
@@ -303,7 +303,7 @@ def test_firmware_to_routed_pcb(mcp_server, tmp_path):
     assert r1["status"] == "ok"
     assert r1["board"] == "esp32dev"
     assert r1["summary"]["mcu"] == "ESP32-WROOM-32E"
-    assert {p["type"] for p in r1["summary"]["peripherals"]} == {"HX711", "MCP23017"}
+    assert {p["type"] for p in r1["summary"]["peripherals"]} == {"HX711", "MCP23017", "PIEZO"}
 
     # 2) expand templates (power/glue + USB programming block)
     r2 = design(operation="expand_templates", intent_path=str(intent))
@@ -315,19 +315,20 @@ def test_firmware_to_routed_pcb(mcp_server, tmp_path):
                 schematic_path=str(sch))
     assert r3["status"] == "ok"
     assert not r3["unresolved_endpoints"]
-    assert r3["components_placed"] == 23      # 3 ICs + power tree + USB block
+    assert r3["components_placed"] == 24      # 3 ICs + power tree + USB block + PIEZO terminal
 
     # 4) build a routed PCB from it — the core gate
     pro.write_text(json.dumps(_MINIMAL_PRO))
     # add_mounting_holes=False: this explicit size was calibrated pre-Phase-5 and
     # is tight; the test gates nets + routing, not holes (holes-on is gated by the
     # roomy audio_s3 and the auto-sized audio-remote boards).
-    # autoroute_passes=6 (not 2): FreeRouter is stochastic and does best-of-N.
-    # best-of-2 against the bound of 2 sits at the noise floor and occasionally
-    # lands at 3 unrouted. More passes reduce — but do not eliminate — that
-    # flake; the bound stays at 2 (SPEC §9-A3: bump passes, never loosen it).
+    # autoroute_passes=10 (was 6): FreeRouter is stochastic and does best-of-N.
+    # The PIEZO terminal added a net, nudging this crowded board to the marginal
+    # KiCad-9 router's noise floor — best-of-6 occasionally landed at 3 unrouted
+    # (>bound 2). Match the dense track-geometry board's best-of-10 for headroom;
+    # the bound stays at 2 (SPEC §9-A3: bump passes, never loosen it).
     r4 = build(project_path=str(pro), board_width_mm=90, board_height_mm=75,
-               autoroute_passes=6, export_gerbers=False, add_mounting_holes=False)
+               autoroute_passes=10, export_gerbers=False, add_mounting_holes=False)
     assert r4["status"] == "ok"
     assert r4["pads_assigned"] > 0
     _assert_mostly_routed(r4, max_unrouted=2)
@@ -352,10 +353,16 @@ def test_firmware_to_routed_pcb(mcp_server, tmp_path):
     def refs_on(net):
         return {x["component"] for x in nl["nets"].get(net, [])}
 
-    # MCU (U1) + LDO (U4) powered from +3V3; CP2102 (U5) VDD is an OUTPUT, so U5
-    # must NOT appear on +3V3 (the landmine the templates handle).
-    assert {"U1", "U4"} <= refs_on("+3V3")
-    assert "U5" not in refs_on("+3V3")
+    # MCU (U1) + the LDO are powered from +3V3; the CP2102's VDD is an OUTPUT, so
+    # it must NOT appear on +3V3 (the landmine the templates handle). Resolve the
+    # LDO and bridge BY VALUE, not a hardcoded ref — adding a peripheral (e.g. the
+    # PIEZO terminal) shifts U-numbers, which is exactly what made the old
+    # {"U1","U4"}/{"U5"} asserts stale.
+    val = {ref: (c.get("value") or "") for ref, c in nl["components"].items()}
+    ldo = next(r for r, v in val.items() if "AMS1117" in v)
+    cp2102 = next(r for r, v in val.items() if "CP2102" in v)
+    assert {"U1", ldo} <= refs_on("+3V3")
+    assert cp2102 not in refs_on("+3V3")
     assert "U1" in refs_on("GND")
     # I2C bus joins the ESP32 (U1) and the MCP23017 (U3).
     assert {"U1", "U3"} <= refs_on("I2C_SDA")
@@ -936,8 +943,9 @@ def test_track_geometry_to_routed_pcb(mcp_server, tmp_path):
     the generalization that matters here — MULTIPLE address-declared devices,
     INCLUDING TWO OF THE SAME TYPE (dual MPU-6050 at 0x68/0x69), sharing one I2C
     bus, plus an OLED. Devices are modeled as breakout-module headers; AD0 is
-    strapped per address. The buzzer GPIO stays a flagged orphan (no driver
-    template yet) — which must NOT break routing."""
+    strapped per address. The buzzer resolves via the PIEZO card's BUZZER alias
+    into a terminal device (off-board screw terminal) — which must NOT break
+    routing."""
     design = _tool(mcp_server, "design")
     build = _tool(mcp_server, "build_pcb_from_schematic")
     intent = tmp_path / "intent.yaml"
@@ -952,13 +960,14 @@ def test_track_geometry_to_routed_pcb(mcp_server, tmp_path):
     # Two MPU6050 instances + one OLED, all recognized off their *_ADDR macros.
     types = [p["type"] for p in r1["summary"]["peripherals"]]
     assert types.count("MPU6050") == 2 and types.count("OLED") == 1
-    # The undriven buzzer (declared BUZZER_PIN, no device card) MUST be surfaced
-    # as an unknown_peripheral gap, not silently dropped — that gap is the user's
-    # only signal it became a single-pad orphan net. Pin it so a refactor can't
-    # quietly stop emitting it (the orphan itself is invisible to the route count).
+    # The buzzer (declared BUZZER_PIN) resolves via the PIEZO card's BUZZER alias
+    # into a terminal device (v1 terminal cards) — it materializes as a recognized
+    # peripheral and emits NO unknown_peripheral gap. Pin both halves so a refactor
+    # can't silently drop the alias or re-orphan the buzzer.
+    assert "BUZZER" in types
     buzzer_gaps = [g for g in r1["gaps"]
                    if g["kind"] == "unknown_peripheral" and "BUZZER" in g["detail"].upper()]
-    assert buzzer_gaps, f"undriven-buzzer gap not surfaced; gaps={r1['gaps']}"
+    assert not buzzer_gaps, f"buzzer should resolve as a terminal, not a gap; gaps={r1['gaps']}"
 
     r2 = design(operation="expand_templates", intent_path=str(intent))
     assert r2["status"] == "ok"
@@ -973,11 +982,11 @@ def test_track_geometry_to_routed_pcb(mcp_server, tmp_path):
     # MULTI-pad nets unrouted — pure FreeRouter nondeterminism on the crowded
     # SDA/SCL cluster (MCU + 2× MPU-6050 + OLED + pull-ups) and the CP2102/USB
     # block. The bound of 2 is observed-max + 1 margin of that router noise.
-    # NOTE: the buzzer GPIO is a single-pad ORPHAN net (declared BUZZER_PIN, no
-    # driver template) — a single pad has no ratsnest, so KiCad's
-    # GetUnconnectedCount (what incomplete_nets reads, see pcb_autoroute.py) scores
-    # it ZERO. The orphan is NOT part of the bound; older comments that blamed it
-    # were wrong. Each prior bound bump hit the tail again on CI's KiCad 9
+    # NOTE: the buzzer (BUZZER_PIN) is now a TERMINAL device (PIEZO card's BUZZER
+    # alias) — its net runs MCU-GPIO -> screw-terminal pad, a routable 2-point net,
+    # not the old single-pad orphan. It routes within the bound here; the margin is
+    # for FreeRouter noise on the crowded SDA/SCL cluster, not the buzzer. Each
+    # prior bound bump hit the tail again on CI's KiCad 9
     # (best-of-2, then -4, then -6 on 2026-06-02). best-of-N keeps the best of N
     # independent routing attempts, so raising N shrinks the all-attempts-fail tail
     # exponentially; 10 gives real headroom over the chronically-marginal 9.0
@@ -989,7 +998,7 @@ def test_track_geometry_to_routed_pcb(mcp_server, tmp_path):
                autoroute_passes=10, export_gerbers=False, add_mounting_holes=False)
     assert r4["status"] == "ok"
     assert r4["pads_assigned"] > 0
-    _assert_mostly_routed(r4, max_unrouted=2)            # router-noise margin (single-pad buzzer orphan isn't counted)
+    _assert_mostly_routed(r4, max_unrouted=2)            # router-noise margin on the I2C cluster
     assert r4["steps"]["zones"]["zones_added"] >= 1
 
     from kicad_mcp.utils.netlist_parser import extract_netlist_via_cli
@@ -1001,9 +1010,14 @@ def test_track_geometry_to_routed_pcb(mcp_server, tmp_path):
 
     def refs_on(net):
         return {x["component"] for x in nl["nets"].get(net, [])}
-    # The shared I2C bus joins the ESP32 (U1) + both MPU6050 (U2/U3) + OLED (U4).
-    assert {"U1", "U2", "U3", "U4"} <= refs_on("I2C_SDA")
-    assert {"U1", "U2", "U3", "U4"} <= refs_on("I2C_SCL")
+    # The shared I2C bus joins the ESP32 (U1) + both MPU6050 + the OLED. Resolve
+    # those device refs BY VALUE, not hardcoded U-numbers — the buzzer terminal
+    # now consumes a ref slot, shifting the I2C devices (what made U2/U3/U4 stale).
+    val = {ref: (c.get("value") or "") for ref, c in nl["components"].items()}
+    i2c_devs = {r for r, v in val.items() if "MPU-6050" in v or "SSD1306" in v}
+    assert len(i2c_devs) == 3                            # 2 MPU6050 + 1 OLED
+    assert {"U1", *i2c_devs} <= refs_on("I2C_SDA")
+    assert {"U1", *i2c_devs} <= refs_on("I2C_SCL")
     assert "U1" in refs_on("+3V3")
 
 

--- a/tests/test_device_cards.py
+++ b/tests/test_device_cards.py
@@ -180,7 +180,7 @@ def test_recognized_part_names_hyphenated_raw_preserved_I1():
 
 def test_packaged_cards_load():
     peris, mcus = load_cards()
-    assert set(peris) >= {"MCP23017", "HX711", "MPU6050", "OLED"}
+    assert set(peris) >= {"MCP23017", "HX711", "MPU6050", "OLED", "ICS43434"}
     assert {m["part"] for m in mcus} >= {"ESP32-WROOM-32E", "ESP32-S3-WROOM-1"}
 
 

--- a/tests/test_device_cards.py
+++ b/tests/test_device_cards.py
@@ -136,6 +136,47 @@ def test_serves_validation(serves, ok):
     assert (validate_peripheral_card(card) == []) is ok
 
 
+# --- alt_lib_ids + cross-version symbol resolution ---------------------------
+
+@pytest.mark.parametrize("alts,ok", [
+    (None, True),                                  # optional — absent is fine
+    ([], True),                                    # empty list is fine
+    (["Interface_Expansion:MCP23017_SO"], True),   # one older-KiCad name
+    (["Lib:A", "Lib:B"], True),                    # several
+    ("Lib:A", False),                              # a bare string is not a list
+    (["NoColon"], False),                          # entry not a Library:Symbol
+    ([""], False),                                 # empty entry
+    ([1], False),                                  # non-string entry
+])
+def test_alt_lib_ids_validation(alts, ok):
+    card = dict(_GOOD_PERIPHERAL, alt_lib_ids=alts)
+    assert (validate_peripheral_card(card) == []) is ok
+
+
+class _FakeCache:
+    """Minimal symbol cache: a name resolves iff it is in ``known``."""
+    def __init__(self, known):
+        self.known = set(known)
+
+    def get_symbol(self, name):
+        return object() if name in self.known else None
+
+
+@pytest.mark.parametrize("known,lib_id,alts,expected", [
+    ({"Lib:New", "Lib:Old"}, "Lib:New", ["Lib:Old"], "Lib:New"),   # primary preferred
+    ({"Lib:Old"},            "Lib:New", ["Lib:Old"], "Lib:Old"),   # MCP23017-on-KiCad-9: use the alt
+    ({"Lib:Older"}, "Lib:New", ["Lib:Old", "Lib:Older"], "Lib:Older"),  # alts tried in order
+    (set(),                  "Lib:New", ["Lib:Old"], None),        # nothing resolves
+    ({"Lib:Old"},            None,      ["Lib:Old"], "Lib:Old"),   # None primary skipped
+    ({"Lib:Old"},            "",        ["Lib:Old"], "Lib:Old"),   # empty primary skipped
+    (set(),                  None,      [],          None),        # nothing to try
+])
+def test_resolve_symbol(known, lib_id, alts, expected):
+    name, sym = K.resolve_symbol(_FakeCache(known), lib_id, alts)
+    assert name == expected
+    assert (sym is not None) == (expected is not None)
+
+
 def test_recognized_part_names_maps_raw_to_canonical():
     peripherals = {
         "INMP441": dict(_GOOD_PERIPHERAL, type="INMP441"),
@@ -192,9 +233,13 @@ def test_packaged_cards_load():
 _EXPECTED = {
     "MCP23017": {
         "lib_id": "Interface_Expansion:MCP23017x-x-SO", "value": "MCP23017",
+        # KiCad-9 fallback name (symbol family was renamed in KiCad 10).
+        "alt_lib_ids": ["Interface_Expansion:MCP23017_SO"],
         "bus": "I2C", "footprint": "Package_SO:SOIC-28W_7.5x17.9mm_P1.27mm",
         "roles": {"SDA": "SDA", "SCL": "SCK", "INT": "INTA", "INTA": "INTA"},
-        "supply_pins": ["V_{DD}"], "ground_pins": ["V_{SS}"], "module": False,
+        # Power pins by pad NUMBER (V_{DD}/V_{SS} in KiCad 10 are VDD/VSS in
+        # KiCad 9; pads 9/10 are identical) so they resolve on both versions.
+        "supply_pins": ["9"], "ground_pins": ["10"], "module": False,
     },
     "HX711": {
         "lib_id": "Analog_ADC:HX711", "value": "HX711", "bus": None,

--- a/tests/test_device_cards.py
+++ b/tests/test_device_cards.py
@@ -180,7 +180,11 @@ def test_recognized_part_names_hyphenated_raw_preserved_I1():
 
 def test_packaged_cards_load():
     peris, mcus = load_cards()
-    assert set(peris) >= {"MCP23017", "HX711", "MPU6050", "OLED", "ICS43434"}
+    # Chip-down cards + module cards + terminal-only v1 cards.
+    assert set(peris) >= {
+        "MCP23017", "HX711", "MPU6050", "OLED", "ICS43434",
+        "PIEZO", "SWITCH", "TCRT5000",
+    }
     assert {m["part"] for m in mcus} >= {"ESP32-WROOM-32E", "ESP32-S3-WROOM-1"}
 
 

--- a/tests/test_expander_terminals.py
+++ b/tests/test_expander_terminals.py
@@ -81,6 +81,34 @@ def test_single_over_16_falls_back_to_pin_header_with_gap():
     assert any(g.kind == "expander_terminals_single_overflow" for g in it.gaps)
 
 
+def test_single_at_16_positions_stays_a_screw_terminal():
+    # Boundary (< vs <=): 14 ports + 3V3 + GND = 16 = the screw-terminal max — NO
+    # overflow; 18 (the test above) does overflow. Pins the threshold side.
+    it = _mcp_intent(device="S", ports=14, group="single")
+    expand_intent(it)
+    terms = _terminals(it, "S")
+    assert len(terms) == 1 and terms[0].type == "TERM"       # screw block, not header
+    assert not any(g.kind == "expander_terminals_single_overflow" for g in it.gaps)
+
+
+def test_per_bank_gpa_only_is_one_terminal():
+    # GPA0-5 only -> one bank -> exactly one terminal (no empty GPB terminal).
+    it = _mcp_intent(device="S", ports=6, group="per_bank")
+    expand_intent(it)
+    assert len(_terminals(it, "S")) == 1
+
+
+def test_i2c_side_untouched_no_double_emit():
+    # Tapping GPA pins must not duplicate or retarget the MCP's existing I2C net,
+    # and the on-board MCP must not be pulled into a remote terminal.
+    it = _mcp_intent(device="S", ports=4)
+    expand_intent(it)
+    sda = [n for n in it.nets if n.name == "I2C_SDA"]
+    assert len(sda) == 1                                     # not duplicated
+    refs = {e.ref for e in sda[0].endpoints}
+    assert not any(r.startswith("J") for r in refs)          # no terminal tapped onto I2C
+
+
 def test_power_none_two_position_terminals():
     it = _mcp_intent(device="S", ports=2, group="per_sensor", power="none")
     expand_intent(it)
@@ -90,9 +118,26 @@ def test_power_none_two_position_terminals():
                for lg in it.connector_legends)
 
 
-def test_power_5v_without_rail_downgrades_with_gap():
+def test_power_5v_with_rail_emits_5v_position():
+    # ESP32 board -> power_tree adds the AMS1117 (+5V regulator input) BEFORE this
+    # template runs, so power: 5v is honored: a +5V terminal position is emitted.
     it = _mcp_intent(device="S", ports=2, group="per_sensor", power="5v")
-    expand_intent(it)                                        # minimal intent has no +5V rail
+    expand_intent(it)
+    assert not any(g.kind == "expander_terminals_power" for g in it.gaps)
+    assert any("+5V" in lg.positions for lg in it.connector_legends)
+
+
+def test_power_5v_without_rail_downgrades_with_gap():
+    # A board with no +5V source (no MCU -> power_tree never fires, no regulator/USB
+    # block) downgrades power: 5v to signal+GND with a disclosed gap — never a
+    # sourceless +5V pin on the terminal.
+    it = DesignIntent()
+    it.peripherals = [Peripheral(
+        ref="U3", type="MCP23017", lib_id="Interface_Expansion:MCP23017x-x-SO",
+        value="MCP23017", bus="I2C")]
+    apply_sidecar(it, BoardSidecar(
+        expander_terminals={"U3": {"device": "S", "ports": 2, "power": "5v"}}))
+    expand_intent(it)
     assert any(g.kind == "expander_terminals_power" for g in it.gaps)
     assert all("+5V" not in lg.positions for lg in it.connector_legends)
 

--- a/tests/test_expander_terminals.py
+++ b/tests/test_expander_terminals.py
@@ -1,0 +1,143 @@
+"""Tests for the expander_terminals template: tap a placed MCP23017's floating
+GPA/GPB pins out to labeled screw terminal(s), per a board.yaml declaration.
+Behavior + edge cases; no KiCad needed (the data flow is pin-name based)."""
+from __future__ import annotations
+
+import pytest
+
+from kicad_mcp.utils.firmware.intent import (
+    DesignIntent,
+    Endpoint,
+    Mcu,
+    Net,
+    Peripheral,
+)
+from kicad_mcp.utils.firmware.sidecar import BoardSidecar, apply_sidecar
+from kicad_mcp.utils.firmware.templates import expand_intent
+
+
+def _mcp_intent(**spec):
+    """ESP32 + a placed MCP23017 (U3) on I2C; optionally apply a board.yaml
+    expander_terminals spec for U3 (raw dict, as load_sidecar would produce)."""
+    it = DesignIntent()
+    it.mcu = Mcu(ref="U1", part="ESP32-WROOM-32E", lib_id="RF_Module:ESP32-WROOM-32E")
+    it.peripherals = [Peripheral(
+        ref="U3", type="MCP23017", lib_id="Interface_Expansion:MCP23017x-x-SO",
+        alt_lib_ids=["Interface_Expansion:MCP23017_SO"], value="MCP23017", bus="I2C")]
+    it.nets = [Net("I2C_SDA", "peripheral", "high",
+                   [Endpoint(ref="U1", gpio=21), Endpoint(ref="U3", role="SDA")])]
+    if spec:
+        apply_sidecar(it, BoardSidecar(expander_terminals={"U3": spec}))
+    return it
+
+
+def _sensor_nets(intent, prefix):
+    return [n for n in intent.nets if n.name.startswith(prefix + "_")]
+
+
+def _terminals(intent, prefix):
+    """The connector Peripherals this feature synthesized — identified by being an
+    endpoint of one of its sensor nets (robust to other expand glue / USB block)."""
+    refs = {e.ref for n in _sensor_nets(intent, prefix)
+            for e in n.endpoints if e.ref.startswith("J")}
+    return [p for p in intent.peripherals if p.ref in refs]
+
+
+def test_per_sensor_one_terminal_per_port():
+    it = _mcp_intent(device="TCRT5000", ports=6, group="per_sensor")
+    expand_intent(it)
+    terms = _terminals(it, "TCRT5000")
+    assert len(terms) == 6                                          # N ports -> N terminals
+    assert all(t.lib_id.endswith("Screw_Terminal_01x03") for t in terms)  # sig+3V3+GND
+    nets = _sensor_nets(it, "TCRT5000")
+    assert len(nets) == 6
+    for i, n in enumerate(sorted(nets, key=lambda n: n.name)):
+        refs = {(e.ref, e.pin) for e in n.endpoints}
+        assert ("U3", f"GPA{i}") in refs                           # taps the right port pin
+        assert any(r.startswith("J") for r, _ in refs)             # lands on a terminal pad
+
+
+def test_per_bank_one_terminal_per_used_bank():
+    # 10 ports span GPA0-7 + GPB0-1 -> two banks -> two terminals.
+    it = _mcp_intent(device="S", ports=10, group="per_bank")
+    expand_intent(it)
+    terms = _terminals(it, "S")
+    assert len(terms) == 2
+    # GPA bank: 8 sig + 3V3 + GND = 10; GPB bank: 2 sig + 3V3 + GND = 4.
+    assert sorted(int(t.lib_id[-2:]) for t in terms) == [4, 10]
+
+
+def test_single_one_terminal():
+    it = _mcp_intent(device="S", ports=6, group="single")
+    expand_intent(it)
+    assert len(_terminals(it, "S")) == 1
+
+
+def test_single_over_16_falls_back_to_pin_header_with_gap():
+    it = _mcp_intent(device="S", ports=16, group="single")   # 16 + 3V3 + GND = 18 > 16
+    expand_intent(it)
+    terms = _terminals(it, "S")
+    assert len(terms) == 1 and terms[0].type == "HDR"        # pin header, not screw block
+    assert any(g.kind == "expander_terminals_single_overflow" for g in it.gaps)
+
+
+def test_power_none_two_position_terminals():
+    it = _mcp_intent(device="S", ports=2, group="per_sensor", power="none")
+    expand_intent(it)
+    terms = _terminals(it, "S")
+    assert terms and all(t.lib_id.endswith("01x02") for t in terms)   # signal + GND only
+    assert all("+3V3" not in lg.positions and "+5V" not in lg.positions
+               for lg in it.connector_legends)
+
+
+def test_power_5v_without_rail_downgrades_with_gap():
+    it = _mcp_intent(device="S", ports=2, group="per_sensor", power="5v")
+    expand_intent(it)                                        # minimal intent has no +5V rail
+    assert any(g.kind == "expander_terminals_power" for g in it.gaps)
+    assert all("+5V" not in lg.positions for lg in it.connector_legends)
+
+
+def test_ports_zero_is_a_noop_gap():
+    it = _mcp_intent(device="S", ports=0)
+    expand_intent(it)
+    assert any(g.kind == "expander_terminals_empty" for g in it.gaps)
+    assert not _terminals(it, "S")
+
+
+def test_non_mcp_ref_is_a_gap_not_a_crash():
+    it = DesignIntent()
+    it.mcu = Mcu(ref="U1", part="ESP32-WROOM-32E", lib_id="RF_Module:ESP32-WROOM-32E")
+    it.peripherals = [Peripheral(ref="U2", type="HX711", lib_id="Analog_ADC:HX711")]
+    apply_sidecar(it, BoardSidecar(expander_terminals={"U2": {"device": "X", "ports": 2}}))
+    expand_intent(it)
+    assert not _terminals(it, "X")                           # nothing synthesized
+    assert any(g.kind == "expander_terminals_unresolved" for g in it.gaps)
+
+
+def test_net_collision_is_namespaced_with_gap():
+    it = _mcp_intent()
+    it.nets.append(Net("SENSOR_0", "peripheral", "high", [Endpoint(ref="U1", gpio=5)]))
+    apply_sidecar(it, BoardSidecar(expander_terminals={"U3": {"device": "SENSOR", "ports": 2}}))
+    expand_intent(it)
+    names = {n.name for n in it.nets}
+    assert "SENSOR_0" in names and "SENSOR_0_U3" in names    # namespaced, not duplicated
+    assert any(g.kind == "expander_terminals_net_collision" for g in it.gaps)
+
+
+def test_no_expander_block_is_a_noop():
+    it = _mcp_intent()                                       # no spec applied
+    expand_intent(it)
+    assert not any(g.kind.startswith("expander_terminals") for g in it.gaps)
+    assert not any(n.name.startswith("SENSOR_") for n in it.nets)
+
+
+def test_expander_spec_round_trips():
+    # to_dict -> yaml -> from_dict must preserve the ExpanderSpec (this is the path
+    # import->expand takes across two design() calls via the saved intent doc).
+    from kicad_mcp.utils.firmware.intent import from_dict, to_dict
+    it = _mcp_intent(device="TCRT5000", ports=3, group="per_bank", power="none")
+    rt = from_dict(to_dict(it))
+    assert to_dict(rt) == to_dict(it)
+    spec = rt.expander_terminals["U3"]
+    assert spec.ports == ["GPA0", "GPA1", "GPA2"]
+    assert spec.group == "per_bank" and spec.power == "none"

--- a/tests/test_firmware_generate.py
+++ b/tests/test_firmware_generate.py
@@ -55,6 +55,27 @@ def test_pin_map_handles_none_symbol():
     assert pin_number_by_name(None, "SDA") is None
 
 
+# --- build-status contract (CI-safe; pure decision, no KiCad) ----------------
+
+@pytest.mark.parametrize("errs,unres,any_placed,expected", [
+    # clean build -> ok (the only "ok" cases: BOTH failure lists empty)
+    ([],            [],           True,  "ok"),
+    ([],            [],           False, "ok"),    # no components, no failures: pinned ok
+    # a dropped component (the MCP23017-rename failure mode) is NOT ok
+    ([{"ref": "U3"}], [],         True,  "partial"),  # others still placed
+    ([{"ref": "U1"}], [],         False, "error"),    # nothing placed (e.g. bad MCU)
+    # an endpoint that should have wired but didn't is NOT ok
+    ([],            [{"net": "X"}], True,  "partial"),
+    ([],            [{"net": "X"}], False, "error"),
+    # both failure signals present
+    ([{"ref": "U3"}], [{"net": "X"}], True,  "partial"),
+    ([{"ref": "U3"}], [{"net": "X"}], False, "error"),
+])
+def test_build_status(errs, unres, any_placed, expected):
+    from kicad_mcp.utils.firmware.generate import _build_status
+    assert _build_status(errs, unres, any_placed) == expected
+
+
 # --- generation integration (needs real KiCad symbol libraries) --------------
 
 SPEEDCAL_CONFIG = Path(
@@ -107,3 +128,37 @@ def test_generate_speedcal_end_to_end(tmp_path):
     assert members("MCP23017_INT") == {"U1.16", "U3.20"} # -> INTA pin
     # orphan net: MCU pin only, far end open
     assert members("I2S_SCK") == {"U1.30"}
+
+
+@pytest.mark.skipif(not _kicad_symbols_available(),
+                    reason="KiCad symbol libraries not available")
+@pytest.mark.skipif(not SPEEDCAL_CONFIG.exists(), reason="speed-cal config.h not present")
+def test_unresolvable_symbol_flips_status_off_ok(tmp_path):
+    """A component whose lib_id doesn't resolve must NOT report status 'ok'.
+
+    Regression for the MCP23017 cross-version rename: KiCad 10 renamed the
+    symbol family (``MCP23017_SO`` -> ``MCP23017x-x-SO``), so the card's
+    KiCad-10-only lib_id silently dropped U3 on KiCad 9 while the build still
+    reported ``ok``. Here we simulate that by corrupting an on-board
+    peripheral's lib_id to a name that resolves on NO version.
+    """
+    from kicad_mcp.utils.firmware.generate import generate_schematic
+    from kicad_mcp.utils.firmware.intent import build_intent, find_board_id
+    from kicad_mcp.utils.firmware.knowledge import is_terminal_card_type
+    from kicad_mcp.utils.firmware.parse import parse_defines, partition
+
+    parsed = partition(parse_defines(SPEEDCAL_CONFIG.read_text()))
+    intent = build_intent(parsed, firmware_path=str(SPEEDCAL_CONFIG),
+                          board_id=find_board_id(str(SPEEDCAL_CONFIG)))
+    # Pick an on-board peripheral (terminal cards are never placed, so corrupting
+    # one would not produce a component_error).
+    target = next(p for p in intent.peripherals
+                  if p.lib_id and not is_terminal_card_type(p.type))
+    target.lib_id = "Interface_Expansion:MCP23017_DOES_NOT_EXIST"
+
+    out = tmp_path / "gen.kicad_sch"
+    res = generate_schematic(intent, str(out))
+
+    assert res["status"] == "partial"          # the bug: this used to be "ok"
+    assert any(e["ref"] == target.ref for e in res["component_errors"])
+    assert res["components_placed"] >= 1        # the MCU + other IC still placed

--- a/tests/test_firmware_generate.py
+++ b/tests/test_firmware_generate.py
@@ -86,7 +86,11 @@ def test_generate_speedcal_end_to_end(tmp_path):
     res = generate_schematic(intent, str(out))
 
     assert res["status"] == "ok"
-    assert res["components_placed"] == 3        # ESP32 + MCP23017 + HX711
+    # PIEZO and TRACK are terminal-only cards (realize: terminal) — intrinsically
+    # off-board, so generate excludes them from schematic placement even on this
+    # raw (non-expanded) intent. Only the on-board ICs are placed; their terminal
+    # signals are not flagged unresolved (a screw terminal carries them at expand).
+    assert res["components_placed"] == 3        # ESP32 + HX711 + MCP23017
     assert not res["component_errors"] and not res["unresolved_endpoints"]
 
     nl = extract_netlist_via_cli(str(out))

--- a/tests/test_firmware_intent.py
+++ b/tests/test_firmware_intent.py
@@ -57,7 +57,8 @@ def test_mcu_unknown_when_no_board():
 
 def test_peripherals_materialized():
     types = {p.type for p in _intent().peripherals}
-    assert types == {"HX711", "MCP23017"}  # PIEZO has no symbol -> not placed
+    # PIEZO now resolves via the terminal-only card (Connector_Generic:Conn_01x01).
+    assert types == {"HX711", "MCP23017", "PIEZO"}
 
 def test_bus_net_tier():
     n = _net(_intent(), "I2C_SDA")
@@ -73,8 +74,10 @@ def test_peripheral_net_tier():
 
 def test_orphan_net_tiers():
     i = _intent()
-    assert _net(i, "I2S_SCK").kind == "orphan"     # no I2S device declared
-    assert _net(i, "PIEZO_ADC").kind == "orphan"   # PIEZO has no symbol
+    assert _net(i, "I2S_SCK").kind == "orphan"          # no I2S device declared
+    # PIEZO is now a recognized terminal-only card, so PIEZO_ADC is a peripheral net
+    # (the card gives it a ref; remote_peripherals will route it to a terminal).
+    assert _net(i, "PIEZO_ADC").kind == "peripheral"    # resolved via piezo.yaml
 
 def test_always_gaps_present():
     assert {"power_tree", "decoupling", "pullups", "connectors", "parts"} <= _gap_kinds(_intent())
@@ -85,9 +88,12 @@ def test_invalid_pin_becomes_gap_not_net():
     assert all(n.name != "BAD" for n in i.nets)
 
 def test_unknown_peripheral_gaps():
-    # I2S (no device) and PIEZO (no symbol) each flag a gap.
-    details = " ".join(g.detail for g in _intent().gaps if g.kind == "unknown_peripheral")
-    assert "I2S" in details and "PIEZO" in details
+    # I2S (no device) still flags a gap. PIEZO is now a recognized terminal-only
+    # card — it is resolved (no unknown_peripheral gap) and its net is "peripheral".
+    gaps = _intent().gaps
+    details = " ".join(g.detail for g in gaps if g.kind == "unknown_peripheral")
+    assert "I2S" in details                             # I2S device still unknown
+    assert "PIEZO" not in details                       # PIEZO now recognized via card
 
 def test_provenance_retains_unmodeled_macros():
     prov = _intent().provenance
@@ -380,10 +386,14 @@ def test_hub_register_macro_is_not_a_device():
     assert "MPU6050_REG_PWR_MGMT_1" not in types and "MPU6050_REG" not in types
 
 
-def test_hub_buzzer_stays_flagged_orphan():
+def test_hub_buzzer_resolves_via_piezo_terminal_card():
+    # BUZZER_PIN resolves via the PIEZO terminal-only card (its BUZZER alias) — it
+    # is NOT a dropped orphan. Its net is a peripheral net; at expand time it
+    # becomes a labeled screw terminal. Guards the alias-resolution path for
+    # hint-matched cards (resolve_peripheral must honor aliases, not just types).
     i = _hub_intent()
-    assert _net(i, "BUZZER").kind == "orphan"
-    assert any(g.kind == "unknown_peripheral" and "BUZZER" in g.detail for g in i.gaps)
+    assert _net(i, "BUZZER").kind == "peripheral"
+    assert not any(g.kind == "unknown_peripheral" and "BUZZER" in g.detail for g in i.gaps)
 
 
 def test_hub_module_assumption_flagged():

--- a/tests/test_firmware_placement_locus.py
+++ b/tests/test_firmware_placement_locus.py
@@ -286,7 +286,9 @@ def test_remote_peripheral_terminal_joins_its_signal_net():
     """A carded remote device's terminal must actually join the device's signal
     net (else the terminal is a routing island with no net)."""
     intent = _intent(TRACK_GEOM)
-    ref = intent.peripherals[0].ref          # an MPU6050 on the shared I2C bus
+    # pick the MPU explicitly (not [0]): TRACK_GEOM's BUZZER now resolves to a
+    # terminal-only card, so peripherals[0] is no longer guaranteed to be the MPU.
+    ref = next(p.ref for p in intent.peripherals if p.type == "MPU6050")  # on shared I2C bus
     apply_sidecar(intent, BoardSidecar(placement={ref: {"locus": "remote",
                                                         "device": "MPU6050"}}))
     intent = expand_intent(intent)

--- a/tests/test_firmware_sidecar.py
+++ b/tests/test_firmware_sidecar.py
@@ -219,6 +219,7 @@ def test_known_keys_all_accepted(tmp_path):
         terminal_distribution: multi_edge
         terminal_centering: true
         board_refit: true
+        expander_terminals: {}
     """))
     assert sc.power_source == "usb_c"
     assert sc.board_size_mm == [90, 75]
@@ -230,6 +231,7 @@ def test_known_keys_all_accepted(tmp_path):
     assert sc.terminal_distribution == "multi_edge"
     assert sc.terminal_centering is True
     assert sc.board_refit is True
+    assert sc.expander_terminals == {}
 
 
 # --- layout flags: terminal_centering / board_refit (bool) --------------------
@@ -346,3 +348,67 @@ def test_apply_threads_mounting_holes_into_source():
     sc = BoardSidecar(mounting_holes={"count": 4, "drill_mm": 3.2})
     apply_sidecar(i, sc)
     assert i.source["mounting_holes"] == {"count": 4, "drill_mm": 3.2}
+
+
+# --- expander_terminals (v2: tap an expander's GPA/GPB pins -> terminals) ------
+
+def test_expander_terminals_load_and_apply(tmp_path):
+    sc = load_sidecar(_write(tmp_path, """\
+        expander_terminals:
+          U3:
+            device: TCRT5000
+            ports: 6
+    """))
+    assert "U3" in sc.expander_terminals
+    intent = _intent()
+    apply_sidecar(intent, sc)
+    spec = intent.expander_terminals["U3"]
+    assert spec.device == "TCRT5000"
+    assert spec.group == "per_sensor" and spec.power == "3v3"   # defaults
+    assert spec.net_prefix == "TCRT5000"                        # default = device
+    # ports:int resolves to the first N pins in MCP hardware register order
+    assert spec.ports == ["GPA0", "GPA1", "GPA2", "GPA3", "GPA4", "GPA5"]
+
+
+def test_expander_terminals_int_and_list_equivalent(tmp_path):
+    sc_i = load_sidecar(_write(tmp_path,
+        "expander_terminals:\n  U3:\n    device: D\n    ports: 3\n"))
+    sc_l = load_sidecar(_write(tmp_path,
+        "expander_terminals:\n  U3:\n    device: D\n    ports: [GPA0, GPA1, GPA2]\n"))
+    a, b = _intent(), _intent()
+    apply_sidecar(a, sc_i)
+    apply_sidecar(b, sc_l)
+    assert a.expander_terminals["U3"].ports == b.expander_terminals["U3"].ports \
+        == ["GPA0", "GPA1", "GPA2"]
+
+
+@pytest.mark.parametrize("ports", [0, 16])    # at/below: 0 and the 16-pin max accept
+def test_expander_terminals_ports_boundary_accepts(tmp_path, ports):
+    sc = load_sidecar(_write(tmp_path,
+        f"expander_terminals:\n  U3:\n    device: D\n    ports: {ports}\n"))
+    intent = _intent()
+    apply_sidecar(intent, sc)
+    assert len(intent.expander_terminals["U3"].ports) == ports
+
+
+@pytest.mark.parametrize("body,needle", [
+    ("expander_terminals: 5\n", "must be a mapping"),
+    ("expander_terminals:\n  U3: 5\n", "must be a mapping"),
+    ("expander_terminals:\n  NOTAREF:\n    ports: 1\n", "not a KiCad ref"),
+    ("expander_terminals:\n  U3:\n    device: D\n", "ports is required"),
+    ("expander_terminals:\n  U3:\n    ports: true\n", "ports must be an int"),
+    ("expander_terminals:\n  U3:\n    ports: -1\n", ">= 0"),
+    ("expander_terminals:\n  U3:\n    ports: 17\n", "exceeds"),          # above max
+    ("expander_terminals:\n  U3:\n    ports: [GPA0, GPC9]\n", "unknown port pin"),
+    ("expander_terminals:\n  U3:\n    ports: 1\n    group: weird\n", "group"),
+    ("expander_terminals:\n  U3:\n    ports: 1\n    power: 12v\n", "power"),
+    ("expander_terminals:\n  U3:\n    ports: 1\n    bogus: x\n", "unknown key"),
+    ("expander_terminals:\n  U3:\n    ports: 1\n    net_prefix: ''\n", "net_prefix"),
+    # two entries whose EFFECTIVE prefix (default = device) collide
+    ("expander_terminals:\n  U3:\n    device: D\n    ports: 1\n"
+     "  U4:\n    device: D\n    ports: 1\n", "must be unique"),
+])
+def test_expander_terminals_rejected(tmp_path, body, needle):
+    with pytest.raises(SidecarError) as e:
+        load_sidecar(_write(tmp_path, body))
+    assert needle in str(e.value)

--- a/tests/test_firmware_sidecar.py
+++ b/tests/test_firmware_sidecar.py
@@ -219,7 +219,7 @@ def test_known_keys_all_accepted(tmp_path):
         terminal_distribution: multi_edge
         terminal_centering: true
         board_refit: true
-        expander_terminals: {}
+        expander_terminals: {U3: {device: TCRT5000, ports: 6}}
     """))
     assert sc.power_source == "usb_c"
     assert sc.board_size_mm == [90, 75]
@@ -231,7 +231,8 @@ def test_known_keys_all_accepted(tmp_path):
     assert sc.terminal_distribution == "multi_edge"
     assert sc.terminal_centering is True
     assert sc.board_refit is True
-    assert sc.expander_terminals == {}
+    # content (not just an empty dict) exercises the 3-source guard end-to-end
+    assert sc.expander_terminals["U3"]["device"] == "TCRT5000"
 
 
 # --- layout flags: terminal_centering / board_refit (bool) --------------------
@@ -400,6 +401,8 @@ def test_expander_terminals_ports_boundary_accepts(tmp_path, ports):
     ("expander_terminals:\n  U3:\n    ports: -1\n", ">= 0"),
     ("expander_terminals:\n  U3:\n    ports: 17\n", "exceeds"),          # above max
     ("expander_terminals:\n  U3:\n    ports: [GPA0, GPC9]\n", "unknown port pin"),
+    ("expander_terminals:\n  U3:\n    ports: [GPA0, GPA0]\n", "duplicate"),   # short
+
     ("expander_terminals:\n  U3:\n    ports: 1\n    group: weird\n", "group"),
     ("expander_terminals:\n  U3:\n    ports: 1\n    power: 12v\n", "power"),
     ("expander_terminals:\n  U3:\n    ports: 1\n    bogus: x\n", "unknown key"),

--- a/tests/test_firmware_templates.py
+++ b/tests/test_firmware_templates.py
@@ -364,6 +364,22 @@ def test_i2s_mic_builds_ics43434_when_declared():
     assert ("+3V3", Endpoint(ref=mic.ref, pin="VDD")) in ex.power
 
 
+def test_i2s_mic_refuses_named_inmp441():
+    """A firmware-named mic with no realization (EOL INMP441 — no KiCad symbol) is
+    REFUSED at the TEMPLATE level: nothing placed, part_unavailable disclosed. Guards
+    the build_part fallback — INMP441 must route to the default/refuse path, never be
+    built (and never silently substituted with the SPH0645 default or ICS-43434)."""
+    i = _audio()
+    mic_bus = next(b for b in i.buses if b.type == "I2S_IN")
+    mic_bus.resolved_part = "INMP441"           # recognized name, no realization
+    mic_bus.part_provenance = "corpus"
+    ex = i2s_mic(i, RefAllocator(i))
+    assert ex.components == [], "no mic may be placed for the unrealizable INMP441"
+    assert ex.new_nets == []
+    assert any(g.kind == "part_unavailable" and "INMP441" in g.detail for g in ex.gaps)
+    assert mic_bus.resolved_part == "INMP441"   # declared part not overwritten
+
+
 def test_i2c_device_header_with_pullups():
     i = _audio()
     ex = i2c_device_header(i, RefAllocator(i))

--- a/tests/test_firmware_templates.py
+++ b/tests/test_firmware_templates.py
@@ -535,13 +535,17 @@ def test_generate_expanded_speedcal(tmp_path):
     # the MCP_INT signal net is NOT polluted into a rail
     assert members("MCP23017_INT") == {"U1.16", "U3.20"}
 
-    # --- CP2102 programming block (U5=CP2102, J1=USB-C — deterministic refs) ---
-    assert {"J1.A4", "J1.A9", "J1.B4", "J1.B9", "U4.3"} <= p5  # +5V USB-sourced
-    assert "U5.6" not in p3                              # LANDMINE: CP2102 VDD not +3V3
-    assert "U5.6" in members("CP2102_VDD")              # ...it's on its own net
-    assert {"U5.3", "U5.29"} <= gnd                      # LANDMINE: both CP2102 GND pins
-    assert members("UART_RX") == {"U1.34", "U5.26"}     # CP2102 TXD -> ESP32 RX
-    assert members("UART_TX") == {"U1.35", "U5.25"}     # CP2102 RXD <- ESP32 TX
+    # --- CP2102 programming block (U7=CP2102, J1=USB-C — deterministic refs).
+    # U4=PIEZO, U5=TRACK (both terminal-only cards, remote), U6=AMS1117 (VI=pin3),
+    # so CP2102 is U7. U6.3 = AMS1117 VI (input) on +5V; J1 VBUS pins are the source.
+    assert {"J1.A4", "J1.A9", "J1.B4", "J1.B9", "U6.3"} <= p5  # +5V USB-sourced
+    # CP2102 VREGIN+VBUS are also on +5V (pin numbers vary by symbol version).
+    assert p5 & {f"U7.{n}" for n in range(1, 30)}        # CP2102 has at least one +5V pin
+    assert "U7.6" not in p3                              # LANDMINE: CP2102 VDD not +3V3
+    assert "U7.6" in members("CP2102_VDD")              # ...it's on its own net
+    assert {"U7.3", "U7.29"} <= gnd                      # LANDMINE: both CP2102 GND pins
+    assert members("UART_RX") == {"U1.34", "U7.26"}     # CP2102 TXD -> ESP32 RX
+    assert members("UART_TX") == {"U1.35", "U7.25"}     # CP2102 RXD <- ESP32 TX
 
 
 def test_first_preserves_gpio_zero():

--- a/tests/test_firmware_templates.py
+++ b/tests/test_firmware_templates.py
@@ -333,6 +333,37 @@ def test_i2s_mic_ambiguous_bus_held_not_assumed():
         "must not emit a contradictory assumed_part gap for an ambiguous bus"
 
 
+def test_i2s_mic_builds_ics43434_when_declared():
+    """Firmware naming ICS-43434 (canonical 'ICS43434') gets THAT exact part placed
+    — not the SPH0645 default — wired to ITS pin names. The ICS-43434 symbol differs
+    from SPH0645 on three pins (bit clock SCK not BCLK, data SD not DATA, L/R select
+    LR not SEL), so a wrong realization would silently orphan BCLK/data/SEL."""
+    i = _audio()
+    mic_bus = next(b for b in i.buses if b.type == "I2S_IN")
+    mic_bus.resolved_part = "ICS43434"          # as resolve_bus_parts marks it
+    mic_bus.part_provenance = "corpus"
+    ex = i2s_mic(i, RefAllocator(i))
+
+    mics = [c for c in ex.components if c.type == "ICS43434"]
+    assert len(mics) == 1, "the declared ICS-43434 must be placed"
+    mic = mics[0]
+    assert mic.lib_id == "Sensor_Audio:ICS-43434"
+    assert mic.footprint == "Sensor_Audio:InvenSense_ICS-43434-6_3.5x2.65mm"
+    assert mic.origin == "imported"             # firmware-named, not assumed/substituted
+    assert not any(c.type == "SPH0645" for c in ex.components), \
+        "SPH0645 default must NOT be substituted when ICS-43434 is named"
+    # Realized → no honesty gap.
+    assert not any(g.kind in ("assumed_part", "part_unavailable") for g in ex.gaps)
+    # Signal nets land on the ICS-43434 pin NAMES (SCK/SD/WS), not SPH0645's.
+    pins_by_net = {n.name: [e.pin for e in n.endpoints if e.pin] for n in ex.new_nets}
+    assert pins_by_net["MIC_BCLK"] == ["SCK"]
+    assert pins_by_net["MIC_SD"] == ["SD"]
+    assert pins_by_net["MIC_WS"] == ["WS"]
+    # L/R-select pin "LR" strapped to GND (left); VDD to +3V3.
+    assert ("GND", Endpoint(ref=mic.ref, pin="LR")) in ex.power
+    assert ("+3V3", Endpoint(ref=mic.ref, pin="VDD")) in ex.power
+
+
 def test_i2c_device_header_with_pullups():
     i = _audio()
     ex = i2c_device_header(i, RefAllocator(i))

--- a/tests/test_part_identity_guardrail.py
+++ b/tests/test_part_identity_guardrail.py
@@ -13,7 +13,7 @@ from kicad_mcp.utils.firmware.intent import Bus, load_intent
 from kicad_mcp.utils.firmware.templates import Expansion, _decide_part
 
 # The recognized device TYPES a template places (vs. generic R/C/HDR/CONN glue).
-_DEVICE_TYPES = {"MAX98357A", "SPH0645"}
+_DEVICE_TYPES = {"MAX98357A", "SPH0645", "ICS43434"}
 
 
 # --- _decide_part: the three honest cases, directly --------------------------

--- a/tests/test_part_resolution_ics43434.py
+++ b/tests/test_part_resolution_ics43434.py
@@ -1,0 +1,44 @@
+"""ICS-43434 resolution + realization — the companion to test_part_resolution_inmp441.
+
+The INMP441 case proves the front end RECOGNIZES a named part and REFUSES to
+substitute when it can't build it. This proves the other half: its in-stock
+successor ICS-43434 HAS a real KiCad symbol (Sensor_Audio:ICS-43434), so the same
+firmware that named INMP441 — once migrated to ICS-43434 — both resolves AND gets
+the mic placed (no part_unavailable gap, no orphan I2S-input bus). No KiCad
+(import + expand only).
+"""
+from __future__ import annotations
+
+import asyncio
+
+from kicad_mcp.server import create_server
+from kicad_mcp.utils.firmware.intent import load_intent
+
+_FIX = "tests/fixtures/firmware/audio_ics43434"
+
+
+def _design():
+    return asyncio.run(create_server().get_tool("design")).fn
+
+
+def test_declared_ics43434_resolves_and_places(tmp_path):
+    design = _design()
+    out = str(tmp_path / "intent.yaml")
+    r1 = design(operation="import_firmware",
+                firmware_path=f"{_FIX}/config.h", out_path=out)
+    # Firmware NAMES "ICS-43434" → canonical key "ICS43434", bound from the corpus
+    # (not invented/assumed) — the hyphen is stripped by canonical_type.
+    assert r1["resolved_parts"]["CMCA_MIC"] == {"part": "ICS43434", "via": "corpus"}
+
+    r2 = design(operation="expand_templates", intent_path=out)
+    # Unlike INMP441, ICS-43434 is realizable → NO part_unavailable refusal.
+    assert not any(g["kind"] == "part_unavailable" and "ICS43434" in g["detail"]
+                   for g in r2["gaps"]), "ICS-43434 has a symbol; it must not be refused"
+
+    it = load_intent(out)
+    mics = [p for p in it.peripherals if p.type == "ICS43434"]
+    assert len(mics) == 1, "the declared ICS-43434 mic must be placed"
+    assert mics[0].origin == "imported"                     # firmware-named, not assumed
+    assert mics[0].lib_id == "Sensor_Audio:ICS-43434"
+    # The SPH0645 default must NOT be silently substituted.
+    assert not any(p.type == "SPH0645" for p in it.peripherals)

--- a/tests/test_terminal_device_cards.py
+++ b/tests/test_terminal_device_cards.py
@@ -1,0 +1,429 @@
+"""Terminal-only device card tests (v1).
+
+A "terminal-only" card (``realize: terminal``) is a device that is ALWAYS
+realized as a labeled screw terminal — no chip-down symbol, no board.yaml
+``locus: remote`` required. The card IS the explicit declaration. Three cards
+ship with v1: PIEZO (single ADC/GPIO), SWITCH (single GPIO), TCRT5000 (single
+digital output).
+
+Coverage per CLAUDE.md threshold / seam rules:
+  * A firmware naming a terminal-only device gets a labeled screw terminal
+    with its GPIO + power wired and NO orphan net.
+  * Glue suppression: no bypass caps / decoupling added for a terminal device.
+  * The peripheral's original ref is NOT placed in the schematic (excluded via
+    is_remote); unresolved_endpoints does not fire for its original net endpoint.
+  * Multi-instance non-collision: two PIEZO instances get distinct J-refs.
+  * **Invariant pin**: an I2S bus without locus:remote is STILL REFUSED (no
+    auto-terminal), i.e. INMP441 without a remote directive is never silently
+    terminal-ized. This guards the spec §4 honesty-contradiction rule.
+  * At/below/above at the realize-field boundary: terminal / chip / bus+remote /
+    bus-no-remote / absent-realize.
+  * Card structural validation accepts "terminal", rejects unknown values.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from kicad_mcp.utils.firmware import knowledge as K
+from kicad_mcp.utils.firmware.cards import (
+    load_cards,
+    terminal_card_types,
+    validate_peripheral_card,
+)
+from kicad_mcp.utils.firmware.intent import (
+    build_intent,
+    find_board_id,
+)
+from kicad_mcp.utils.firmware.parse import (
+    idf_target_defines,
+    parse_defines,
+    partition,
+    select_active_branches,
+)
+from kicad_mcp.utils.firmware.templates import (
+    expand_intent,
+)
+
+_FIX = "tests/fixtures/firmware/terminal_devices"
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+def _intent_from_fix():
+    """Build a DesignIntent from the terminal_devices fixture (ESP32 + PIEZO +
+    TCRT5000), selecting the active #if branch for esp32dev."""
+    config_path = f"{_FIX}/config.h"
+    board = find_board_id(config_path)
+    text = select_active_branches(
+        open(config_path).read(), idf_target_defines(board)
+    )
+    parsed = partition(parse_defines(text))
+    return build_intent(parsed, firmware_path=config_path, board_id=board)
+
+
+def _design():
+    from kicad_mcp.server import create_server
+    return asyncio.run(create_server().get_tool("design")).fn
+
+
+# ---------------------------------------------------------------------------
+# Card structural validation
+# ---------------------------------------------------------------------------
+
+_GOOD_TERMINAL_CARD = {
+    "type": "MYTERMINAL",
+    "lib_id": "Connector_Generic:Conn_01x01",
+    "value": "MyTerminal (terminal)",
+    "bus": None,
+    "footprint": "Connector_PinHeader_2.54mm:PinHeader_1x01_P2.54mm_Vertical",
+    "roles": {"SIGNAL": "1"},
+    "supply_pins": [],
+    "ground_pins": [],
+    "module": False,
+    "realize": "terminal",
+}
+
+
+def test_validate_accepts_realize_terminal():
+    """A card with realize: terminal passes structural validation."""
+    assert validate_peripheral_card(_GOOD_TERMINAL_CARD) == []
+
+
+def test_validate_rejects_unknown_realize():
+    """An unknown realize value is a structural error."""
+    bad = dict(_GOOD_TERMINAL_CARD, realize="chip_down")
+    errs = validate_peripheral_card(bad)
+    assert any("realize" in e for e in errs)
+
+
+def test_validate_accepts_card_without_realize():
+    """Omitting realize is valid — default is chip-down (no realize field)."""
+    card = {k: v for k, v in _GOOD_TERMINAL_CARD.items() if k != "realize"}
+    assert validate_peripheral_card(card) == []
+
+
+def test_terminal_card_types_returns_terminal_cards():
+    """terminal_card_types(peripherals) returns only the terminal-realize cards."""
+    peripherals = {
+        "PIEZO": dict(_GOOD_TERMINAL_CARD, type="PIEZO"),
+        "HX711": {
+            "type": "HX711", "lib_id": "Analog_ADC:HX711", "value": "HX711",
+            "bus": None, "footprint": "Package_SO:SOIC-16_3.9x9.9mm_P1.27mm",
+            "roles": {"DOUT": "DOUT"}, "supply_pins": ["VSUP"], "ground_pins": ["AGND"],
+            "module": False,
+        },
+    }
+    result = terminal_card_types(peripherals)
+    assert "PIEZO" in result
+    assert "HX711" not in result
+
+
+# ---------------------------------------------------------------------------
+# Packaged card assertions
+# ---------------------------------------------------------------------------
+
+def test_packaged_cards_load_includes_terminal_cards():
+    """The three v1 terminal cards ship with the package and load clean."""
+    peris, _ = load_cards()
+    assert {"PIEZO", "SWITCH", "TCRT5000"} <= set(peris), (
+        "v1 terminal cards must be present in the packaged card library"
+    )
+    for name in ("PIEZO", "SWITCH", "TCRT5000"):
+        assert peris[name].get("realize") == "terminal", (
+            f"{name} card must declare realize: terminal"
+        )
+
+
+def test_packaged_terminal_types_set():
+    """terminal_card_types() from the live card cache includes the v1 cards."""
+    peris, _ = load_cards()
+    tt = terminal_card_types(peris)
+    assert {"PIEZO", "SWITCH", "TCRT5000"} <= tt
+
+
+# ---------------------------------------------------------------------------
+# build_intent: terminal-only cards resolve as peripheral (not orphan)
+# ---------------------------------------------------------------------------
+
+def test_terminal_card_resolves_to_peripheral_net():
+    """A PIEZO_ADC_PIN macro resolves via the PIEZO card → peripheral net (not
+    orphan) at build_intent time — the card gives the signal a far-end ref."""
+    intent = _intent_from_fix()
+    piezo_net = next(
+        (n for n in intent.nets if n.name == "PIEZO_ADC"), None
+    )
+    assert piezo_net is not None, "PIEZO_ADC net must be emitted"
+    assert piezo_net.kind == "peripheral", (
+        "PIEZO_ADC must be a peripheral net (not orphan) once the card resolves it"
+    )
+
+
+def test_terminal_card_peripheral_in_intent():
+    """After build_intent, a PIEZO peripheral is present (it gets a ref)."""
+    intent = _intent_from_fix()
+    piezos = [p for p in intent.peripherals if p.type == "PIEZO"]
+    assert len(piezos) == 1, "one PIEZO peripheral must be materialized"
+    tcrt = [p for p in intent.peripherals if p.type == "TCRT5000"]
+    assert len(tcrt) == 1, "one TCRT5000 peripheral must be materialized"
+
+
+# ---------------------------------------------------------------------------
+# expand_intent: terminal injection + remote_peripherals synthesis
+# ---------------------------------------------------------------------------
+
+def test_terminal_card_gets_screw_terminal_no_chip():
+    """After expand_intent a terminal-only card has a screw terminal in
+    intent.peripherals and its original placeholder is remote (not placed)."""
+    intent = _intent_from_fix()
+    intent = expand_intent(intent)
+
+    # The PIEZO placeholder is present but remote (not placed as a chip).
+    piezos = [p for p in intent.peripherals if p.type == "PIEZO"]
+    assert len(piezos) == 1
+    assert piezos[0].locus == "remote", "terminal card must be locus=remote after expand"
+
+    # A screw terminal was synthesized for it.
+    terms = [p for p in intent.peripherals
+             if p.type == "TERM" and "Piezo" in (p.value or "")]
+    assert len(terms) == 1, "exactly one PIEZO screw terminal must be emitted"
+
+
+def test_terminal_card_gpio_wired_to_terminal():
+    """The MCU GPIO and the screw terminal both appear on the PIEZO_ADC net —
+    no orphan endpoint remains."""
+    intent = _intent_from_fix()
+    intent = expand_intent(intent)
+
+    piezo_term = next(
+        p for p in intent.peripherals
+        if p.type == "TERM" and "Piezo" in (p.value or "")
+    )
+    piezo_net = next(n for n in intent.nets if n.name == "PIEZO_ADC")
+    refs_on_net = {ep.ref for ep in piezo_net.endpoints}
+    assert intent.mcu.ref in refs_on_net, "MCU GPIO endpoint must be on PIEZO_ADC"
+    assert piezo_term.ref in refs_on_net, "terminal connector must be on PIEZO_ADC"
+
+
+def test_terminal_card_no_remote_device_gap_needed():
+    """A terminal-only card produces a remote_device gap (the standard disclosure)
+    — this confirms the device's wire-out is documented in the gap manifest."""
+    intent = _intent_from_fix()
+    intent = expand_intent(intent)
+    remote_gaps = [g for g in intent.gaps if g.kind == "remote_device"]
+    assert any("PIEZO" in g.detail or "Piezo" in g.detail for g in remote_gaps), (
+        "remote_device gap must document the PIEZO terminal"
+    )
+
+
+def test_terminal_card_no_bypass_cap():
+    """Terminal-only cards are remote → no bypass cap is added on the board
+    (glue suppression). The terminal card must produce FEWER caps than a
+    board with the same MCU but no terminal device."""
+    intent_no_terminal = build_intent(
+        partition(parse_defines("#define MCP23017_ADDR 0x27")),
+        firmware_path="c.h", board_id="esp32dev",
+    )
+    intent_no_terminal = expand_intent(intent_no_terminal)
+
+    intent_with_terminal = _intent_from_fix()
+    intent_with_terminal = expand_intent(intent_with_terminal)
+
+    # Cap count with a terminal device should not EXCEED the no-terminal count
+    # (the terminal gets no on-board bypass; a baseline device like MCP23017 does).
+    caps_no_term = [p for p in intent_no_terminal.peripherals if p.type == "C"]
+    caps_with_term = [p for p in intent_with_terminal.peripherals if p.type == "C"]
+    # The terminal adds NO extra caps; any difference comes from other devices.
+    # Simple guard: piezo terminal device doesn't appear in the cap list at all.
+    assert not any(
+        "PIEZO" in (p.value or "") for p in caps_with_term
+    ), "no cap should be tied to the PIEZO peripheral (glue suppression)"
+
+
+def test_terminal_card_injection_honors_explicit_placement_override():
+    """If board.yaml explicitly sets locus: on_board for a terminal-only card,
+    that override takes precedence over the card's realize: terminal default.
+    The peripheral gets placed on-board (no terminal synthesized for it)."""
+    from kicad_mcp.utils.firmware.sidecar import BoardSidecar, apply_sidecar
+    intent = _intent_from_fix()
+    # Get the PIEZO ref before expansion.
+    piezo_ref = next(p.ref for p in intent.peripherals if p.type == "PIEZO")
+    # Force it on-board via explicit placement.
+    apply_sidecar(intent, BoardSidecar(placement={
+        piezo_ref: {"locus": "on_board", "device": "PIEZO_ONBOARD"},
+    }))
+    intent = expand_intent(intent)
+    # The locus override is honored — PIEZO not remote.
+    piezo = next(p for p in intent.peripherals if p.type == "PIEZO")
+    assert piezo.locus == "on_board", "explicit on_board override must be honored"
+    # No PIEZO terminal synthesized.
+    piezo_terms = [p for p in intent.peripherals
+                   if p.type == "TERM" and "Piezo" in (p.value or "")]
+    assert len(piezo_terms) == 0, "on_board override must suppress the terminal"
+
+
+# ---------------------------------------------------------------------------
+# Multi-instance non-collision
+# ---------------------------------------------------------------------------
+
+def test_two_terminal_instances_get_distinct_refs():
+    """Two PIEZO instances in the same firmware get distinct J-refs with no
+    collision (the ref allocator handles this)."""
+    src = """\
+#define PIEZO1_ADC_PIN 34
+#define PIEZO2_ADC_PIN 35
+"""
+    # NOTE: two PIEZO_* pins both resolve hint="PIEZO"; candidate_devices dedupes
+    # to ONE PIEZO per unique hint — multi-instance needs an _ADDR declaration.
+    # So here we test TWO DISTINCT terminal types (PIEZO + TCRT5000) to confirm
+    # the ref allocator never reuses a J-ref.
+    intent = _intent_from_fix()    # has PIEZO + TCRT5000
+    intent = expand_intent(intent)
+    term_refs = [p.ref for p in intent.peripherals if p.type == "TERM"]
+    assert len(term_refs) == len(set(term_refs)), (
+        "synthesized terminal connectors must have distinct refs"
+    )
+    assert len(term_refs) >= 2, "PIEZO and TCRT5000 each get a terminal"
+
+
+# ---------------------------------------------------------------------------
+# Invariant: bus peripheral without locus:remote is STILL REFUSED, not terminal-ized
+# ---------------------------------------------------------------------------
+
+def test_inmp441_without_locus_remote_still_refused_not_terminalized():
+    """INMP441 is an I2S mic (bus-typed) with no KiCad symbol. WITHOUT a
+    board.yaml `locus: remote` directive it must be REFUSED (part_unavailable gap)
+    — NOT silently converted to a screw terminal. This guards the spec §4
+    honesty-contradiction rule: terminal-only cards apply ONLY to cards with
+    realize: terminal, never to un-declared bus peripherals."""
+
+    src = """\
+#define CMCA_MIC_BCLK  8
+#define CMCA_MIC_WS    9
+#define CMCA_MIC_SD    10
+"""
+    parsed = partition(parse_defines(src))
+    intent = build_intent(parsed, firmware_path="c.h", board_id="esp32-s3-devkitc-1")
+    # Manually force INMP441 as the resolved part (as the bus resolver would).
+    for bus in intent.buses:
+        if bus.type == "I2S_IN":
+            bus.resolved_part = "INMP441"
+            bus.part_provenance = "corpus"
+    intent = expand_intent(intent)
+
+    # INMP441 is refused (part_unavailable gap), not placed AND not terminal-ized.
+    assert any(
+        g.kind == "part_unavailable" and "INMP441" in g.detail
+        for g in intent.gaps
+    ), "INMP441 without locus:remote must still produce a part_unavailable gap"
+    # No screw terminal was synthesized for the I2S bus.
+    i2s_terms = [
+        p for p in intent.peripherals
+        if p.type == "TERM" and "mic" in (p.value or "").lower()
+    ]
+    assert len(i2s_terms) == 0, (
+        "no terminal must be auto-emitted for a bus peripheral without locus:remote"
+    )
+
+
+def test_inmp441_with_locus_remote_still_works():
+    """INMP441 WITH locus: remote gets a screw terminal (the existing mechanism).
+    This test guards that the invariant fix did not accidentally break the
+    intentional remote-mic path."""
+    from kicad_mcp.utils.firmware.sidecar import BoardSidecar, apply_sidecar
+
+    src = """\
+#define CMCA_MIC_BCLK  8
+#define CMCA_MIC_WS    9
+#define CMCA_MIC_SD    10
+"""
+    parsed = partition(parse_defines(src))
+    intent = build_intent(parsed, firmware_path="c.h", board_id="esp32-s3-devkitc-1")
+    apply_sidecar(intent, BoardSidecar(placement={
+        "CMCA_MIC": {"locus": "remote", "device": "INMP441"},
+    }))
+    intent = expand_intent(intent)
+    # A terminal IS emitted for the I2S bus when locus: remote is declared.
+    mic_terms = [
+        p for p in intent.peripherals
+        if p.type == "TERM" and p.value == "INMP441"
+    ]
+    assert len(mic_terms) == 1, (
+        "INMP441 with locus: remote must still emit a screw terminal"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Screw terminal symbol / silk legend
+# ---------------------------------------------------------------------------
+
+def test_terminal_card_emits_silk_legend():
+    """The screw terminal synthesized for a PIEZO gets a silk legend entry
+    so the field-wiring silk is generated."""
+    intent = _intent_from_fix()
+    intent = expand_intent(intent)
+    piezo_term = next(
+        p for p in intent.peripherals
+        if p.type == "TERM" and "Piezo" in (p.value or "")
+    )
+    leg = next(
+        (L for L in intent.connector_legends if L.ref == piezo_term.ref), None
+    )
+    assert leg is not None, "terminal connector must have a silk legend entry"
+    # Signal label appears in positions (the GPIO signal crosses to the terminal).
+    assert any(label for label in leg.positions), (
+        "legend must have at least one non-empty position label"
+    )
+
+
+def test_terminal_card_uses_screw_terminal_symbol():
+    """The synthesized connector uses a Connector:Screw_Terminal_01x{N} symbol —
+    not a pin header — because it is field-wired."""
+    intent = _intent_from_fix()
+    intent = expand_intent(intent)
+    piezo_term = next(
+        p for p in intent.peripherals
+        if p.type == "TERM" and "Piezo" in (p.value or "")
+    )
+    assert "Screw_Terminal" in (piezo_term.lib_id or ""), (
+        f"terminal lib_id must be a Screw_Terminal symbol, got {piezo_term.lib_id!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Alias resolution for hint-matched terminal cards (the resolve_peripheral fix).
+# These guard a real bug: a firmware peripheral named by a card ALIAS (TRACK ->
+# SWITCH, BUZZER -> PIEZO) was silently dropped to an orphan net because
+# resolve_peripheral only honored the canonical card type, not its aliases.
+# ---------------------------------------------------------------------------
+
+def test_resolve_peripheral_honors_aliases_for_terminal_cards():
+    K.reload_cards()
+    assert (K.resolve_peripheral("TRACK") or {}).get("value") == "Switch (terminal)"
+    assert (K.resolve_peripheral("BUZZER") or {}).get("value") == "Piezo (terminal)"
+    assert K.is_terminal_card_type("TRACK")        # alias -> SWITCH card
+    assert K.is_terminal_card_type("BUZZER")       # alias -> PIEZO card
+    assert K.is_terminal_card_type("PIEZO")        # canonical type still resolves
+    assert not K.is_terminal_card_type("MCP23017")  # a chip card is NOT a terminal
+
+
+def test_track_switches_group_into_one_terminal():
+    """TRACK_SW1_PIN + TRACK_SW2_PIN share hint 'TRACK' -> ONE switch terminal
+    carrying BOTH signals plus power (the real speed-cal polarity-switch pattern).
+    Exercises the alias path end-to-end (hint 'TRACK' -> SWITCH terminal card)."""
+    K.reload_cards()
+    sample = "#define TRACK_SW1_PIN 25\n#define TRACK_SW2_PIN 26\n"
+    intent = build_intent(partition(parse_defines(sample)),
+                          firmware_path="c.h", board_id="esp32dev")
+    intent = expand_intent(intent)
+    terms = [p for p in intent.peripherals
+             if p.type == "TERM" and "Switch" in (p.value or "")]
+    assert len(terms) == 1, "the two track switches must share ONE terminal"
+    leg = next(lg for lg in intent.connector_legends if lg.ref == terms[0].ref)
+    assert {"SW1", "SW2"} <= set(leg.positions)         # both signals cross out
+    assert {"+3V3", "GND"} <= set(leg.positions)        # power taps present
+    for sig in ("TRACK_SW1", "TRACK_SW2"):
+        n = next(x for x in intent.nets if x.name == sig)
+        assert n.kind == "peripheral"                    # not an orphan
+        assert terms[0].ref in {ep.ref for ep in n.endpoints}  # reaches the terminal


### PR DESCRIPTION
Lands the full **off-board-terminals arc**: declaring an off-board peripheral (or an I/O-expander's sensor ports) as labeled screw terminals, plus the cross-version symbol-resolution work that unblocked it. 10 commits, all verified on **both KiCad 9 and KiCad 10** (full import→expand→generate→build→route→DRC on the matrix).

## What's in it

**v1 — off-board / terminal devices** (`d1a5377`, `ac3655c`, `e2d904c`)
- ICS-43434 becomes a buildable I2S mic (resolve + place); INMP441 stays refused.
- `realize: terminal` device cards (PIEZO/SWITCH/TCRT5000 + aliases) become labeled screw terminals via the existing connector-synthesis machinery.

**Cross-version symbol resolution** (`2597c93`, `ba8911d`, `fbdec57`)
- **The blocker:** KiCad 10 renamed whole symbol families — `MCP23017_SO` (K9) → `MCP23017x-x-SO` (K10), no common name. The card named only the K10 symbol, so on K9 the chip silently dropped from the schematic (masked because the K9 CI leg is `continue-on-error`).
- New card field `alt_lib_ids` + a single `resolve_symbol(cache, lib_id, alts)` that tries the primary then alternates **against the live library** — first that exists wins, so no version detection and a future rename just adds a name. Both the generator and the card validator consume it (one source of truth).
- Empirically the MCP23017 SO symbol differs in only two pins (`V_{DD}`/`V_{SS}` ↔ `VDD`/`VSS`, same pads 9/10), so the card addresses power by **pad number** — collapsing the seam to the `lib_id` alone.
- `generate_schematic` now returns `ok`/`partial`/`error` instead of always `"ok"`, so a dropped component surfaces instead of silently producing a board missing a chip (this is what hid the K9 bug).
- Completed the v1 integration-test update the v1 commit had skipped (PIEZO/BUZZER now resolve as terminals → stale peripheral-set/count/ref assertions; refs now resolved by value, not hardcoded U-numbers).

**v2 — expander_terminals** (`6b9ab8d`, `7061b49`)
- A `board.yaml` block taps a placed MCP23017's floating GPA/GPB pins out to labeled terminals — the firmware-blind case (sensors are register-addressed at runtime):
  ```yaml
  expander_terminals:
    U3: {device: TCRT5000, ports: 6, group: per_sensor, power: 3v3}
  ```
- `ports: N` → first N pins in MCP hardware register order (or an explicit list). `group`: per_sensor / per_bank / single (single>16 → pin-header fallback + gap). `power`: 3v3 / 5v / none. `net_prefix` unique-at-load.
- Cold-reviewed by 3 severity-tier agents; remediation in `7061b49` (notably a real `power: 5v` always-downgrade bug — it read rail nets before they're merged in the template loop).

## Verification
- ~2223 unit tests + mypy clean.
- Integration on **K9 and K10**: the firmware→routed-PCB pipeline (incl. the speed-cal MCP23017 board and a new `expander_demo` fixture routing 6 TCRT5000 terminals DRC-clean), and the card-pins validator (all 16 MCP `port_pins` resolve on both versions).

## Notes for the reviewer
- The two `docs/SPEC_*` files are kept in the tree to aid review; they'll be removed from the tip in a follow-up (kept in history, per preference) — so **rebase-merge (not squash)** to preserve the per-commit history.
- The K9 integration leg is `continue-on-error` by design (advisory, non-gating); these changes were validated against it locally on the real matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)