### PR TITLE
Configure and wire up pytest-cov (was a declared dependency, never used)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,19 @@ markers = [
     "requires_kicad: Tests that require KiCad Python 3.9 with pcbnew bindings",
 ]
 
+# pytest-cov was already a declared dev dependency but never configured or
+# invoked. Coverage is a floor-check, not a quality gate — deliberately not
+# wired into the default pytest run above; invoke explicitly at release-gate
+# cadence: `.venv/bin/pytest --cov --cov-report=term-missing -m "not integration"`.
+# /full-review's Phase 3.5 detects this config and runs it the same way.
+[tool.coverage.run]
+source = ["src/kicad_mcp"]
+omit = ["*/__pycache__/*"]
+
+[tool.coverage.report]
+exclude_lines = ["pragma: no cover", "if __name__ == .__main__.:"]
+skip_empty = true
+
 [tool.mypy]
 python_version = "3.10"
 warn_return_any = true


### PR DESCRIPTION
## Summary
- `pytest-cov>=7.1.0` was already listed in `[dependency-groups].dev` but had no `[tool.coverage.*]` config and nothing invoking it with `--cov` — dependency declared, never actually wired up.
- Adds coverage config, deliberately kept out of the default `pytest` invocation (coverage is a floor-check, not a quality gate) — run explicitly at release-gate cadence.
- `/full-review`'s new Phase 3.5 auto-detects this config and runs it going forward instead of reporting SKIPPED.
- Non-emergency, low-risk (config-only) change — targeting `dev` directly per usual practice for this class of change.

## Verification
`.venv/bin/pytest --cov --cov-report=term-missing -m "not integration and not requires_kicad"` — 2500 passed, 1 skipped, 78% overall coverage on `src/kicad_mcp` (verified against current `dev`, including the `hypothesis` dependency added there).

## Test plan
- [x] Full non-integration suite green against dev
- [x] Coverage report generates without error